### PR TITLE
Added CLI cmd to add processors

### DIFF
--- a/internal/cli/processor.go
+++ b/internal/cli/processor.go
@@ -1,12 +1,23 @@
 package cli
 
 import (
+	"bufio"
 	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math/big"
 	"os"
+	"strings"
 
+	"github.com/T4cceptor/centian/internal/config"
 	"github.com/T4cceptor/centian/internal/processor"
 	"github.com/urfave/cli/v3"
 )
+
+const renameOption = "rename"
+const overwriteOption = "overwrite"
+const abortOption = "abort"
 
 // ProcessorCommand provides processor management functionality.
 var ProcessorCommand = &cli.Command{
@@ -14,6 +25,7 @@ var ProcessorCommand = &cli.Command{
 	Usage: "Manage Centian processors",
 	Commands: []*cli.Command{
 		ProcessorInitCommand,
+		ProcessorAddCommand,
 	},
 }
 
@@ -25,6 +37,151 @@ var ProcessorInitCommand = &cli.Command{
 	Action:      handleProcessorInit,
 }
 
+// ProcessorAddCommand registers an existing processor script in the global config.
+var ProcessorAddCommand = &cli.Command{
+	Name:        "add",
+	Usage:       "Add a processor to the configuration",
+	Description: "Register a processor script in the global config. Name is inferred from the filename unless --name is provided.",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "path",
+			Aliases:  []string{"p"},
+			Usage:    "Path to the processor script",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:    "name",
+			Aliases: []string{"n"},
+			Usage:   "Processor name (default: inferred from filename)",
+		},
+		&cli.StringFlag{
+			Name:    "type",
+			Aliases: []string{"t"},
+			Usage:   "Processor type",
+			Value:   "cli",
+		},
+	},
+	Action: handleProcessorAdd,
+}
+
 func handleProcessorInit(_ context.Context, _ *cli.Command) error {
 	return processor.RunScaffoldInteractive(os.Stdin, os.Stdout)
+}
+
+func handleProcessorAdd(_ context.Context, cmd *cli.Command) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	path := cmd.String("path")
+	processorType := cmd.String("type")
+
+	// Infer name from filename if not provided.
+	name := cmd.String("name")
+	if name == "" {
+		name = config.InferProcessorNameFromPath(path)
+	}
+
+	// Handle duplicate name.
+	if cfg.HasProcessor(name) {
+		action, resolvedName, promptErr := promptProcessorNameConflict(name, os.Stdin)
+		if promptErr != nil {
+			return promptErr
+		}
+		switch action {
+		case renameOption:
+			name = resolvedName
+		case overwriteOption:
+			// Will replace below.
+		case abortOption:
+			fmt.Println("❌ Operation cancelled.")
+			return nil
+		}
+	}
+
+	// Infer command from file extension.
+	command, args, err := config.InferCommandFromPath(path)
+	if err != nil {
+		return err
+	}
+
+	// Build args as []interface{} for the config map.
+	configArgs := make([]interface{}, len(args))
+	for i, a := range args {
+		configArgs[i] = a
+	}
+
+	enabled := true
+	processorConfig := &config.ProcessorConfig{
+		Name:    name,
+		Type:    processorType,
+		Enabled: enabled,
+		Timeout: 15,
+		Config: map[string]interface{}{
+			"command": command,
+			"args":    configArgs,
+		},
+	}
+
+	// Add or replace.
+	if cfg.HasProcessor(name) {
+		cfg.ReplaceProcessor(name, processorConfig)
+	} else {
+		cfg.AddProcessor(processorConfig)
+	}
+
+	if err := config.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	fmt.Printf("✅ Added processor '%s' (command: %s %s)\n", name, command, strings.Join(args, " "))
+	return nil
+}
+
+// promptProcessorNameConflict handles the interactive conflict resolution when a
+// processor name already exists. Returns the chosen action and resolved name.
+func promptProcessorNameConflict(name string, input io.Reader) (action, resolvedName string, err error) {
+	suffix, err := generateRandomSuffix(4)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate random suffix: %w", err)
+	}
+	suggested := name + "_" + suffix
+
+	fmt.Printf("\n⚠️  Processor '%s' already exists.\n\n", name)
+	fmt.Printf("  [1] Rename to '%s'\n", suggested)
+	fmt.Printf("  [2] Overwrite existing processor\n")
+	fmt.Printf("  [3] Abort\n\n")
+	fmt.Print("Select [1-3]: ")
+
+	reader := bufio.NewReader(input)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read input: %w", err)
+	}
+	response = strings.TrimSpace(response)
+
+	switch response {
+	case "1":
+		return renameOption, suggested, nil
+	case "2":
+		return overwriteOption, name, nil
+	default:
+		return abortOption, "", nil
+	}
+}
+
+const randomSuffixChars = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+// generateRandomSuffix generates a random alphanumeric string of the given length.
+func generateRandomSuffix(length int) (string, error) {
+	result := make([]byte, length)
+	for i := range result {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(randomSuffixChars))))
+		if err != nil {
+			return "", err
+		}
+		result[i] = randomSuffixChars[idx.Int64()]
+	}
+	return string(result), nil
 }

--- a/internal/cli/processor_test.go
+++ b/internal/cli/processor_test.go
@@ -1,0 +1,321 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/T4cceptor/centian/internal/config"
+	urfavecli "github.com/urfave/cli/v3"
+)
+
+func TestGenerateRandomSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{"Given: length 4, When: generating suffix, Then: returns 4-char string", 4},
+		{"Given: length 5, When: generating suffix, Then: returns 5-char string", 5},
+		{"Given: length 1, When: generating suffix, Then: returns 1-char string", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When: generating a random suffix.
+			result, err := generateRandomSuffix(tt.length)
+
+			// Then: no error and correct length.
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result) != tt.length {
+				t.Errorf("expected length %d, got %d (%q)", tt.length, len(result), result)
+			}
+
+			// Then: all characters are from the allowed set.
+			for _, c := range result {
+				if !strings.ContainsRune(randomSuffixChars, c) {
+					t.Errorf("character %q not in allowed set %q", c, randomSuffixChars)
+				}
+			}
+		})
+	}
+
+	// Given: two generated suffixes, When: comparing, Then: they differ (probabilistically).
+	t.Run("Given: two calls, When: generating suffixes, Then: results differ", func(t *testing.T) {
+		a, _ := generateRandomSuffix(8)
+		b, _ := generateRandomSuffix(8)
+		if a == b {
+			t.Errorf("two random suffixes should differ (both were %q)", a)
+		}
+	})
+}
+
+func TestPromptProcessorNameConflict(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedAction string
+	}{
+		{
+			name:           "Given: user selects 1 (rename), When: prompting, Then: returns rename action",
+			input:          "1\n",
+			expectedAction: "rename",
+		},
+		{
+			name:           "Given: user selects 2 (overwrite), When: prompting, Then: returns overwrite action",
+			input:          "2\n",
+			expectedAction: "overwrite",
+		},
+		{
+			name:           "Given: user selects 3 (abort), When: prompting, Then: returns abort action",
+			input:          "3\n",
+			expectedAction: "abort",
+		},
+		{
+			name:           "Given: user enters invalid input, When: prompting, Then: returns abort action",
+			input:          "x\n",
+			expectedAction: "abort",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When: prompting with simulated input.
+			reader := strings.NewReader(tt.input)
+			action, resolvedName, err := promptProcessorNameConflict("test-proc", reader)
+
+			// Then: no error.
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Then: action matches expectation.
+			if action != tt.expectedAction {
+				t.Errorf("expected action %q, got %q", tt.expectedAction, action)
+			}
+
+			// Then: rename action returns a suffixed name.
+			if tt.expectedAction == "rename" {
+				if !strings.HasPrefix(resolvedName, "test-proc_") {
+					t.Errorf("expected renamed to start with 'test-proc_', got %q", resolvedName)
+				}
+				// Suffix should be underscore + 4 chars = 5 chars after the original name.
+				suffix := strings.TrimPrefix(resolvedName, "test-proc_")
+				if len(suffix) != 4 {
+					t.Errorf("expected 4-char suffix, got %d chars (%q)", len(suffix), suffix)
+				}
+			}
+
+			// Then: overwrite returns the original name.
+			if tt.expectedAction == "overwrite" && resolvedName != "test-proc" {
+				t.Errorf("expected overwrite to return original name 'test-proc', got %q", resolvedName)
+			}
+		})
+	}
+}
+
+// setupTestHome creates an isolated HOME with an initialized centian config.
+// Returns a cleanup function that restores the original HOME.
+func setupTestHome(t *testing.T) func() {
+	t.Helper()
+	tempDir := t.TempDir()
+	testHome := filepath.Join(tempDir, "processor_cmd_test")
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", testHome)
+
+	// Create default config.
+	cfg := config.DefaultConfig()
+	if err := config.SaveConfig(cfg); err != nil {
+		t.Fatalf("failed to save test config: %v", err)
+	}
+
+	return func() {
+		os.Setenv("HOME", originalHome)
+	}
+}
+
+func TestHandleProcessorAdd(t *testing.T) {
+	t.Run("Given: a valid python path, When: adding processor, Then: processor is saved to config", func(t *testing.T) {
+		// Given: isolated config environment.
+		cleanup := setupTestHome(t)
+		defer cleanup()
+
+		// When: running 'centian processor add --path ./audit.py'.
+		app := &urfavecli.Command{
+			Name: "centian",
+			Commands: []*urfavecli.Command{
+				ProcessorCommand,
+			},
+		}
+		err := app.Run(context.Background(), []string{"centian", "processor", "add", "--path", "./audit.py"})
+
+		// Then: no error.
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Then: config contains the processor with inferred name and command.
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			t.Fatalf("failed to load config: %v", err)
+		}
+		if !cfg.HasProcessor("audit") {
+			t.Fatal("expected processor 'audit' to exist in config")
+		}
+		proc := cfg.Processors[0]
+		if proc.Type != "cli" {
+			t.Errorf("expected type 'cli', got %q", proc.Type)
+		}
+		if proc.Config["command"] != "python3" {
+			t.Errorf("expected command 'python3', got %v", proc.Config["command"])
+		}
+		if proc.Timeout != 15 {
+			t.Errorf("expected timeout 15, got %d", proc.Timeout)
+		}
+		if !proc.Enabled {
+			t.Error("expected processor to be enabled")
+		}
+	})
+
+	t.Run("Given: --name override, When: adding processor, Then: uses provided name", func(t *testing.T) {
+		// Given: isolated config environment.
+		cleanup := setupTestHome(t)
+		defer cleanup()
+
+		// When: running with explicit --name.
+		app := &urfavecli.Command{
+			Name: "centian",
+			Commands: []*urfavecli.Command{
+				ProcessorCommand,
+			},
+		}
+		err := app.Run(context.Background(), []string{
+			"centian", "processor", "add",
+			"--path", "./scripts/my_logger.js",
+			"--name", "custom-logger",
+		})
+
+		// Then: no error.
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Then: processor uses the provided name, not inferred.
+		cfg, _ := config.LoadConfig()
+		if !cfg.HasProcessor("custom-logger") {
+			t.Fatal("expected processor 'custom-logger' to exist")
+		}
+		if cfg.HasProcessor("my_logger") {
+			t.Error("inferred name 'my_logger' should not exist when --name was provided")
+		}
+	})
+
+	t.Run("Given: a .sh file, When: adding processor, Then: command is bash", func(t *testing.T) {
+		cleanup := setupTestHome(t)
+		defer cleanup()
+
+		app := &urfavecli.Command{
+			Name:     "centian",
+			Commands: []*urfavecli.Command{ProcessorCommand},
+		}
+		err := app.Run(context.Background(), []string{
+			"centian", "processor", "add", "--path", "./filter.sh",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cfg, _ := config.LoadConfig()
+		if !cfg.HasProcessor("filter") {
+			t.Fatal("expected processor 'filter' to exist")
+		}
+		if cfg.Processors[0].Config["command"] != "bash" {
+			t.Errorf("expected command 'bash', got %v", cfg.Processors[0].Config["command"])
+		}
+	})
+
+	t.Run("Given: a .ts file, When: adding processor, Then: command is npx with ts-node", func(t *testing.T) {
+		cleanup := setupTestHome(t)
+		defer cleanup()
+
+		app := &urfavecli.Command{
+			Name:     "centian",
+			Commands: []*urfavecli.Command{ProcessorCommand},
+		}
+		err := app.Run(context.Background(), []string{
+			"centian", "processor", "add", "--path", "./validator.ts",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cfg, _ := config.LoadConfig()
+		if !cfg.HasProcessor("validator") {
+			t.Fatal("expected processor 'validator' to exist")
+		}
+		if cfg.Processors[0].Config["command"] != "npx" {
+			t.Errorf("expected command 'npx', got %v", cfg.Processors[0].Config["command"])
+		}
+	})
+
+	t.Run("Given: unsupported extension, When: adding processor, Then: returns error", func(t *testing.T) {
+		cleanup := setupTestHome(t)
+		defer cleanup()
+
+		app := &urfavecli.Command{
+			Name:     "centian",
+			Commands: []*urfavecli.Command{ProcessorCommand},
+		}
+		err := app.Run(context.Background(), []string{
+			"centian", "processor", "add", "--path", "./script.rb",
+		})
+
+		// Then: error about unsupported extension.
+		if err == nil {
+			t.Fatal("expected error for unsupported extension")
+		}
+		if !strings.Contains(err.Error(), "unsupported file extension") {
+			t.Errorf("expected 'unsupported file extension' error, got: %v", err)
+		}
+	})
+
+	t.Run("Given: multiple processors added, When: loading config, Then: all persist", func(t *testing.T) {
+		cleanup := setupTestHome(t)
+		defer cleanup()
+
+		app := &urfavecli.Command{
+			Name:     "centian",
+			Commands: []*urfavecli.Command{ProcessorCommand},
+		}
+
+		// When: adding two processors sequentially.
+		err := app.Run(context.Background(), []string{
+			"centian", "processor", "add", "--path", "./first.py",
+		})
+		if err != nil {
+			t.Fatalf("first add failed: %v", err)
+		}
+
+		err = app.Run(context.Background(), []string{
+			"centian", "processor", "add", "--path", "./second.js",
+		})
+		if err != nil {
+			t.Fatalf("second add failed: %v", err)
+		}
+
+		// Then: both processors exist in config.
+		cfg, _ := config.LoadConfig()
+		if len(cfg.Processors) != 2 {
+			t.Fatalf("expected 2 processors, got %d", len(cfg.Processors))
+		}
+		if !cfg.HasProcessor("first") {
+			t.Error("expected processor 'first' to exist")
+		}
+		if !cfg.HasProcessor("second") {
+			t.Error("expected processor 'second' to exist")
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/T4cceptor/centian/internal/common"
 )
@@ -522,6 +523,60 @@ func validateProcessor(index int, processor *ProcessorConfig, processorNames map
 
 	// Validate type-specific config.
 	return validateProcessorTypeConfig(processor)
+}
+
+// HasProcessor returns true if a processor with the given name exists in the global config.
+func (g *GlobalConfig) HasProcessor(name string) bool {
+	for _, p := range g.Processors {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// AddProcessor appends a processor to the global processor chain.
+func (g *GlobalConfig) AddProcessor(p *ProcessorConfig) {
+	g.Processors = append(g.Processors, p)
+}
+
+// ReplaceProcessor replaces an existing processor by name, preserving its position in the chain.
+// Returns false if no processor with the given name was found.
+func (g *GlobalConfig) ReplaceProcessor(name string, p *ProcessorConfig) bool {
+	for i, existing := range g.Processors {
+		if existing.Name == name {
+			g.Processors[i] = p
+			return true
+		}
+	}
+	return false
+}
+
+// InferProcessorNameFromPath extracts a processor name from a file path.
+// Strips the directory and extension, lowercases the result.
+func InferProcessorNameFromPath(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	return strings.ToLower(name)
+}
+
+// InferCommandFromPath determines the runtime command and args for a CLI processor
+// based on the file extension of the script path.
+func InferCommandFromPath(path string) (command string, args []string, err error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".py":
+		return "python3", []string{path}, nil
+	case ".js":
+		return "node", []string{path}, nil
+	case ".ts":
+		return "npx", []string{"ts-node", path}, nil
+	case ".sh":
+		return "bash", []string{path}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported file extension '%s' - supported: .py, .js, .ts, .sh", ext)
+	}
 }
 
 // validateProcessorTypeConfig validates type-specific processor configuration.

--- a/internal/config/config_processor_add_test.go
+++ b/internal/config/config_processor_add_test.go
@@ -1,0 +1,285 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInferProcessorNameFromPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "Given: a python script path, When: inferring name, Then: returns filename without extension",
+			path:     "./processors/security_validator.py",
+			expected: "security_validator",
+		},
+		{
+			name:     "Given: a JS script with hyphens, When: inferring name, Then: preserves hyphens",
+			path:     "/home/user/my-logger.js",
+			expected: "my-logger",
+		},
+		{
+			name:     "Given: a bash script, When: inferring name, Then: returns lowercase name",
+			path:     "./Audit.sh",
+			expected: "audit",
+		},
+		{
+			name:     "Given: a typescript script, When: inferring name, Then: strips .ts extension",
+			path:     "processors/request_filter.ts",
+			expected: "request_filter",
+		},
+		{
+			name:     "Given: a path with multiple dots, When: inferring name, Then: only strips last extension",
+			path:     "./my.processor.py",
+			expected: "my.processor",
+		},
+		{
+			name:     "Given: just a filename, When: inferring name, Then: works without directory",
+			path:     "script.py",
+			expected: "script",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When: inferring the processor name from the path.
+			result := InferProcessorNameFromPath(tt.path)
+
+			// Then: the result matches the expected name.
+			if result != tt.expected {
+				t.Errorf("InferProcessorNameFromPath(%q) = %q, want %q", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInferCommandFromPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		wantCmd     string
+		wantArgs    []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "Given: a .py file, When: inferring command, Then: returns python3",
+			path:     "./processors/script.py",
+			wantCmd:  "python3",
+			wantArgs: []string{"./processors/script.py"},
+		},
+		{
+			name:     "Given: a .js file, When: inferring command, Then: returns node",
+			path:     "./processors/script.js",
+			wantCmd:  "node",
+			wantArgs: []string{"./processors/script.js"},
+		},
+		{
+			name:     "Given: a .ts file, When: inferring command, Then: returns npx with ts-node",
+			path:     "./processors/script.ts",
+			wantCmd:  "npx",
+			wantArgs: []string{"ts-node", "./processors/script.ts"},
+		},
+		{
+			name:     "Given: a .sh file, When: inferring command, Then: returns bash",
+			path:     "./processors/script.sh",
+			wantCmd:  "bash",
+			wantArgs: []string{"./processors/script.sh"},
+		},
+		{
+			name:        "Given: an unsupported extension, When: inferring command, Then: returns error",
+			path:        "./processors/script.rb",
+			wantErr:     true,
+			errContains: "unsupported file extension '.rb'",
+		},
+		{
+			name:        "Given: no extension, When: inferring command, Then: returns error",
+			path:        "./processors/script",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:     "Given: uppercase extension, When: inferring command, Then: handles case-insensitively",
+			path:     "./processors/script.PY",
+			wantCmd:  "python3",
+			wantArgs: []string{"./processors/script.PY"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// When: inferring the command from the path.
+			cmd, args, err := InferCommandFromPath(tt.path)
+
+			// Then: error expectation matches.
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errContains)
+				}
+				if !contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Then: command and args match expectations.
+			if cmd != tt.wantCmd {
+				t.Errorf("command = %q, want %q", cmd, tt.wantCmd)
+			}
+			if len(args) != len(tt.wantArgs) {
+				t.Fatalf("args length = %d, want %d", len(args), len(tt.wantArgs))
+			}
+			for i, arg := range args {
+				if arg != tt.wantArgs[i] {
+					t.Errorf("args[%d] = %q, want %q", i, arg, tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestHasProcessor(t *testing.T) {
+	// Given: a config with one processor.
+	cfg := &GlobalConfig{
+		Processors: []*ProcessorConfig{
+			{Name: "existing-processor", Type: "cli", Enabled: true},
+		},
+	}
+
+	// When/Then: checking for existing processor returns true.
+	if !cfg.HasProcessor("existing-processor") {
+		t.Error("expected HasProcessor to return true for existing processor")
+	}
+
+	// When/Then: checking for non-existing processor returns false.
+	if cfg.HasProcessor("nonexistent") {
+		t.Error("expected HasProcessor to return false for nonexistent processor")
+	}
+
+	// When/Then: checking on nil Processors slice returns false.
+	emptyCfg := &GlobalConfig{}
+	if emptyCfg.HasProcessor("anything") {
+		t.Error("expected HasProcessor to return false on empty config")
+	}
+}
+
+func TestAddProcessor(t *testing.T) {
+	// Given: a config with no processors.
+	cfg := &GlobalConfig{
+		Processors: []*ProcessorConfig{},
+	}
+
+	// When: adding a processor.
+	proc := &ProcessorConfig{Name: "new-proc", Type: "cli", Enabled: true}
+	cfg.AddProcessor(proc)
+
+	// Then: config has one processor.
+	if len(cfg.Processors) != 1 {
+		t.Fatalf("expected 1 processor, got %d", len(cfg.Processors))
+	}
+	if cfg.Processors[0].Name != "new-proc" {
+		t.Errorf("expected processor name 'new-proc', got %q", cfg.Processors[0].Name)
+	}
+}
+
+func TestReplaceProcessor(t *testing.T) {
+	// Given: a config with two processors.
+	cfg := &GlobalConfig{
+		Processors: []*ProcessorConfig{
+			{Name: "first", Type: "cli", Enabled: true, Timeout: 10},
+			{Name: "second", Type: "cli", Enabled: true, Timeout: 20},
+		},
+	}
+
+	// When: replacing the first processor.
+	replacement := &ProcessorConfig{Name: "first", Type: "cli", Enabled: false, Timeout: 30}
+	replaced := cfg.ReplaceProcessor("first", replacement)
+
+	// Then: replacement was successful and position preserved.
+	if !replaced {
+		t.Fatal("expected ReplaceProcessor to return true")
+	}
+	if len(cfg.Processors) != 2 {
+		t.Fatalf("expected 2 processors, got %d", len(cfg.Processors))
+	}
+	if cfg.Processors[0].Timeout != 30 {
+		t.Errorf("expected replaced processor timeout 30, got %d", cfg.Processors[0].Timeout)
+	}
+	if cfg.Processors[0].Enabled {
+		t.Error("expected replaced processor to be disabled")
+	}
+
+	// When: replacing a nonexistent processor.
+	notFound := cfg.ReplaceProcessor("nonexistent", replacement)
+
+	// Then: returns false.
+	if notFound {
+		t.Error("expected ReplaceProcessor to return false for nonexistent processor")
+	}
+}
+
+func TestProcessorAddPersistence(t *testing.T) {
+	// Given: a temp HOME directory for isolated config.
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	testHome := filepath.Join(tempDir, "processor_add_test")
+	os.Setenv("HOME", testHome)
+	defer os.Setenv("HOME", originalHome)
+
+	// Given: a default config saved to disk.
+	cfg := DefaultConfig()
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatalf("failed to save initial config: %v", err)
+	}
+
+	// When: adding a processor and saving.
+	cmd, args, err := InferCommandFromPath("./processors/audit.py")
+	if err != nil {
+		t.Fatalf("unexpected error from InferCommandFromPath: %v", err)
+	}
+	configArgs := make([]interface{}, len(args))
+	for i, a := range args {
+		configArgs[i] = a
+	}
+	proc := &ProcessorConfig{
+		Name:    InferProcessorNameFromPath("./processors/audit.py"),
+		Type:    "cli",
+		Enabled: true,
+		Timeout: 15,
+		Config: map[string]interface{}{
+			"command": cmd,
+			"args":    configArgs,
+		},
+	}
+	cfg.AddProcessor(proc)
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatalf("failed to save config with processor: %v", err)
+	}
+
+	// Then: loading the config preserves the processor.
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if len(loaded.Processors) != 1 {
+		t.Fatalf("expected 1 processor, got %d", len(loaded.Processors))
+	}
+	p := loaded.Processors[0]
+	if p.Name != "audit" {
+		t.Errorf("expected processor name 'audit', got %q", p.Name)
+	}
+	if p.Type != "cli" {
+		t.Errorf("expected processor type 'cli', got %q", p.Type)
+	}
+	command, ok := p.Config["command"].(string)
+	if !ok || command != "python3" {
+		t.Errorf("expected command 'python3', got %v", p.Config["command"])
+	}
+}


### PR DESCRIPTION
Using `centian processor add -p <path>` we can now add an existing processor to the centian config.

The command infers processor `name` and `command` (e.g. `python`, `node`etc.) automatically based on provided file path / name / extension.

In case there is a name clash in the current config, the user is prompted 3 options how to resolve:
- use a slightly different name
- overwrite
- abort
