### PR TITLE
Added config restore command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,58 @@ Minimal example:
 }
 ```
 
+### Valid Configuration Requirements
+
+At a minimum (for config management commands), a config must include:
+
+- `version` (non-empty string)
+- `proxy` (object)
+
+For `centian start` (strict validation), the config must also include:
+
+- At least one gateway in `gateways`
+- Each gateway must have at least one active MCP server
+- Gateway names and server names must be URL-safe (`a-z`, `A-Z`, `0-9`, `_`, `-`)
+- Each server must define exactly one transport:
+  - `command` for stdio, or
+  - `url` for HTTP(S)
+- If `url` is used, it must be a valid `http://` or `https://` URL
+- Header keys and values must be non-empty
+
+You can validate your current config with:
+
+```bash
+centian config validate
+```
+
+### Environment Variable Interpolation
+
+Centian supports environment variable interpolation in `mcpServers.<server>.headers` values.
+
+Example:
+```json
+{
+  "gateways": {
+    "default": {
+      "mcpServers": {
+        "github": {
+          "url": "https://api.githubcopilot.com/mcp/",
+          "headers": {
+            "Authorization": "Bearer ${GITHUB_PAT}",
+            "X-Api-Key": "$API_KEY",
+            "X-Custom": "prefix-${ENV}-suffix"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Endpoints
 
-- Aggregated gateway endpoint:
-  - `http://127.0.0.1:8080/mcp/<gateway>`
-- Individual server endpoint:
-  - `http://127.0.0.1:8080/mcp/<gateway>/<server>`
+- Aggregated gateway endpoint: `http://localhost:8080/mcp/<gateway>`
+- Individual server endpoint: `http://localhost:8080/mcp/<gateway>/<server>`
 
 In aggregated mode, tools are namespaced to avoid collisions.
 

--- a/internal/config/commands.go
+++ b/internal/config/commands.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/urfave/cli/v3"
@@ -22,9 +23,12 @@ var ConfigCommand = &cli.Command{
 		configInitCommand,
 		configShowCommand,
 		configValidateCommand,
+		configRestoreCommand,
 		configRemoveCommand,
 	},
 }
+
+const defaultBackupConfigPath = "~/.centian/backup.config.json"
 
 var configInitCommand = &cli.Command{
 	Name:        "init",
@@ -66,6 +70,26 @@ var configRemoveCommand = &cli.Command{
 		},
 	},
 	Action: removeConfig,
+}
+
+var configRestoreCommand = &cli.Command{
+	Name:        "restore",
+	Usage:       "Restore configuration from a backup file",
+	Description: "Validates and restores a backup configuration into ~/.centian/config.json",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "path",
+			Aliases: []string{"p"},
+			Usage:   "Path to backup configuration file",
+			Value:   defaultBackupConfigPath,
+		},
+		&cli.BoolFlag{
+			Name:    "force",
+			Aliases: []string{"f"},
+			Usage:   "Skip confirmation prompt when overwriting existing configuration",
+		},
+	},
+	Action: restoreConfig,
 }
 
 // ServerCommand provides MCP server management functionality.
@@ -259,6 +283,72 @@ func validateConfigCommand(_ context.Context, _ *cli.Command) error {
 	configPath, _ := GetConfigPath()
 	fmt.Printf("✅ Configuration is valid: %s\n", configPath)
 	return nil
+}
+
+func restoreConfig(_ context.Context, cmd *cli.Command) error {
+	backupPath, err := resolveBackupConfigPath(cmd.String("path"))
+	if err != nil {
+		return err
+	}
+
+	backupConfig, err := LoadConfigFromPath(backupPath)
+	if err != nil {
+		return fmt.Errorf("backup configuration is invalid: %w", err)
+	}
+
+	configPath, err := GetConfigPath()
+	if err != nil {
+		return fmt.Errorf("failed to get config path: %w", err)
+	}
+
+	if _, err := os.Stat(configPath); err == nil {
+		if !cmd.Bool("force") {
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Printf("⚠️  A configuration already exists at %s\n", configPath)
+			fmt.Printf("⚠️  This will overwrite it with backup from %s\n", backupPath)
+			fmt.Printf("Continue? [y/N]: ")
+
+			response, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("failed to read input: %w", err)
+			}
+
+			response = strings.TrimSpace(strings.ToLower(response))
+			if response != "y" && response != "yes" {
+				fmt.Printf("❌ Operation cancelled")
+				return nil
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to check existing configuration: %w", err)
+	}
+
+	if err := SaveConfig(backupConfig); err != nil {
+		return fmt.Errorf("failed to restore configuration: %w", err)
+	}
+
+	fmt.Printf("✅ Configuration restored from %s to %s\n", backupPath, configPath)
+	return nil
+}
+
+func resolveBackupConfigPath(path string) (string, error) {
+	expandedPath := strings.TrimSpace(path)
+	if expandedPath == "" {
+		expandedPath = defaultBackupConfigPath
+	}
+	if strings.HasPrefix(expandedPath, "~/") || expandedPath == "~" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		if expandedPath == "~" {
+			expandedPath = homeDir
+		} else {
+			expandedPath = filepath.Join(homeDir, expandedPath[2:])
+		}
+	}
+	expandedPath = os.ExpandEnv(expandedPath)
+	return filepath.Clean(expandedPath), nil
 }
 
 func listServers(_ context.Context, cmd *cli.Command) error {

--- a/internal/config/commands_test.go
+++ b/internal/config/commands_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -37,6 +38,19 @@ func setupTestEnv(t *testing.T) func() {
 func createTestConfig(t *testing.T) {
 	config := DefaultConfig()
 	err := SaveConfig(config)
+	assert.NilError(t, err)
+}
+
+func writeConfigToPath(t *testing.T, path string, cfg *GlobalConfig) {
+	t.Helper()
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	assert.NilError(t, err)
+
+	err = os.MkdirAll(filepath.Dir(path), 0o755)
+	assert.NilError(t, err)
+
+	err = os.WriteFile(path, data, 0o644)
 	assert.NilError(t, err)
 }
 
@@ -830,6 +844,149 @@ func TestListServers_FailsIfNoConfig(t *testing.T) {
 
 	// Then: should return error.
 	assert.ErrorContains(t, err, "failed to load configuration")
+}
+
+// ========================================
+// restoreConfig Tests
+// ========================================
+
+func TestRestoreConfig_RestoresConfigWithForceFlag(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	existingConfig := DefaultConfig()
+	existingConfig.Name = "Original Config"
+	assert.NilError(t, SaveConfig(existingConfig))
+
+	backupConfig := DefaultConfig()
+	backupConfig.Name = "Restored Config"
+	backupConfig.Gateways = map[string]*GatewayConfig{
+		"backup-gateway": {
+			MCPServers: map[string]*MCPServerConfig{
+				"backup-server": {
+					Name: "backup-server",
+					URL:  "https://backup.example.com/mcp",
+				},
+			},
+		},
+	}
+
+	backupPath := filepath.Join(os.Getenv("HOME"), ".centian", "backup.config.json")
+	writeConfigToPath(t, backupPath, backupConfig)
+
+	ctx := context.Background()
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "path", Value: backupPath},
+			&cli.BoolFlag{Name: "force", Value: true},
+		},
+	}
+
+	err := restoreConfig(ctx, cmd)
+	assert.NilError(t, err)
+
+	restoredConfig, err := LoadConfig()
+	assert.NilError(t, err)
+	assert.Equal(t, "Restored Config", restoredConfig.Name)
+	_, exists := restoredConfig.Gateways["backup-gateway"]
+	assert.Assert(t, exists)
+}
+
+func TestRestoreConfig_FailsForInvalidBackup(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	existingConfig := DefaultConfig()
+	existingConfig.Name = "Original Config"
+	assert.NilError(t, SaveConfig(existingConfig))
+
+	backupPath := filepath.Join(os.Getenv("HOME"), ".centian", "backup.config.json")
+	assert.NilError(t, os.MkdirAll(filepath.Dir(backupPath), 0o755))
+	assert.NilError(t, os.WriteFile(backupPath, []byte("{invalid json"), 0o644))
+
+	ctx := context.Background()
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "path", Value: backupPath},
+			&cli.BoolFlag{Name: "force", Value: true},
+		},
+	}
+
+	err := restoreConfig(ctx, cmd)
+	assert.ErrorContains(t, err, "backup configuration is invalid")
+}
+
+func TestRestoreConfig_CancelsWhenUserDoesNotConfirm(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	existingConfig := DefaultConfig()
+	existingConfig.Name = "Original Config"
+	assert.NilError(t, SaveConfig(existingConfig))
+
+	backupConfig := DefaultConfig()
+	backupConfig.Name = "Restored Config"
+	backupPath := filepath.Join(os.Getenv("HOME"), ".centian", "backup.config.json")
+	writeConfigToPath(t, backupPath, backupConfig)
+
+	restoreStdin := replaceStdin(t, "n\n")
+	defer restoreStdin()
+
+	ctx := context.Background()
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "path", Value: backupPath},
+			&cli.BoolFlag{Name: "force", Value: false},
+		},
+	}
+
+	err := restoreConfig(ctx, cmd)
+	assert.NilError(t, err)
+
+	currentConfig, err := LoadConfig()
+	assert.NilError(t, err)
+	assert.Equal(t, "Original Config", currentConfig.Name)
+}
+
+func TestRestoreConfig_OverwritesAfterUserConfirmation(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	existingConfig := DefaultConfig()
+	existingConfig.Name = "Original Config"
+	assert.NilError(t, SaveConfig(existingConfig))
+
+	backupConfig := DefaultConfig()
+	backupConfig.Name = "Restored Config"
+	backupPath := filepath.Join(os.Getenv("HOME"), ".centian", "backup.config.json")
+	writeConfigToPath(t, backupPath, backupConfig)
+
+	restoreStdin := replaceStdin(t, "yes\n")
+	defer restoreStdin()
+
+	ctx := context.Background()
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "path", Value: backupPath},
+			&cli.BoolFlag{Name: "force", Value: false},
+		},
+	}
+
+	err := restoreConfig(ctx, cmd)
+	assert.NilError(t, err)
+
+	currentConfig, err := LoadConfig()
+	assert.NilError(t, err)
+	assert.Equal(t, "Restored Config", currentConfig.Name)
+}
+
+func TestResolveBackupConfigPath_ExpandsHomePath(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	backupPath, err := resolveBackupConfigPath("~/.centian/backup.config.json")
+	assert.NilError(t, err)
+	assert.Equal(t, filepath.Join(os.Getenv("HOME"), ".centian", "backup.config.json"), backupPath)
 }
 
 // ========================================


### PR DESCRIPTION
### Added
- New CLI command: centian config restore.
- Support for restoring `~/.centian/config.json` from a backup file.
- Default backup source path: `~/.centian/backup.config.json`.
- `--path / -p` flag to restore from a custom backup file.
- `--force / -f` flag to skip overwrite confirmation.

### Changed
- Restore now validates the backup config before writing anything to the active config.
- If an active config already exists, restore requires explicit confirmation unless --force is provided.
- Backup paths now support ~ expansion and environment variable expansion before validation/use.

### Documentation
- Expanded the README configuration section with:
- valid Centian config requirements
- startup-time config validation expectations
- environment variable interpolation rules for server headers

### Testing
- Added coverage for:
- - forced restore success
- - invalid backup rejection
- - cancel-on-prompt behavior
- - confirmed overwrite behavior
- - backup path home-directory expansion

### Relevant files:
- `internal/config/commands.go`
- `internal/config/commands_test.go`
- `README.md`