### PR TITLE
Corrected README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Centian is a lightweight MCP ([Model Context Protocol](https://modelcontextproto
 1) **Install**
 
 ```bash
-curl -fsSL https://github.com/T4cceptor/centian/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/T4cceptor/centian/main/scripts/install.sh | bash
 ```
 
 2) **Initialize quickstart config (npx required)**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This does the following:
     ```
     centian server add --name "my-local-memory" --command "npx" --args "-y,@modelcontextprotocol/server-memory"
 
-    centian server add --name "my-local-memory" --url "https://mcp.deepwiki.com/mcp"
+    centian server add --name "my-deepwiki" --url "https://mcp.deepwiki.com/mcp"
     ```
 * Creates an API key to authenticate at the centian proxy
 * Displays MCP client configurations including API key header


### PR DESCRIPTION
- example server name renamed from `my-local-memory` to `my-deepwiki`, correctly reflecting what this server is
- fixed install script URL