### PR TITLE
Implemented AggregatedToolName struct and helper functions

### DIFF
--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -38,7 +38,7 @@ func TestHandleLogsCommandOutputsEntries(t *testing.T) {
 			Success:          true,
 			ProcessingErrors: make(map[string]error),
 		},
-		Routing: common.RoutingLog{
+		Routing: common.RoutingContext{
 			DownstreamCommand: "npx",
 			Args:              []string{"@server"},
 		},

--- a/internal/common/mcp_event.go
+++ b/internal/common/mcp_event.go
@@ -14,14 +14,14 @@ type MCPEvent struct {
 	BaseMcpEvent
 
 	// Routing context (always present)
-	Routing RoutingLog `json:"routing"`
+	Routing RoutingContext `json:"routing"`
 
 	// Tool call context (optional - only for tool call events)
 	ToolCall *ToolCallLog `json:"tool_call,omitempty"`
 }
 
-// RoutingLog captures where the request is going.
-type RoutingLog struct {
+// RoutingContext captures where the request is going.
+type RoutingContext struct {
 	// Transport describes the used transport for this connection (http or stdio)
 	Transport McpTransportType `json:"transport,omitempty"`
 
@@ -87,7 +87,7 @@ func NewMCPEvent(
 			ProcessingErrors: make(map[string]error),
 			Metadata:         make(map[string]string),
 		},
-		Routing: RoutingLog{},
+		Routing: RoutingContext{},
 	}
 }
 

--- a/internal/logging/common_logger_test.go
+++ b/internal/logging/common_logger_test.go
@@ -58,7 +58,7 @@ func TestLogMcpEvent(t *testing.T) {
 	baseMcpEvent := getBaseMcpEvent()
 	mcpEvent := common.MCPEvent{
 		BaseMcpEvent: baseMcpEvent,
-		Routing: common.RoutingLog{
+		Routing: common.RoutingContext{
 			DownstreamCommand: command,
 			Args:              args,
 		},

--- a/internal/logging/log_reader_test.go
+++ b/internal/logging/log_reader_test.go
@@ -35,7 +35,7 @@ func TestLoadRecentLogEntriesOrdersByTimestamp(t *testing.T) {
 			Success:          true,
 			ProcessingErrors: make(map[string]error),
 		},
-		Routing: common.RoutingLog{
+		Routing: common.RoutingContext{
 			DownstreamCommand: "npx",
 			Args:              []string{"pkg"},
 		},
@@ -50,7 +50,7 @@ func TestLoadRecentLogEntriesOrdersByTimestamp(t *testing.T) {
 			Success:          true,
 			ProcessingErrors: make(map[string]error),
 		},
-		Routing: common.RoutingLog{
+		Routing: common.RoutingContext{
 			DownstreamCommand: "npx",
 			Args:              []string{"pkg"},
 		},
@@ -97,7 +97,7 @@ func TestLoadRecentLogEntriesLimit(t *testing.T) {
 			Success:          true,
 			ProcessingErrors: make(map[string]error),
 		},
-		Routing: common.RoutingLog{
+		Routing: common.RoutingContext{
 			DownstreamCommand: "test",
 		},
 	}
@@ -111,7 +111,7 @@ func TestLoadRecentLogEntriesLimit(t *testing.T) {
 			Success:          true,
 			ProcessingErrors: make(map[string]error),
 		},
-		Routing: common.RoutingLog{
+		Routing: common.RoutingContext{
 			DownstreamCommand: "npx",
 		},
 	}
@@ -173,7 +173,7 @@ func TestFormatDisplayLine(t *testing.T) {
 			Success:          true,
 			ProcessingErrors: make(map[string]error),
 		},
-		Routing: common.RoutingLog{
+		Routing: common.RoutingContext{
 			DownstreamCommand: "npx",
 			Args:              []string{"@mcp/server"},
 		},

--- a/internal/proxy/call_context.go
+++ b/internal/proxy/call_context.go
@@ -41,10 +41,7 @@ type CallContext interface {
 	GetServerName() string            // Returns current server name
 	SetServerName(string)             // Sets current server name, can be used for re-routing
 	GetRequest() *mcp.CallToolRequest // Returns current CallToolRequest
-	GetRawToolName() string           // Returns current raw request tool name
-	GetToolName() string              // Returns current raw request tool name
-	GetDownstreamToolName() string    // Returns the tool name to use for downstream dispatch
-	RewriteToolName(string) error     // Rewrites the current request tool name for the active routing mode
+	GetToolName() string              // Returns current tool name
 
 	// Status and error handling
 	GetStatus() int   // Returns current status code (0 = not set, 200 = ok, 4xx/5xx = error)
@@ -64,7 +61,7 @@ type CallContext interface {
 	SetMessageType(common.McpMessageType)
 
 	// Routing context (reuses common.RoutingContext)
-	GetRoutingContext() *common.RoutingLog
+	GetRoutingContext() *common.RoutingContext
 
 	// Handler access
 	GetHandler(part string) (CallContextHandler, bool) // Returns handler for given part (payload, meta, routing, etc.)

--- a/internal/proxy/call_context.go
+++ b/internal/proxy/call_context.go
@@ -41,7 +41,10 @@ type CallContext interface {
 	GetServerName() string            // Returns current server name
 	SetServerName(string)             // Sets current server name, can be used for re-routing
 	GetRequest() *mcp.CallToolRequest // Returns current CallToolRequest
-	GetToolName() string              // Returns current tool name
+	GetRawToolName() string           // Returns current raw request tool name
+	GetToolName() string              // Returns current raw request tool name
+	GetDownstreamToolName() string    // Returns the tool name to use for downstream dispatch
+	RewriteToolName(string) error     // Rewrites the current request tool name for the active routing mode
 
 	// Status and error handling
 	GetStatus() int   // Returns current status code (0 = not set, 200 = ok, 4xx/5xx = error)

--- a/internal/proxy/downstream_connection.go
+++ b/internal/proxy/downstream_connection.go
@@ -17,10 +17,11 @@ type ConnectionStatus string
 
 // Connection status constants for tracking downstream connection lifecycle.
 const (
-	StatusPending    ConnectionStatus = "pending"
-	StatusConnecting ConnectionStatus = "connecting"
-	StatusConnected  ConnectionStatus = "connected"
-	StatusFailed     ConnectionStatus = "failed"
+	StatusPending      ConnectionStatus = "pending"
+	StatusConnecting   ConnectionStatus = "connecting"
+	StatusConnected    ConnectionStatus = "connected"
+	StatusFailed       ConnectionStatus = "failed"
+	StatusDisconnected ConnectionStatus = "disconnected"
 )
 
 // DownstreamConnection represents a connection to a downstream MCP server.
@@ -30,7 +31,6 @@ type DownstreamConnection struct {
 	client     *mcp.Client
 	session    *mcp.ClientSession
 	tools      []*mcp.Tool
-	connected  bool
 	mu         sync.RWMutex
 
 	// Progressive connection tracking
@@ -39,21 +39,23 @@ type DownstreamConnection struct {
 	connectedAt time.Time
 }
 
+// GetServerName returns the server name for this DownstreamConnection.
+func (dc *DownstreamConnection) GetServerName() string {
+	return dc.serverName
+}
+
 // Connect establishes connection to downstream server
 // authHeaders: additional headers from upstream request (for passthrough auth).
 func (dc *DownstreamConnection) Connect(ctx context.Context, authHeaders map[string]string) error {
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-
-	if dc.connected {
+	if dc.IsConnected() {
 		return nil // Already connected
 	}
-
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
 	dc.status = StatusConnecting
-
 	dc.client = mcp.NewClient(&mcp.Implementation{
 		Name:    dc.serverName,
-		Version: "1.0.0", // TODO: replace with gateway version
+		Version: "1.0.0", // TODO: replace with gateway version?
 	}, nil)
 
 	transport, err := dc.createTransport(authHeaders)
@@ -78,19 +80,16 @@ func (dc *DownstreamConnection) Connect(ctx context.Context, authHeaders map[str
 		dc.connError = err
 		return fmt.Errorf("failed to discover tools: %w", err)
 	}
-
-	dc.connected = true
 	dc.status = StatusConnected
 	dc.connectedAt = time.Now()
 	return nil
 }
 
 // NewDownstreamConnection creates an unconnected downstream wrapper.
-func NewDownstreamConnection(name string, cfg *config.MCPServerConfig) *DownstreamConnection {
+func NewDownstreamConnection(serverName string, cfg *config.MCPServerConfig) *DownstreamConnection {
 	return &DownstreamConnection{
-		serverName: name,
+		serverName: serverName,
 		config:     cfg,
-		connected:  false,
 		status:     StatusPending,
 	}
 }
@@ -183,7 +182,7 @@ func (dc *DownstreamConnection) CallTool(ctx context.Context, toolName string, a
 	dc.mu.RLock()
 	defer dc.mu.RUnlock()
 
-	if !dc.connected || dc.session == nil {
+	if !dc.IsConnected() || dc.session == nil {
 		return nil, fmt.Errorf("not connected to %s", dc.serverName)
 	}
 
@@ -204,7 +203,7 @@ func (dc *DownstreamConnection) Close() error {
 			return err
 		}
 	}
-	dc.connected = false
+	dc.status = StatusConnected
 	return nil
 }
 
@@ -219,7 +218,7 @@ func (dc *DownstreamConnection) Tools() []*mcp.Tool {
 func (dc *DownstreamConnection) IsConnected() bool {
 	dc.mu.RLock()
 	defer dc.mu.RUnlock()
-	return dc.connected
+	return dc.status == StatusConnected
 }
 
 // GetConfig returns the server configuration for this connection.

--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -11,7 +11,7 @@ import (
 // MockDownstreamConnection is a shared test double for DownstreamConnectionInterface.
 type MockDownstreamConnection struct {
 	mu           sync.RWMutex
-	connected    bool
+	serverName   string
 	tools        []*mcp.Tool
 	cfg          *config.MCPServerConfig
 	ConnectCalls int
@@ -27,6 +27,13 @@ type MockDownstreamConnection struct {
 	ResultToReturn *mcp.CallToolResult
 	ErrorToReturn  error
 	Status         ConnectionStatus
+}
+
+func (m *MockDownstreamConnection) GetServerName() string {
+	if m.serverName != "" {
+		return m.serverName
+	}
+	return "mock-server"
 }
 
 func (m *MockDownstreamConnection) Connect(ctx context.Context, headers map[string]string) error {
@@ -50,7 +57,6 @@ func (m *MockDownstreamConnection) Connect(ctx context.Context, headers map[stri
 		return m.ErrorToReturn
 	}
 	m.Status = StatusConnected
-	m.connected = true
 	return nil
 }
 
@@ -77,7 +83,7 @@ func (m *MockDownstreamConnection) CallTool(_ context.Context, toolName string, 
 func (m *MockDownstreamConnection) IsConnected() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.connected
+	return m.Status == StatusConnected
 }
 
 func (m *MockDownstreamConnection) Tools() []*mcp.Tool {
@@ -90,7 +96,7 @@ func (m *MockDownstreamConnection) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.CloseCalls++
-	m.connected = false
+	m.Status = StatusDisconnected
 	return nil
 }
 

--- a/internal/proxy/downstream_connection_test.go
+++ b/internal/proxy/downstream_connection_test.go
@@ -172,7 +172,7 @@ func containsEnv(env []string, entry string) bool {
 func TestDownstreamConnectionConnect_EarlyReturn(t *testing.T) {
 	// Given: an already connected downstream
 	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
-	dc.connected = true
+	dc.status = StatusConnected
 
 	// When: connecting
 	err := dc.Connect(context.Background(), nil)

--- a/internal/proxy/downstream_connection_test.go
+++ b/internal/proxy/downstream_connection_test.go
@@ -160,6 +160,65 @@ func TestDownstreamConnectionServerName(t *testing.T) {
 	assert.Equal(t, dc.ServerName(), "my-server")
 }
 
+func TestDownstreamConnectionGetConfigAndStatus(t *testing.T) {
+	cfg := &config.MCPServerConfig{URL: "https://example.com/mcp"}
+	dc := NewDownstreamConnection("server", cfg)
+	dc.status = StatusFailed
+
+	assert.Assert(t, dc.GetConfig() == cfg)
+	assert.Equal(t, dc.GetStatus(), StatusFailed)
+}
+
+func TestDownstreamConnectionDiscoverTools(t *testing.T) {
+	clientSession, cleanup := connectTestClientSession(t, func(server *mcp.Server) {
+		mcp.AddTool(server, &mcp.Tool{Name: "ping", Description: "ping"}, func(context.Context, *mcp.CallToolRequest, map[string]any) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "pong"}},
+			}, nil, nil
+		})
+	})
+	defer cleanup()
+
+	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
+	dc.session = clientSession
+
+	err := dc.discoverTools(context.Background())
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(dc.tools), 1)
+	assert.Equal(t, dc.tools[0].Name, "ping")
+}
+
+func TestDownstreamConnectionCallTool_NotConnected(t *testing.T) {
+	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
+
+	result, err := dc.CallTool(context.Background(), "ping", map[string]any{"k": "v"})
+
+	assert.Assert(t, result == nil)
+	assert.ErrorContains(t, err, "not connected to server")
+}
+
+func TestDownstreamConnectionCallTool(t *testing.T) {
+	clientSession, cleanup := connectTestClientSession(t, func(server *mcp.Server) {
+		mcp.AddTool(server, &mcp.Tool{Name: "ping", Description: "ping"}, func(_ context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: args["message"].(string)}},
+			}, nil, nil
+		})
+	})
+	defer cleanup()
+
+	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
+	dc.session = clientSession
+	dc.status = StatusConnected
+
+	result, err := dc.CallTool(context.Background(), "ping", map[string]any{"message": "pong"})
+
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.Equal(t, result.Content[0].(*mcp.TextContent).Text, "pong")
+}
+
 func containsEnv(env []string, entry string) bool {
 	for _, value := range env {
 		if value == entry {
@@ -167,6 +226,31 @@ func containsEnv(env []string, entry string) bool {
 		}
 	}
 	return false
+}
+
+func connectTestClientSession(t *testing.T, register func(server *mcp.Server)) (*mcp.ClientSession, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "1.0.0"}, nil)
+	if register != nil {
+		register(server)
+	}
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	assert.NilError(t, err)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "1.0.0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	assert.NilError(t, err)
+
+	cleanup := func() {
+		_ = clientSession.Close()
+		_ = serverSession.Close()
+	}
+
+	return clientSession, cleanup
 }
 
 func TestDownstreamConnectionConnect_EarlyReturn(t *testing.T) {

--- a/internal/proxy/handle_tool_call_test.go
+++ b/internal/proxy/handle_tool_call_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
 	"github.com/T4cceptor/centian/internal/logging"
+	"github.com/T4cceptor/centian/internal/processor"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/assert"
 )
@@ -178,4 +179,49 @@ func TestHandleToolCall_ProcessorModifiesResponse(t *testing.T) {
 		common.DirectionClientToServer,
 		common.DirectionServerToClient,
 	})
+}
+
+func TestHandleToolCall_AggregatedRoutingRoundTripKeepsNamespacedRequest(t *testing.T) {
+	roundTripProcessor := &mockProcessor{
+		cfg: &config.ProcessorConfig{
+			Name:  "routing-roundtrip",
+			Parts: []string{"payload", "meta", "routing"},
+		},
+		processFn: func(input *processor.DataContext) (*processor.DataContext, error) {
+			return input, nil
+		},
+	}
+
+	mockDownstream := &MockDownstreamConnection{
+		connected: true,
+		cfg:       &config.MCPServerConfig{URL: "http://test"},
+		ResultToReturn: &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+		},
+	}
+
+	proxy := createTestProxy(t, &ProcessingController{
+		processors: []processor.ProcessorInterface{roundTripProcessor},
+	})
+	proxy.isAggregatedProxy = true
+
+	session := &UpstreamSession{
+		id: "test-session",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"logging-demo-db": mockDownstream,
+		},
+	}
+
+	req := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "logging-demo-db___query",
+			Arguments: json.RawMessage(`{"sql":"select 1"}`),
+		},
+	}
+
+	_, err := proxy.handleToolCall(context.Background(), session, "logging-demo-db", req)
+
+	assert.NilError(t, err)
+	assert.Equal(t, mockDownstream.CapturedToolName, "query")
+	assert.Equal(t, req.Params.Name, "logging-demo-db___query")
 }

--- a/internal/proxy/handle_tool_call_test.go
+++ b/internal/proxy/handle_tool_call_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
 	"github.com/T4cceptor/centian/internal/logging"
+	"github.com/T4cceptor/centian/internal/processor"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/assert"
 )
@@ -52,6 +53,20 @@ func createTestProxy(t *testing.T, eventProcessor ProcessingControllerInterface)
 			Logger:   logger,
 		},
 	}
+}
+
+type passthroughProcessor struct {
+	cfg       *config.ProcessorConfig
+	lastInput *processor.DataContext
+}
+
+func (p *passthroughProcessor) Process(input *processor.DataContext) (*processor.DataContext, error) {
+	p.lastInput = input
+	return input, nil
+}
+
+func (p *passthroughProcessor) GetConfig() *config.ProcessorConfig {
+	return p.cfg
 }
 
 // TestHandleToolCall_ProcessorModifiesRequest verifies that when the event processor
@@ -178,4 +193,64 @@ func TestHandleToolCall_ProcessorModifiesResponse(t *testing.T) {
 		common.DirectionClientToServer,
 		common.DirectionServerToClient,
 	})
+}
+
+// TestHandleToolCall_AggregatedPassthroughProcessorKeepsNormalizedToolName verifies
+// that a processor receiving payload and routing data and returning them unchanged
+// does not reintroduce the aggregated upstream namespace into the current request state.
+func TestHandleToolCall_AggregatedPassthroughProcessorKeepsNormalizedToolName(t *testing.T) {
+	mockProcessor := &passthroughProcessor{
+		cfg: &config.ProcessorConfig{
+			Name:  "passthrough",
+			Parts: []string{"payload", "routing"},
+		},
+	}
+
+	mockDownstream := &MockDownstreamConnection{
+		cfg: &config.MCPServerConfig{URL: "http://test"},
+		ResultToReturn: &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "ok"},
+			},
+		},
+		Status: StatusConnected,
+	}
+
+	proxy := createTestProxy(t, &ProcessingController{
+		processors: []processor.ProcessorInterface{mockProcessor},
+	})
+	proxy.isAggregatedProxy = true
+
+	session := &UpstreamSession{
+		id: "test-session",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"test-server": mockDownstream,
+		},
+	}
+
+	req := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "test-server___test-tool",
+			Arguments: json.RawMessage(`{"original": "value"}`),
+		},
+	}
+
+	result, err := proxy.handleToolCall(context.Background(), session, "test-server", req)
+
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.Assert(t, mockProcessor.lastInput != nil)
+	assert.Assert(t, mockProcessor.lastInput.Payload != nil)
+	assert.Assert(t, mockProcessor.lastInput.Payload.Request != nil)
+	assert.Assert(t, mockProcessor.lastInput.Payload.OriginalRequest != nil)
+	assert.Assert(t, mockProcessor.lastInput.Routing != nil)
+
+	assert.Equal(t, mockProcessor.lastInput.Payload.Request.Params.Name, "test-tool")
+	assert.Equal(t, mockProcessor.lastInput.Payload.OriginalRequest.Params.Name, "test-server___test-tool")
+	assert.Equal(t, mockProcessor.lastInput.Routing.ToolName, "test-tool")
+	assert.Equal(t, mockProcessor.lastInput.Routing.OriginalToolname, "test-server___test-tool")
+
+	assert.Equal(t, req.Params.Name, "test-tool")
+	assert.Equal(t, mockDownstream.CapturedToolName, "test-tool")
+	assert.Equal(t, mockDownstream.CapturedArgs["original"], "value")
 }

--- a/internal/proxy/handle_tool_call_test.go
+++ b/internal/proxy/handle_tool_call_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
 	"github.com/T4cceptor/centian/internal/logging"
-	"github.com/T4cceptor/centian/internal/processor"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/assert"
 )
@@ -81,14 +80,14 @@ func TestHandleToolCall_ProcessorModifiesRequest(t *testing.T) {
 
 	// And: a mock downstream that captures what it receives
 	mockDownstream := &MockDownstreamConnection{
-		connected: true,
-		cfg:       &config.MCPServerConfig{URL: "http://test"},
+		cfg: &config.MCPServerConfig{URL: "http://test"},
 		ResultToReturn: &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: "original response"},
 			},
 		},
 	}
+	mockDownstream.Status = StatusConnected
 
 	// And: a proxy with the mock processor and session with mock downstream
 	proxy := createTestProxy(t, mockProcessor)
@@ -138,14 +137,14 @@ func TestHandleToolCall_ProcessorModifiesResponse(t *testing.T) {
 
 	// And: a mock downstream that returns original content
 	mockDownstream := &MockDownstreamConnection{
-		connected: true,
-		cfg:       &config.MCPServerConfig{URL: "http://test"},
+		cfg: &config.MCPServerConfig{URL: "http://test"},
 		ResultToReturn: &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: "original response"},
 			},
 		},
 	}
+	mockDownstream.Status = StatusConnected
 
 	// And: a proxy with the mock processor and session with mock downstream
 	proxy := createTestProxy(t, mockProcessor)
@@ -179,49 +178,4 @@ func TestHandleToolCall_ProcessorModifiesResponse(t *testing.T) {
 		common.DirectionClientToServer,
 		common.DirectionServerToClient,
 	})
-}
-
-func TestHandleToolCall_AggregatedRoutingRoundTripKeepsNamespacedRequest(t *testing.T) {
-	roundTripProcessor := &mockProcessor{
-		cfg: &config.ProcessorConfig{
-			Name:  "routing-roundtrip",
-			Parts: []string{"payload", "meta", "routing"},
-		},
-		processFn: func(input *processor.DataContext) (*processor.DataContext, error) {
-			return input, nil
-		},
-	}
-
-	mockDownstream := &MockDownstreamConnection{
-		connected: true,
-		cfg:       &config.MCPServerConfig{URL: "http://test"},
-		ResultToReturn: &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
-		},
-	}
-
-	proxy := createTestProxy(t, &ProcessingController{
-		processors: []processor.ProcessorInterface{roundTripProcessor},
-	})
-	proxy.isAggregatedProxy = true
-
-	session := &UpstreamSession{
-		id: "test-session",
-		downstreamConns: map[string]DownstreamConnectionInterface{
-			"logging-demo-db": mockDownstream,
-		},
-	}
-
-	req := &mcp.CallToolRequest{
-		Params: &mcp.CallToolParamsRaw{
-			Name:      "logging-demo-db___query",
-			Arguments: json.RawMessage(`{"sql":"select 1"}`),
-		},
-	}
-
-	_, err := proxy.handleToolCall(context.Background(), session, "logging-demo-db", req)
-
-	assert.NilError(t, err)
-	assert.Equal(t, mockDownstream.CapturedToolName, "query")
-	assert.Equal(t, req.Params.Name, "logging-demo-db___query")
 }

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -2,11 +2,13 @@ package proxy
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/logging"
 	"github.com/T4cceptor/centian/internal/processor"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // CallContextHandler handles a specific part of the processing context.
@@ -110,7 +112,7 @@ func (h *DefaultRoutingHandler) AttachPart(callCtx CallContext, input *processor
 	}
 	input.Routing = &processor.RoutingPart{
 		ServerName:         callCtx.GetServerName(),
-		ToolName:           callCtx.GetDownstreamToolName(),
+		ToolName:           callCtx.GetToolName(),
 		OriginalServerName: callCtx.GetOriginalServerName(),
 		OriginalToolname:   callCtx.GetOriginalToolName(),
 	}
@@ -125,10 +127,15 @@ func (h *DefaultRoutingHandler) Apply(callCtx CallContext, result *processor.Dat
 	if result.Routing.ServerName != "" {
 		callCtx.SetServerName(result.Routing.ServerName)
 	}
-	if result.Routing.ToolName != "" && result.Routing.ToolName != callCtx.GetDownstreamToolName() {
-		if err := callCtx.RewriteToolName(result.Routing.ToolName); err != nil {
-			return err
+	if result.Routing.ToolName != "" {
+		req := callCtx.GetRequest()
+		if req == nil {
+			return fmt.Errorf("call context does not contain request")
 		}
+		if req.Params == nil {
+			req.Params = &mcp.CallToolParamsRaw{}
+		}
+		req.Params.Name = result.Routing.ToolName
 	}
 	return nil
 }
@@ -180,7 +187,7 @@ func (h *DefaultLogHandler) ToLogEntry(callCtx CallContext) *common.MCPEvent {
 	// Add arguments for request
 	req := callCtx.GetRequest()
 	if req != nil && req.Params != nil {
-		event.WithToolRequest(callCtx.GetDownstreamToolName(), callCtx.GetOriginalToolName(), req.Params.Arguments)
+		event.WithToolRequest(callCtx.GetToolName(), callCtx.GetOriginalToolName(), req.Params.Arguments)
 	}
 
 	// Add result for response

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -2,13 +2,11 @@ package proxy
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/logging"
 	"github.com/T4cceptor/centian/internal/processor"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // CallContextHandler handles a specific part of the processing context.
@@ -112,7 +110,7 @@ func (h *DefaultRoutingHandler) AttachPart(callCtx CallContext, input *processor
 	}
 	input.Routing = &processor.RoutingPart{
 		ServerName:         callCtx.GetServerName(),
-		ToolName:           callCtx.GetToolName(),
+		ToolName:           callCtx.GetDownstreamToolName(),
 		OriginalServerName: callCtx.GetOriginalServerName(),
 		OriginalToolname:   callCtx.GetOriginalToolName(),
 	}
@@ -127,15 +125,10 @@ func (h *DefaultRoutingHandler) Apply(callCtx CallContext, result *processor.Dat
 	if result.Routing.ServerName != "" {
 		callCtx.SetServerName(result.Routing.ServerName)
 	}
-	if result.Routing.ToolName != "" {
-		req := callCtx.GetRequest()
-		if req == nil {
-			return fmt.Errorf("call context does not contain request")
+	if result.Routing.ToolName != "" && result.Routing.ToolName != callCtx.GetDownstreamToolName() {
+		if err := callCtx.RewriteToolName(result.Routing.ToolName); err != nil {
+			return err
 		}
-		if req.Params == nil {
-			req.Params = &mcp.CallToolParamsRaw{}
-		}
-		req.Params.Name = result.Routing.ToolName
 	}
 	return nil
 }
@@ -187,7 +180,7 @@ func (h *DefaultLogHandler) ToLogEntry(callCtx CallContext) *common.MCPEvent {
 	// Add arguments for request
 	req := callCtx.GetRequest()
 	if req != nil && req.Params != nil {
-		event.WithToolRequest(callCtx.GetToolName(), callCtx.GetOriginalToolName(), req.Params.Arguments)
+		event.WithToolRequest(callCtx.GetDownstreamToolName(), callCtx.GetOriginalToolName(), req.Params.Arguments)
 	}
 
 	// Add result for response

--- a/internal/proxy/handlers_test.go
+++ b/internal/proxy/handlers_test.go
@@ -30,7 +30,7 @@ func newHandlerTestCallContext() *ToolCallContext {
 		result:             &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "result-current"}}},
 		originalResult:     &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "result-original"}}},
 		event:              common.NewMCPRequestEvent("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
-		routingContext:     &common.RoutingLog{ServerName: "server-current"},
+		routingContext:     &common.RoutingContext{ServerName: "server-current"},
 	}
 }
 
@@ -175,22 +175,6 @@ func TestDefaultRoutingHandlerApply(t *testing.T) {
 		assert.Equal(t, callCtx.GetRequest().Params.Name, "tool-updated")
 	})
 
-	t.Run("does not rewrite aggregated raw tool name when downstream tool is unchanged", func(t *testing.T) {
-		callCtx := newHandlerTestCallContext()
-		callCtx.proxy = &MCPProxy{isAggregatedProxy: true}
-		callCtx.routingContext.ServerName = "server-current"
-		callCtx.request.Params.Name = "server-current___tool-current"
-
-		err := handler.Apply(callCtx, &processor.DataContext{
-			Routing: &processor.RoutingPart{
-				ToolName: "tool-current",
-			},
-		})
-
-		assert.NilError(t, err)
-		assert.Equal(t, callCtx.GetRequest().Params.Name, "server-current___tool-current")
-	})
-
 	t.Run("fails when tool name is set but request is nil", func(t *testing.T) {
 		callCtx := newHandlerTestCallContext()
 		callCtx.request = nil
@@ -261,7 +245,7 @@ func TestDefaultLogHandlerGetTransport(t *testing.T) {
 	callCtx.routingContext = nil
 	assert.Equal(t, handler.getTransport(callCtx), "unknown")
 
-	callCtx.routingContext = &common.RoutingLog{Transport: common.HTTPTransport}
+	callCtx.routingContext = &common.RoutingContext{Transport: common.HTTPTransport}
 	assert.Equal(t, handler.getTransport(callCtx), string(common.HTTPTransport))
 }
 

--- a/internal/proxy/handlers_test.go
+++ b/internal/proxy/handlers_test.go
@@ -175,6 +175,22 @@ func TestDefaultRoutingHandlerApply(t *testing.T) {
 		assert.Equal(t, callCtx.GetRequest().Params.Name, "tool-updated")
 	})
 
+	t.Run("does not rewrite aggregated raw tool name when downstream tool is unchanged", func(t *testing.T) {
+		callCtx := newHandlerTestCallContext()
+		callCtx.proxy = &MCPProxy{isAggregatedProxy: true}
+		callCtx.routingContext.ServerName = "server-current"
+		callCtx.request.Params.Name = "server-current___tool-current"
+
+		err := handler.Apply(callCtx, &processor.DataContext{
+			Routing: &processor.RoutingPart{
+				ToolName: "tool-current",
+			},
+		})
+
+		assert.NilError(t, err)
+		assert.Equal(t, callCtx.GetRequest().Params.Name, "server-current___tool-current")
+	})
+
 	t.Run("fails when tool name is set but request is nil", func(t *testing.T) {
 		callCtx := newHandlerTestCallContext()
 		callCtx.request = nil

--- a/internal/proxy/interfaces.go
+++ b/internal/proxy/interfaces.go
@@ -15,6 +15,7 @@ type ProcessingControllerInterface interface {
 // DownstreamConnectionInterface abstracts downstream MCP server connections for testability.
 type DownstreamConnectionInterface interface {
 	CallTool(ctx context.Context, toolName string, args map[string]any) (*mcp.CallToolResult, error)
+	GetServerName() string
 	IsConnected() bool
 	Tools() []*mcp.Tool
 	Close() error

--- a/internal/proxy/proxy_event_processor_test.go
+++ b/internal/proxy/proxy_event_processor_test.go
@@ -19,7 +19,7 @@ type mockCallContext struct {
 	result             *mcp.CallToolResult
 	originalResult     *mcp.CallToolResult
 	event              *common.MCPEvent
-	routing            *common.RoutingLog
+	routing            *common.RoutingContext
 	handlers           map[string]CallContextHandler
 	logHandler         LogHandler
 	serverName         string
@@ -38,7 +38,7 @@ func newMockCallContext() *mockCallContext {
 		request:            req,
 		originalRequest:    deepCloneRequest(req),
 		event:              common.NewMCPRequestEvent("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
-		routing:            &common.RoutingLog{ServerName: "server-a", Transport: common.StdioTransport},
+		routing:            &common.RoutingContext{ServerName: "server-a", Transport: common.StdioTransport},
 		handlers:           map[string]CallContextHandler{},
 		serverName:         "server-a",
 		originalServerName: "server-a",
@@ -79,27 +79,11 @@ func (m *mockCallContext) SetServerName(name string) {
 	}
 }
 func (m *mockCallContext) GetRequest() *mcp.CallToolRequest { return m.request }
-func (m *mockCallContext) GetRawToolName() string {
+func (m *mockCallContext) GetToolName() string {
 	if m.request == nil || m.request.Params == nil {
 		return ""
 	}
 	return m.request.Params.Name
-}
-func (m *mockCallContext) GetToolName() string {
-	return m.GetRawToolName()
-}
-func (m *mockCallContext) GetDownstreamToolName() string {
-	return m.GetRawToolName()
-}
-func (m *mockCallContext) RewriteToolName(toolName string) error {
-	if m.request == nil {
-		return errors.New("call context does not contain request")
-	}
-	if m.request.Params == nil {
-		m.request.Params = &mcp.CallToolParamsRaw{}
-	}
-	m.request.Params.Name = toolName
-	return nil
 }
 func (m *mockCallContext) GetStatus() int       { return m.event.Status }
 func (m *mockCallContext) SetStatus(status int) { m.event.Status = status }
@@ -117,7 +101,7 @@ func (m *mockCallContext) GetMessageType() common.McpMessageType { return m.even
 func (m *mockCallContext) SetMessageType(msgType common.McpMessageType) {
 	m.event.MessageType = msgType
 }
-func (m *mockCallContext) GetRoutingContext() *common.RoutingLog { return m.routing }
+func (m *mockCallContext) GetRoutingContext() *common.RoutingContext { return m.routing }
 func (m *mockCallContext) GetHandler(part string) (CallContextHandler, bool) {
 	handler, ok := m.handlers[part]
 	return handler, ok

--- a/internal/proxy/proxy_event_processor_test.go
+++ b/internal/proxy/proxy_event_processor_test.go
@@ -79,11 +79,27 @@ func (m *mockCallContext) SetServerName(name string) {
 	}
 }
 func (m *mockCallContext) GetRequest() *mcp.CallToolRequest { return m.request }
-func (m *mockCallContext) GetToolName() string {
+func (m *mockCallContext) GetRawToolName() string {
 	if m.request == nil || m.request.Params == nil {
 		return ""
 	}
 	return m.request.Params.Name
+}
+func (m *mockCallContext) GetToolName() string {
+	return m.GetRawToolName()
+}
+func (m *mockCallContext) GetDownstreamToolName() string {
+	return m.GetRawToolName()
+}
+func (m *mockCallContext) RewriteToolName(toolName string) error {
+	if m.request == nil {
+		return errors.New("call context does not contain request")
+	}
+	if m.request.Params == nil {
+		m.request.Params = &mcp.CallToolParamsRaw{}
+	}
+	m.request.Params.Name = toolName
+	return nil
 }
 func (m *mockCallContext) GetStatus() int       { return m.event.Status }
 func (m *mockCallContext) SetStatus(status int) { m.event.Status = status }

--- a/internal/proxy/proxy_server.go
+++ b/internal/proxy/proxy_server.go
@@ -147,10 +147,19 @@ type DownstreamConnectionPool struct {
 	lastUsed         time.Time                                // Timestamp for future cleanup/eviction decisions.
 }
 
+// GetConnectionByServerName returns a MCP connection for the given server name.
+func (d *DownstreamConnectionPool) GetConnectionByServerName(serverName string) (DownstreamConnectionInterface, error) {
+	conn, ok := d.downstreamConns[serverName]
+	if !ok {
+		return nil, fmt.Errorf("no connection to server '%s' found", serverName)
+	}
+	return conn, nil
+}
+
 const initialDownstreamReadyWait = 500 * time.Millisecond
 
-// GetConnectionByName returns a MCP connection for the given server name.
-func (s *UpstreamSession) GetConnectionByName(serverName string) (DownstreamConnectionInterface, error) {
+// GetConnectionByServerName returns a MCP connection for the given server name.
+func (s *UpstreamSession) GetConnectionByServerName(serverName string) (DownstreamConnectionInterface, error) {
 	conn, ok := s.downstreamConns[serverName]
 	if !ok {
 		return nil, fmt.Errorf("no connection to server '%s' found", serverName)
@@ -346,11 +355,11 @@ func (p *MCPProxy) getDownstreamPoolKey(identityKey string, authHeaders map[stri
 	return fmt.Sprintf("%s|%s|%s", p.endpoint, identityKey, authHeadersFingerprint(authHeaders))
 }
 
-func (p *MCPProxy) newDownstreamConnection(name string, cfg *config.MCPServerConfig) DownstreamConnectionInterface {
+func (p *MCPProxy) newDownstreamConnection(serverName string, cfg *config.MCPServerConfig) DownstreamConnectionInterface {
 	if p.connectionFactory != nil {
-		return p.connectionFactory(name, cfg)
+		return p.connectionFactory(serverName, cfg)
 	}
-	return NewDownstreamConnection(name, cfg)
+	return NewDownstreamConnection(serverName, cfg)
 }
 
 // initializeUpstreamSessionLocked attaches a new upstream session to the
@@ -395,19 +404,22 @@ func (p *MCPProxy) getOrCreateDownstreamPool(session *UpstreamSession) (*Downstr
 
 func (p *MCPProxy) ensureDownstreamConnectionsLocked(entry *DownstreamConnectionPool, authHeaders map[string]string) {
 	for serverName, connTemplate := range p.downstreams {
-		conn, exists := entry.downstreamConns[serverName]
-		if !exists || conn.GetStatus() == StatusFailed {
+		conn, err := entry.GetConnectionByServerName(serverName)
+		if err != nil || conn.GetStatus() == StatusFailed {
 			conn = p.newDownstreamConnection(serverName, connTemplate.config)
 			entry.downstreamConns[serverName] = conn
 		}
+		// TODO: why do we have 2 different fields for status here?
+		// 1. entry.connecting[serverName] -> true - see below
+		// 2. conn.GetStatus() == StatusConnecting
 		if entry.connecting[serverName] {
 			continue
 		}
-		if conn.GetStatus() == StatusConnected && conn.IsConnected() {
+		if conn.IsConnected() {
 			continue
 		}
 		entry.connecting[serverName] = true
-		go p.connectDownstreamPoolConnection(entry.poolKey, serverName, conn, cloneAuthHeaders(authHeaders))
+		go p.connectDownstreamPoolConnection(entry.poolKey, conn, cloneAuthHeaders(authHeaders))
 	}
 }
 
@@ -492,9 +504,12 @@ func (p *MCPProxy) inspectDownstreamForRegistration(
 	}
 
 	status := conn.GetStatus()
-	if status == StatusConnected && conn.IsConnected() {
+	if conn.IsConnected() {
 		summary.connectedCount++
-		p.registerDownstreamTools(upstreamSession, serverName, conn.Tools())
+		// Registering downstream tools on upstream Session (endpoint)
+		for _, tool := range conn.Tools() {
+			p.registerTool(upstreamSession, serverName, tool)
+		}
 		return
 	}
 
@@ -505,16 +520,6 @@ func (p *MCPProxy) inspectDownstreamForRegistration(
 
 	if status == StatusFailed && conn.GetError() != nil {
 		summary.connErrors = append(summary.connErrors, fmt.Sprintf("%s: %v", serverName, conn.GetError()))
-	}
-}
-
-func (p *MCPProxy) registerDownstreamTools(
-	upstreamSession *UpstreamSession,
-	serverName string,
-	tools []*mcp.Tool,
-) {
-	for _, tool := range tools {
-		p.registerTool(upstreamSession.upstreamServer, upstreamSession, serverName, tool)
 	}
 }
 
@@ -553,11 +558,13 @@ func (p *MCPProxy) logDownstreamRegistrationSummary(
 // UpstreamSession once the connect succeeds.
 func (p *MCPProxy) connectDownstreamPoolConnection(
 	poolKey string,
-	serverName string,
 	conn DownstreamConnectionInterface,
 	authHeaders map[string]string,
 ) {
+	serverName := conn.GetServerName()
+	// TODO: feels like we should set the status of the DownstreamConnection here somewhere...
 	if err := conn.Connect(context.Background(), authHeaders); err != nil {
+		// TODO: comment explaining this more in-depth
 		p.mu.Lock()
 		if entry, ok := p.downstreamPools[poolKey]; ok {
 			if current, exists := entry.downstreamConns[serverName]; exists && current == conn {
@@ -592,7 +599,7 @@ func (p *MCPProxy) connectDownstreamPoolConnection(
 			continue
 		}
 		for _, tool := range conn.Tools() {
-			p.registerTool(upstreamSession.upstreamServer, upstreamSession, serverName, tool)
+			p.registerTool(upstreamSession, serverName, tool)
 		}
 	}
 	p.toolRegMu.Unlock()
@@ -622,7 +629,8 @@ func (p *MCPProxy) NewMcpServer() *mcp.Server {
 }
 
 // registerTool adds one downstream tool to one upstream-facing server instance.
-func (p *MCPProxy) registerTool(server *mcp.Server, upstreamSession *UpstreamSession, serverName string, tool *mcp.Tool) {
+func (p *MCPProxy) registerTool(upstreamSession *UpstreamSession, serverName string, tool *mcp.Tool) {
+	server := upstreamSession.upstreamServer
 	if upstreamSession.registeredTools == nil {
 		upstreamSession.registeredTools = make(map[string]struct{})
 	}
@@ -674,7 +682,7 @@ func (p *MCPProxy) handleToolCall(ctx context.Context, upstreamSession *Upstream
 		return nil, err
 	}
 	ctx = WithCallContext(ctx, callCtx)
-	common.LogInfo("Tool called: %s :: %s", callCtx.GetServerName(), callCtx.GetDownstreamToolName())
+	common.LogInfo("Tool called: %s :: %s", callCtx.GetServerName(), callCtx.GetToolName())
 
 	// 2. Process REQUEST phase (Client → Server)
 	if err := p.ProcessCall(callCtx, common.DirectionClientToServer, common.MessageTypeRequest); err != nil {

--- a/internal/proxy/proxy_server.go
+++ b/internal/proxy/proxy_server.go
@@ -122,7 +122,6 @@ func NewCentianProxy(globalConfig *config.GlobalConfig) (*CentianProxy, error) {
 // connections that pool currently owns.
 type UpstreamSession struct {
 	id              string
-	initialized     bool
 	upstreamServer  *mcp.Server                              // Server returned to the MCP SDK for this upstream session.
 	downstreamConns map[string]DownstreamConnectionInterface // Current downstream connections borrowed from the assigned pool.
 	registeredTools map[string]struct{}                      // Tools already registered on upstreamServer for this session.
@@ -295,28 +294,16 @@ func (p *MCPProxy) GetServerForRequest(r *http.Request) *mcp.Server {
 	return upstreamSession.upstreamServer
 }
 
-func getAuthHeaders(p *MCPProxy, r *http.Request) map[string]string {
-	authHeaders := make(map[string]string)
-	// Capture auth headers from upstream request for passthrough
-	// TODO: make these headers configurable
-	for _, h := range []string{"Authorization", "X-API-Key", "X-Auth-Token"} {
-		if p.server != nil && p.server.AuthHeader != "" && strings.EqualFold(h, p.server.AuthHeader) {
-			continue
-		}
-		if v := r.Header.Get(h); v != "" {
-			authHeaders[h] = v
-		}
-	}
-	return authHeaders
-}
-
 // createUpstreamSession captures the request state needed to attach a new
 // upstream MCP session to the correct reusable downstream pool.
 func (p *MCPProxy) createUpstreamSession(id string, r *http.Request, identityKey string) *UpstreamSession {
-	authHeaders := getAuthHeaders(p, r)
+	excludedAuthHeader := ""
+	if p.server != nil {
+		excludedAuthHeader = p.server.AuthHeader
+	}
+	authHeaders := getAuthHeaders(r.Header, excludedAuthHeader)
 	return &UpstreamSession{
 		id:              id,
-		initialized:     false,
 		downstreamConns: make(map[string]DownstreamConnectionInterface),
 		registeredTools: make(map[string]struct{}),
 		authHeaders:     authHeaders,
@@ -374,7 +361,6 @@ func (p *MCPProxy) initializeUpstreamSessionLocked(session *UpstreamSession) (*D
 
 	downstreamPool, reused := p.getOrCreateDownstreamPool(session)
 	session.downstreamConns = downstreamPool.downstreamConns
-	session.initialized = true
 	return downstreamPool, reused
 }
 
@@ -409,9 +395,8 @@ func (p *MCPProxy) ensureDownstreamConnectionsLocked(entry *DownstreamConnection
 			conn = p.newDownstreamConnection(serverName, connTemplate.config)
 			entry.downstreamConns[serverName] = conn
 		}
-		// TODO: why do we have 2 different fields for status here?
-		// 1. entry.connecting[serverName] -> true - see below
-		// 2. conn.GetStatus() == StatusConnecting
+		// entry.connecting tracks pool-level in-flight Connect goroutines so we
+		// do not start duplicate background connects for the same downstream.
 		if entry.connecting[serverName] {
 			continue
 		}
@@ -562,9 +547,9 @@ func (p *MCPProxy) connectDownstreamPoolConnection(
 	authHeaders map[string]string,
 ) {
 	serverName := conn.GetServerName()
-	// TODO: feels like we should set the status of the DownstreamConnection here somewhere...
+	// Connection status is owned by the DownstreamConnection implementation.
+	// The pool only tracks whether it currently has a background Connect call in flight.
 	if err := conn.Connect(context.Background(), authHeaders); err != nil {
-		// TODO: comment explaining this more in-depth
 		p.mu.Lock()
 		if entry, ok := p.downstreamPools[poolKey]; ok {
 			if current, exists := entry.downstreamConns[serverName]; exists && current == conn {
@@ -593,18 +578,20 @@ func (p *MCPProxy) connectDownstreamPoolConnection(
 		return
 	}
 
+	tools := conn.Tools()
+
 	p.toolRegMu.Lock()
 	for _, upstreamSession := range upstreamSessions {
 		if upstreamSession == nil || upstreamSession.upstreamServer == nil {
 			continue
 		}
-		for _, tool := range conn.Tools() {
+		for _, tool := range tools {
 			p.registerTool(upstreamSession, serverName, tool)
 		}
 	}
 	p.toolRegMu.Unlock()
 
-	common.LogInfo("MCPProxy[%s]: Connected pooled downstream %s with %d tools", p.name, sanitizeLogValue(serverName), len(conn.Tools()))
+	common.LogInfo("MCPProxy[%s]: Connected pooled downstream %s with %d tools", p.name, sanitizeLogValue(serverName), len(tools))
 }
 
 // NewMcpServer returns a new *mcp.Server based on the MCPProxy name.
@@ -857,21 +844,6 @@ func cloneAuthHeaders(headers map[string]string) map[string]string {
 	return cloned
 }
 
-func redactHeaders(headers http.Header) http.Header {
-	redacted := make(http.Header, len(headers))
-	for key, values := range headers {
-		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "X-Centian-Auth") ||
-			strings.EqualFold(key, "X-API-Key") || strings.EqualFold(key, "X-Auth-Token") {
-			redacted[key] = []string{"<redacted>"}
-			continue
-		}
-		copied := make([]string, len(values))
-		copy(copied, values)
-		redacted[key] = copied
-	}
-	return redacted
-}
-
 func (p *MCPProxy) invalidatePooledDownstream(poolKey string) {
 	if poolKey == "" {
 		return
@@ -918,9 +890,7 @@ func RegisterEndpoint(endpoint string, proxy *MCPProxy, mux *http.ServeMux, opti
 		options,
 	)
 
-	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		baseHandler.ServeHTTP(w, r)
-	})
+	var handler http.Handler = baseHandler
 	if proxy.server != nil && proxy.server.APIKeys != nil {
 		headerName := proxy.server.AuthHeader
 		if headerName == "" {

--- a/internal/proxy/proxy_server.go
+++ b/internal/proxy/proxy_server.go
@@ -674,7 +674,7 @@ func (p *MCPProxy) handleToolCall(ctx context.Context, upstreamSession *Upstream
 		return nil, err
 	}
 	ctx = WithCallContext(ctx, callCtx)
-	common.LogInfo("Tool called: %s :: %s", callCtx.GetServerName(), callCtx.GetToolName())
+	common.LogInfo("Tool called: %s :: %s", callCtx.GetServerName(), callCtx.GetDownstreamToolName())
 
 	// 2. Process REQUEST phase (Client → Server)
 	if err := p.ProcessCall(callCtx, common.DirectionClientToServer, common.MessageTypeRequest); err != nil {

--- a/internal/proxy/proxy_server_unit_test.go
+++ b/internal/proxy/proxy_server_unit_test.go
@@ -394,13 +394,16 @@ func TestGetServerForRequest_RetriesFailedDownstreamsForLaterSessions(t *testing
 		connectionFactory: func(name string, cfg *config.MCPServerConfig) DownstreamConnectionInterface {
 			createdByServer[name]++
 			conn := &MockDownstreamConnection{
-				cfg: cfg,
+				serverName: name,
+				cfg:        cfg,
+				Status:     StatusConnected,
 				tools: []*mcp.Tool{
 					{Name: "ping", Description: "ping", InputSchema: map[string]any{"type": "object"}},
 				},
 			}
 			if name == "server2" && createdByServer[name] == 1 {
 				conn.ErrorToReturn = errors.New("dial failed")
+				conn.Status = StatusFailed
 			}
 			return conn
 		},

--- a/internal/proxy/proxy_server_unit_test.go
+++ b/internal/proxy/proxy_server_unit_test.go
@@ -1,8 +1,10 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -10,6 +12,7 @@ import (
 	"time"
 
 	"github.com/T4cceptor/centian/internal/auth"
+	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/assert"
@@ -442,6 +445,89 @@ func TestGetServerForRequest_RetriesFailedDownstreamsForLaterSessions(t *testing
 	assert.Assert(t, server1 != nil)
 	assert.Assert(t, server2 != nil)
 	assert.Equal(t, createdByServer["server2"], 2)
+}
+
+func TestLogRequestForDebugPreservesRequestBody(t *testing.T) {
+	var console bytes.Buffer
+	err := common.InitInternalLogger(common.LoggerOptions{
+		Level:         "debug",
+		Output:        "console",
+		ConsoleWriter: &console,
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = common.CloseLogger()
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway", io.NopCloser(bytes.NewBufferString(`{"hello":"world"}`)))
+	req.Header.Set("Authorization", "Bearer secret")
+
+	logRequestForDebug(req)
+
+	body, err := io.ReadAll(req.Body)
+	assert.NilError(t, err)
+	assert.Equal(t, string(body), `{"hello":"world"}`)
+	assert.Assert(t, req.GetBody != nil)
+
+	clonedBody, err := req.GetBody()
+	assert.NilError(t, err)
+	defer clonedBody.Close()
+
+	clonedData, err := io.ReadAll(clonedBody)
+	assert.NilError(t, err)
+	assert.Equal(t, string(clonedData), `{"hello":"world"}`)
+	assert.Assert(t, bytes.Contains(console.Bytes(), []byte("Received request body")))
+	assert.Assert(t, !bytes.Contains(console.Bytes(), []byte("Bearer secret")))
+}
+
+func TestInvalidatePooledDownstream(t *testing.T) {
+	conn := &MockDownstreamConnection{Status: StatusConnected}
+	proxy := &MCPProxy{
+		name: "gateway",
+		downstreamPools: map[string]*DownstreamConnectionPool{
+			"pool-1": {
+				poolKey: "pool-1",
+				downstreamConns: map[string]DownstreamConnectionInterface{
+					"server1": conn,
+				},
+			},
+		},
+	}
+
+	proxy.invalidatePooledDownstream("pool-1")
+
+	assert.Equal(t, conn.CloseCalls, 1)
+	assert.Assert(t, proxy.downstreamPools["pool-1"] == nil)
+}
+
+func TestClosePoolEntryLocked(t *testing.T) {
+	okConn := &MockDownstreamConnection{}
+	failingConn := &closeErrorDownstreamConnection{
+		MockDownstreamConnection: &MockDownstreamConnection{},
+		closeErr:                 errors.New("close failed"),
+	}
+
+	errs := (&MCPProxy{}).closePoolEntryLocked(&DownstreamConnectionPool{
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"ok":   okConn,
+			"fail": failingConn,
+		},
+	})
+
+	assert.Equal(t, okConn.CloseCalls, 1)
+	assert.Equal(t, failingConn.CloseCalls, 1)
+	assert.Equal(t, len(errs), 1)
+	assert.ErrorContains(t, errs[0], "close failed")
+}
+
+type closeErrorDownstreamConnection struct {
+	*MockDownstreamConnection
+	closeErr error
+}
+
+func (c *closeErrorDownstreamConnection) Close() error {
+	c.CloseCalls++
+	return c.closeErr
 }
 
 func createTestAPIKeyStore(t *testing.T) *auth.APIKeyStore {

--- a/internal/proxy/tool_call_context.go
+++ b/internal/proxy/tool_call_context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -69,12 +68,27 @@ func NewToolCallContext(
 		WithSessionID(upstreamSession.id).
 		WithServerID(proxy.server.ServerID) // nil check was done above
 
+	// request holds the current mutable MCP tool name. In aggregated mode we
+	// normalize it once before processing so all later code sees the current
+	// downstream tool name directly. originalRequest keeps the raw upstream name.
+	originalRequest := deepCloneRequest(req) // cloned here because req is being modified
+	if proxy.isAggregatedProxy {
+		if req == nil || req.Params == nil {
+			return nil, fmt.Errorf("aggregated tool call requires request params")
+		}
+		toolName, err := parseAggregatedToolName(req.Params.Name, serverName)
+		if err != nil {
+			return nil, err
+		}
+		req.Params.Name = toolName
+	}
+
 	toolCallCtx := &ToolCallContext{
 		proxy:              proxy,
 		upstreamSession:    upstreamSession,
 		originalServerName: serverName,
-		originalRequest:    deepCloneRequest(req), // Immutable clone
-		request:            req,                   // Mutable, will be modified by handlers
+		originalRequest:    originalRequest, // Immutable clone of the upstream request
+		request:            req,             // Mutable, will be modified by handlers
 		routingContext:     routingCtx,
 		event:              event,
 	}
@@ -257,16 +271,7 @@ func (c *ToolCallContext) GetToolName() string {
 	if c.request == nil || c.request.Params == nil {
 		return ""
 	}
-	toolName := c.request.Params.Name
-	if c.proxy.isAggregatedProxy {
-		parts := strings.SplitN(toolName, NamespaceSeparator, 2)
-		if len(parts) < 2 {
-			common.LogWarn("failed to recreate original tool name from %s", toolName)
-			return ""
-		}
-		toolName = strings.Join(parts[1:], "")
-	}
-	return toolName
+	return c.request.Params.Name
 }
 
 // Status and error handling

--- a/internal/proxy/tool_call_context.go
+++ b/internal/proxy/tool_call_context.go
@@ -3,8 +3,8 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -143,7 +143,11 @@ func (c *ToolCallContext) SendRequest(ctx context.Context) error {
 
 	// Make the call with current request data
 	// Note: per-request headers require CallTool signature change (Phase 3)
-	result, err := conn.CallTool(ctx, c.GetToolName(), args)
+	toolName, err := c.resolveDownstreamToolName()
+	if err != nil {
+		return err
+	}
+	result, err := conn.CallTool(ctx, toolName, args)
 	if err != nil {
 		return err
 	}
@@ -254,22 +258,81 @@ func (c *ToolCallContext) GetRequest() *mcp.CallToolRequest {
 	return c.request
 }
 
-// GetToolName returns the current tool name.
-func (c *ToolCallContext) GetToolName() string {
+// GetRawToolName returns the current raw request tool name.
+func (c *ToolCallContext) GetRawToolName() string {
 	if c.request == nil || c.request.Params == nil {
 		return ""
 	}
-	// here we check if we have an aggregated server, then change the name accordingly.
-	toolName := c.request.Params.Name
-	if c.proxy.isAggregatedProxy {
-		parts := strings.SplitN(toolName, NamespaceSeparator, 2)
-		if len(parts) < 2 {
-			common.LogWarn("failed to recreate original tool name from %s", toolName)
-			return ""
-		}
-		toolName = strings.Join(parts[1:], "")
+	return c.request.Params.Name
+}
+
+// GetToolName returns the current raw request tool name.
+func (c *ToolCallContext) GetToolName() string {
+	return c.GetRawToolName()
+}
+
+// GetDownstreamToolName returns the current tool name to use for downstream dispatch.
+//
+// In aggregated mode this strips the server namespace when present. Malformed
+// names fall back to the raw tool name, while namespace mismatches are logged
+// and also fall back to the raw value for non-dispatch uses.
+func (c *ToolCallContext) GetDownstreamToolName() string {
+	toolName, err := c.resolveDownstreamToolName()
+	if err != nil {
+		common.LogWarn("failed to resolve downstream tool name for %q on server %q: %v", c.GetRawToolName(), c.GetServerName(), err)
+		return c.GetRawToolName()
 	}
 	return toolName
+}
+
+// RewriteToolName rewrites the current request tool name for the active routing mode.
+func (c *ToolCallContext) RewriteToolName(toolName string) error {
+	req := c.GetRequest()
+	if req == nil {
+		return fmt.Errorf("call context does not contain request")
+	}
+	if req.Params == nil {
+		req.Params = &mcp.CallToolParamsRaw{}
+	}
+	if c.proxy == nil || !c.proxy.isAggregatedProxy {
+		req.Params.Name = toolName
+		return nil
+	}
+
+	parsed, err := ParseAggregatedToolName(toolName, c.GetServerName())
+	switch {
+	case err == nil && parsed.IsNamespaced:
+		req.Params.Name = toolName
+		return nil
+	case err == nil:
+		rawName, formatErr := formatAggregatedToolName(c.GetServerName(), toolName)
+		if formatErr != nil {
+			return formatErr
+		}
+		req.Params.Name = rawName
+		return nil
+	case errors.Is(err, ErrMalformedAggregatedToolName):
+		return err
+	default:
+		return err
+	}
+}
+
+func (c *ToolCallContext) resolveDownstreamToolName() (string, error) {
+	toolName := c.GetRawToolName()
+	if toolName == "" || c.proxy == nil || !c.proxy.isAggregatedProxy {
+		return toolName, nil
+	}
+
+	parsed, err := ParseAggregatedToolName(toolName, c.GetServerName())
+	if err == nil {
+		return parsed.ToolName, nil
+	}
+	if errors.Is(err, ErrMalformedAggregatedToolName) {
+		common.LogWarn("failed to parse aggregated tool name %q for server %q, using raw tool name", toolName, c.GetServerName())
+		return toolName, nil
+	}
+	return "", err
 }
 
 // Status and error handling

--- a/internal/proxy/tool_call_context.go
+++ b/internal/proxy/tool_call_context.go
@@ -3,8 +3,8 @@ package proxy
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -32,7 +32,7 @@ type ToolCallContext struct {
 	event *common.MCPEvent
 
 	// Routing context (reuses common.RoutingContext)
-	routingContext *common.RoutingLog
+	routingContext *common.RoutingContext
 
 	// Handlers
 	handlers   map[string]CallContextHandler
@@ -56,7 +56,7 @@ func NewToolCallContext(
 	routingCtx := buildRoutingContext(proxy, upstreamSession, serverName)
 	// TODO: get headers from ctx
 
-	conn, err := upstreamSession.GetConnectionByName(serverName)
+	conn, err := upstreamSession.GetConnectionByServerName(serverName)
 	transport := common.UnknownTransport
 	if err != nil {
 		common.LogWarn("unable to get connection for '%s': %v", serverName, err)
@@ -93,9 +93,9 @@ func NewToolCallContext(
 }
 
 // buildRoutingContext creates a RoutingContext from proxy and session info.
-func buildRoutingContext(proxy *MCPProxy, upstreamSession *UpstreamSession, serverName string) *common.RoutingLog {
+func buildRoutingContext(proxy *MCPProxy, upstreamSession *UpstreamSession, serverName string) *common.RoutingContext {
 	// ideally we would combine this somehow with MCPevent data struct
-	rc := &common.RoutingLog{
+	rc := &common.RoutingContext{
 		Gateway:    proxy.name,
 		ServerName: serverName,
 		Endpoint:   proxy.endpoint,
@@ -124,11 +124,10 @@ func buildRoutingContext(proxy *MCPProxy, upstreamSession *UpstreamSession, serv
 // downstream call, instead an immediate error response will be returned.
 func (c *ToolCallContext) SendRequest(ctx context.Context) error {
 	// Resolve connection based on (potentially modified) serverName
-	serverName := c.GetRoutingContext().ServerName
-	conn, ok := c.upstreamSession.downstreamConns[serverName]
-	if !ok {
-		return fmt.Errorf("server %s not found (original: %s)",
-			serverName, c.originalServerName)
+	serverName := c.GetServerName()
+	conn, err := c.upstreamSession.GetConnectionByServerName(serverName)
+	if err != nil {
+		return err
 	}
 	if !conn.IsConnected() {
 		return fmt.Errorf("server %s found (original: %s), but not connected",
@@ -143,11 +142,7 @@ func (c *ToolCallContext) SendRequest(ctx context.Context) error {
 
 	// Make the call with current request data
 	// Note: per-request headers require CallTool signature change (Phase 3)
-	toolName, err := c.resolveDownstreamToolName()
-	if err != nil {
-		return err
-	}
-	result, err := conn.CallTool(ctx, toolName, args)
+	result, err := conn.CallTool(ctx, c.GetToolName(), args)
 	if err != nil {
 		return err
 	}
@@ -229,7 +224,6 @@ func (c *ToolCallContext) GetOriginalToolName() string {
 	if c.originalRequest == nil || c.originalRequest.Params == nil {
 		return ""
 	}
-	// TODO: add aggregated logic here! -> this makes it really convenient to call this then!
 	return c.originalRequest.Params.Name
 }
 
@@ -258,81 +252,21 @@ func (c *ToolCallContext) GetRequest() *mcp.CallToolRequest {
 	return c.request
 }
 
-// GetRawToolName returns the current raw request tool name.
-func (c *ToolCallContext) GetRawToolName() string {
+// GetToolName returns the current tool name.
+func (c *ToolCallContext) GetToolName() string {
 	if c.request == nil || c.request.Params == nil {
 		return ""
 	}
-	return c.request.Params.Name
-}
-
-// GetToolName returns the current raw request tool name.
-func (c *ToolCallContext) GetToolName() string {
-	return c.GetRawToolName()
-}
-
-// GetDownstreamToolName returns the current tool name to use for downstream dispatch.
-//
-// In aggregated mode this strips the server namespace when present. Malformed
-// names fall back to the raw tool name, while namespace mismatches are logged
-// and also fall back to the raw value for non-dispatch uses.
-func (c *ToolCallContext) GetDownstreamToolName() string {
-	toolName, err := c.resolveDownstreamToolName()
-	if err != nil {
-		common.LogWarn("failed to resolve downstream tool name for %q on server %q: %v", c.GetRawToolName(), c.GetServerName(), err)
-		return c.GetRawToolName()
+	toolName := c.request.Params.Name
+	if c.proxy.isAggregatedProxy {
+		parts := strings.SplitN(toolName, NamespaceSeparator, 2)
+		if len(parts) < 2 {
+			common.LogWarn("failed to recreate original tool name from %s", toolName)
+			return ""
+		}
+		toolName = strings.Join(parts[1:], "")
 	}
 	return toolName
-}
-
-// RewriteToolName rewrites the current request tool name for the active routing mode.
-func (c *ToolCallContext) RewriteToolName(toolName string) error {
-	req := c.GetRequest()
-	if req == nil {
-		return fmt.Errorf("call context does not contain request")
-	}
-	if req.Params == nil {
-		req.Params = &mcp.CallToolParamsRaw{}
-	}
-	if c.proxy == nil || !c.proxy.isAggregatedProxy {
-		req.Params.Name = toolName
-		return nil
-	}
-
-	parsed, err := ParseAggregatedToolName(toolName, c.GetServerName())
-	switch {
-	case err == nil && parsed.IsNamespaced:
-		req.Params.Name = toolName
-		return nil
-	case err == nil:
-		rawName, formatErr := formatAggregatedToolName(c.GetServerName(), toolName)
-		if formatErr != nil {
-			return formatErr
-		}
-		req.Params.Name = rawName
-		return nil
-	case errors.Is(err, ErrMalformedAggregatedToolName):
-		return err
-	default:
-		return err
-	}
-}
-
-func (c *ToolCallContext) resolveDownstreamToolName() (string, error) {
-	toolName := c.GetRawToolName()
-	if toolName == "" || c.proxy == nil || !c.proxy.isAggregatedProxy {
-		return toolName, nil
-	}
-
-	parsed, err := ParseAggregatedToolName(toolName, c.GetServerName())
-	if err == nil {
-		return parsed.ToolName, nil
-	}
-	if errors.Is(err, ErrMalformedAggregatedToolName) {
-		common.LogWarn("failed to parse aggregated tool name %q for server %q, using raw tool name", toolName, c.GetServerName())
-		return toolName, nil
-	}
-	return "", err
 }
 
 // Status and error handling
@@ -375,7 +309,7 @@ func (c *ToolCallContext) GetSessionID() string {
 // Routing context
 
 // GetRoutingContext returns the attached RoutingLog.
-func (c *ToolCallContext) GetRoutingContext() *common.RoutingLog {
+func (c *ToolCallContext) GetRoutingContext() *common.RoutingContext {
 	return c.routingContext
 }
 

--- a/internal/proxy/tool_call_context_test.go
+++ b/internal/proxy/tool_call_context_test.go
@@ -156,6 +156,84 @@ func TestNewToolCallContext(t *testing.T) {
 		callCtx.GetRequest().Params.Arguments = json.RawMessage(`{"k":"changed"}`)
 		assert.Equal(t, string(callCtx.GetOriginalRequest().Params.Arguments), `{"k":"v"}`)
 	})
+
+	t.Run("normalizes aggregated tool names into current request state", func(t *testing.T) {
+		t.Setenv("CENTIAN_LOG_DIR", t.TempDir())
+		logger, err := logging.NewLogger()
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = logger.Close()
+		})
+
+		req := &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{
+				Name:      "srv___query",
+				Arguments: json.RawMessage(`{"k":"v"}`),
+			},
+		}
+		proxy := &MCPProxy{
+			name:              "gw",
+			endpoint:          "/mcp/gw",
+			isAggregatedProxy: true,
+			server: &CentianProxy{
+				ServerID: "server-id",
+				Logger:   logger,
+			},
+		}
+		session := &UpstreamSession{
+			id: "sess-1",
+			downstreamConns: map[string]DownstreamConnectionInterface{
+				"srv": &MockDownstreamConnection{
+					cfg: &config.MCPServerConfig{URL: "https://example.com/mcp"},
+				},
+			},
+		}
+
+		callCtxIface, err := NewToolCallContext(context.Background(), proxy, session, "srv", req)
+		assert.NilError(t, err)
+
+		callCtx := callCtxIface.(*ToolCallContext)
+		assert.Equal(t, callCtx.GetToolName(), "query")
+		assert.Equal(t, callCtx.GetOriginalToolName(), "srv___query")
+		assert.Equal(t, req.Params.Name, "query")
+		assert.Equal(t, callCtx.GetOriginalRequest().Params.Name, "srv___query")
+	})
+
+	t.Run("fails early for malformed aggregated tool names", func(t *testing.T) {
+		t.Setenv("CENTIAN_LOG_DIR", t.TempDir())
+		logger, err := logging.NewLogger()
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = logger.Close()
+		})
+
+		req := &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{
+				Name:      "malformed",
+				Arguments: json.RawMessage(`{"k":"v"}`),
+			},
+		}
+		proxy := &MCPProxy{
+			name:              "gw",
+			endpoint:          "/mcp/gw",
+			isAggregatedProxy: true,
+			server: &CentianProxy{
+				ServerID: "server-id",
+				Logger:   logger,
+			},
+		}
+		session := &UpstreamSession{
+			id: "sess-1",
+			downstreamConns: map[string]DownstreamConnectionInterface{
+				"srv": &MockDownstreamConnection{
+					cfg: &config.MCPServerConfig{URL: "https://example.com/mcp"},
+				},
+			},
+		}
+
+		_, err = NewToolCallContext(context.Background(), proxy, session, "srv", req)
+		assert.Assert(t, err != nil)
+	})
 }
 
 func TestToolCallContextSendRequest(t *testing.T) {
@@ -284,17 +362,17 @@ func TestToolCallContextAccessors(t *testing.T) {
 	assert.Equal(t, toolCtx.GetServerName(), "new-srv")
 	assert.Equal(t, toolCtx.GetRoutingContext().Gateway, "gw")
 
-	// And: aggregated tool names are de-namespaced.
-	assert.Equal(t, toolCtx.GetToolName(), "tool_name")
+	// And: tool name accessors are plain request accessors.
+	assert.Equal(t, toolCtx.GetToolName(), "srv___tool_name")
 	assert.Equal(t, toolCtx.GetOriginalToolName(), "orig_tool")
 
-	// And: malformed aggregated name returns empty.
+	// And: malformed names are returned as-is if the request is already in memory.
 	toolCtx.request.Params.Name = "malformed"
-	assert.Equal(t, toolCtx.GetToolName(), "")
+	assert.Equal(t, toolCtx.GetToolName(), "malformed")
 
-	// And: mismatched namespaces still return the stripped suffix.
+	// And: namespaced values are returned exactly as currently stored on the request.
 	toolCtx.request.Params.Name = "other___tool_name"
-	assert.Equal(t, toolCtx.GetToolName(), "tool_name")
+	assert.Equal(t, toolCtx.GetToolName(), "other___tool_name")
 
 	// And: nil request returns empty.
 	toolCtx.request = nil

--- a/internal/proxy/tool_call_context_test.go
+++ b/internal/proxy/tool_call_context_test.go
@@ -168,7 +168,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 					"srv": conn,
 				},
 			},
-			routingContext: &common.RoutingLog{ServerName: "srv"},
+			routingContext: &common.RoutingContext{ServerName: "srv"},
 			request: &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{
 					Name:      "tool_name",
@@ -186,7 +186,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 			upstreamSession: &UpstreamSession{
 				downstreamConns: map[string]DownstreamConnectionInterface{},
 			},
-			routingContext: &common.RoutingLog{ServerName: "srv"},
+			routingContext: &common.RoutingContext{ServerName: "srv"},
 			request: &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{Name: "tool_name", Arguments: json.RawMessage(`{}`)},
 			},
@@ -199,8 +199,8 @@ func TestToolCallContextSendRequest(t *testing.T) {
 
 	t.Run("fails when connection is not connected", func(t *testing.T) {
 		toolCtx := makeContext(&MockDownstreamConnection{
-			cfg:       &config.MCPServerConfig{Command: "python3"},
-			connected: false,
+			cfg:    &config.MCPServerConfig{Command: "python3"},
+			Status: StatusFailed,
 		}, json.RawMessage(`{}`))
 
 		err := toolCtx.SendRequest(context.Background())
@@ -209,8 +209,8 @@ func TestToolCallContextSendRequest(t *testing.T) {
 
 	t.Run("fails on invalid request arguments", func(t *testing.T) {
 		toolCtx := makeContext(&MockDownstreamConnection{
-			cfg:       &config.MCPServerConfig{Command: "python3"},
-			connected: true,
+			cfg:    &config.MCPServerConfig{Command: "python3"},
+			Status: StatusConnected,
 		}, json.RawMessage(`{invalid}`))
 
 		err := toolCtx.SendRequest(context.Background())
@@ -220,7 +220,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 	t.Run("returns downstream call error", func(t *testing.T) {
 		toolCtx := makeContext(&MockDownstreamConnection{
 			cfg:           &config.MCPServerConfig{Command: "python3"},
-			connected:     true,
+			Status:        StatusConnected,
 			ErrorToReturn: errors.New("downstream failed"),
 		}, json.RawMessage(`{"a":1}`))
 
@@ -230,8 +230,8 @@ func TestToolCallContextSendRequest(t *testing.T) {
 
 	t.Run("successfully calls downstream and sets result", func(t *testing.T) {
 		conn := &MockDownstreamConnection{
-			cfg:       &config.MCPServerConfig{Command: "python3"},
-			connected: true,
+			cfg:    &config.MCPServerConfig{Command: "python3"},
+			Status: StatusConnected,
 			ResultToReturn: &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
 			},
@@ -284,25 +284,21 @@ func TestToolCallContextAccessors(t *testing.T) {
 	assert.Equal(t, toolCtx.GetServerName(), "new-srv")
 	assert.Equal(t, toolCtx.GetRoutingContext().Gateway, "gw")
 
-	// And: raw and downstream tool names are both available.
-	toolCtx.request.Params.Name = "new-srv___tool_name"
-	assert.Equal(t, toolCtx.GetRawToolName(), "new-srv___tool_name")
-	assert.Equal(t, toolCtx.GetToolName(), "new-srv___tool_name")
-	assert.Equal(t, toolCtx.GetDownstreamToolName(), "tool_name")
+	// And: aggregated tool names are de-namespaced.
+	assert.Equal(t, toolCtx.GetToolName(), "tool_name")
 	assert.Equal(t, toolCtx.GetOriginalToolName(), "orig_tool")
 
-	// And: malformed aggregated names fall back to the raw tool name.
+	// And: malformed aggregated name returns empty.
 	toolCtx.request.Params.Name = "malformed"
-	assert.Equal(t, toolCtx.GetDownstreamToolName(), "malformed")
+	assert.Equal(t, toolCtx.GetToolName(), "")
 
-	// And: mismatched namespaces are not used for downstream dispatch.
+	// And: mismatched namespaces still return the stripped suffix.
 	toolCtx.request.Params.Name = "other___tool_name"
-	assert.Equal(t, toolCtx.GetDownstreamToolName(), "other___tool_name")
+	assert.Equal(t, toolCtx.GetToolName(), "tool_name")
 
 	// And: nil request returns empty.
 	toolCtx.request = nil
-	assert.Equal(t, toolCtx.GetRawToolName(), "")
-	assert.Equal(t, toolCtx.GetDownstreamToolName(), "")
+	assert.Equal(t, toolCtx.GetToolName(), "")
 
 	// And: status/error accessors round-trip values.
 	toolCtx.SetStatus(422)
@@ -365,39 +361,4 @@ func TestToolCallContextSessionAndOriginalAccessors(t *testing.T) {
 	assert.Equal(t, toolCtx.GetOriginalToolName(), "")
 	assert.Equal(t, toolCtx.GetRequestID(), "req-1")
 	assert.Equal(t, toolCtx.GetOriginalServerName(), "")
-}
-
-func TestToolCallContextRewriteToolName(t *testing.T) {
-	t.Run("rewrites plain tool names in aggregated mode", func(t *testing.T) {
-		toolCtx := &ToolCallContext{
-			proxy: &MCPProxy{
-				isAggregatedProxy: true,
-			},
-			routingContext: &common.RoutingLog{ServerName: "srv"},
-			request: &mcp.CallToolRequest{
-				Params: &mcp.CallToolParamsRaw{Name: "srv___tool_name"},
-			},
-		}
-
-		err := toolCtx.RewriteToolName("tool_updated")
-
-		assert.NilError(t, err)
-		assert.Equal(t, toolCtx.GetRawToolName(), "srv___tool_updated")
-	})
-
-	t.Run("rejects mismatched namespaced tool names in aggregated mode", func(t *testing.T) {
-		toolCtx := &ToolCallContext{
-			proxy: &MCPProxy{
-				isAggregatedProxy: true,
-			},
-			routingContext: &common.RoutingLog{ServerName: "srv"},
-			request: &mcp.CallToolRequest{
-				Params: &mcp.CallToolParamsRaw{Name: "srv___tool_name"},
-			},
-		}
-
-		err := toolCtx.RewriteToolName("other___tool_updated")
-
-		assert.Assert(t, errors.Is(err, ErrUnexpectedToolNamespace))
-	})
 }

--- a/internal/proxy/tool_call_context_test.go
+++ b/internal/proxy/tool_call_context_test.go
@@ -284,17 +284,25 @@ func TestToolCallContextAccessors(t *testing.T) {
 	assert.Equal(t, toolCtx.GetServerName(), "new-srv")
 	assert.Equal(t, toolCtx.GetRoutingContext().Gateway, "gw")
 
-	// And: aggregated tool names are de-namespaced.
-	assert.Equal(t, toolCtx.GetToolName(), "tool_name")
+	// And: raw and downstream tool names are both available.
+	toolCtx.request.Params.Name = "new-srv___tool_name"
+	assert.Equal(t, toolCtx.GetRawToolName(), "new-srv___tool_name")
+	assert.Equal(t, toolCtx.GetToolName(), "new-srv___tool_name")
+	assert.Equal(t, toolCtx.GetDownstreamToolName(), "tool_name")
 	assert.Equal(t, toolCtx.GetOriginalToolName(), "orig_tool")
 
-	// And: malformed aggregated name returns empty.
+	// And: malformed aggregated names fall back to the raw tool name.
 	toolCtx.request.Params.Name = "malformed"
-	assert.Equal(t, toolCtx.GetToolName(), "")
+	assert.Equal(t, toolCtx.GetDownstreamToolName(), "malformed")
+
+	// And: mismatched namespaces are not used for downstream dispatch.
+	toolCtx.request.Params.Name = "other___tool_name"
+	assert.Equal(t, toolCtx.GetDownstreamToolName(), "other___tool_name")
 
 	// And: nil request returns empty.
 	toolCtx.request = nil
-	assert.Equal(t, toolCtx.GetToolName(), "")
+	assert.Equal(t, toolCtx.GetRawToolName(), "")
+	assert.Equal(t, toolCtx.GetDownstreamToolName(), "")
 
 	// And: status/error accessors round-trip values.
 	toolCtx.SetStatus(422)
@@ -357,4 +365,39 @@ func TestToolCallContextSessionAndOriginalAccessors(t *testing.T) {
 	assert.Equal(t, toolCtx.GetOriginalToolName(), "")
 	assert.Equal(t, toolCtx.GetRequestID(), "req-1")
 	assert.Equal(t, toolCtx.GetOriginalServerName(), "")
+}
+
+func TestToolCallContextRewriteToolName(t *testing.T) {
+	t.Run("rewrites plain tool names in aggregated mode", func(t *testing.T) {
+		toolCtx := &ToolCallContext{
+			proxy: &MCPProxy{
+				isAggregatedProxy: true,
+			},
+			routingContext: &common.RoutingLog{ServerName: "srv"},
+			request: &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{Name: "srv___tool_name"},
+			},
+		}
+
+		err := toolCtx.RewriteToolName("tool_updated")
+
+		assert.NilError(t, err)
+		assert.Equal(t, toolCtx.GetRawToolName(), "srv___tool_updated")
+	})
+
+	t.Run("rejects mismatched namespaced tool names in aggregated mode", func(t *testing.T) {
+		toolCtx := &ToolCallContext{
+			proxy: &MCPProxy{
+				isAggregatedProxy: true,
+			},
+			routingContext: &common.RoutingLog{ServerName: "srv"},
+			request: &mcp.CallToolRequest{
+				Params: &mcp.CallToolParamsRaw{Name: "srv___tool_name"},
+			},
+		}
+
+		err := toolCtx.RewriteToolName("other___tool_updated")
+
+		assert.Assert(t, errors.Is(err, ErrUnexpectedToolNamespace))
+	})
 }

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/T4cceptor/centian/internal/common"
@@ -10,6 +12,22 @@ import (
 
 // NamespaceSeparator is used to create tool names in an aggregated proxy server.
 const NamespaceSeparator = "___"
+
+var (
+	// ErrMalformedAggregatedToolName indicates that an aggregated tool name does
+	// not match the expected `<server>___<tool>` shape.
+	ErrMalformedAggregatedToolName = errors.New("malformed aggregated tool name")
+	// ErrUnexpectedToolNamespace indicates that an aggregated tool name is
+	// namespaced for a different downstream server than expected.
+	ErrUnexpectedToolNamespace = errors.New("unexpected aggregated tool namespace")
+)
+
+// AggregatedToolName captures the parsed state of a tool name in aggregated mode.
+type AggregatedToolName struct {
+	ToolName        string
+	IsNamespaced    bool
+	NamespaceServer string
+}
 
 var newUUIDV7 = uuid.NewV7
 
@@ -22,6 +40,43 @@ func getNewUUIDV7() string {
 		result = fmt.Sprintf("req_%d", time.Now().UnixMicro())
 	}
 	return result
+}
+
+// ParseAggregatedToolName parses an aggregated tool name and optionally validates
+// that the namespace matches the expected server.
+func ParseAggregatedToolName(rawName, expectedServer string) (AggregatedToolName, error) {
+	if rawName == "" {
+		return AggregatedToolName{}, ErrMalformedAggregatedToolName
+	}
+
+	if !strings.Contains(rawName, NamespaceSeparator) {
+		return AggregatedToolName{ToolName: rawName}, nil
+	}
+
+	parts := strings.Split(rawName, NamespaceSeparator)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return AggregatedToolName{ToolName: rawName}, ErrMalformedAggregatedToolName
+	}
+
+	result := AggregatedToolName{
+		ToolName:        parts[1],
+		IsNamespaced:    true,
+		NamespaceServer: parts[0],
+	}
+	if expectedServer != "" && result.NamespaceServer != expectedServer {
+		return result, fmt.Errorf("%w: got %q, expected %q", ErrUnexpectedToolNamespace, result.NamespaceServer, expectedServer)
+	}
+	return result, nil
+}
+
+func formatAggregatedToolName(serverName, toolName string) (string, error) {
+	if serverName == "" || toolName == "" {
+		return "", ErrMalformedAggregatedToolName
+	}
+	if strings.Contains(serverName, NamespaceSeparator) || strings.Contains(toolName, NamespaceSeparator) {
+		return "", ErrMalformedAggregatedToolName
+	}
+	return fmt.Sprintf("%s%s%s", serverName, NamespaceSeparator, toolName), nil
 }
 
 // getServerID returns a new serverID using the server name.

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/T4cceptor/centian/internal/common"
@@ -10,6 +11,25 @@ import (
 
 // NamespaceSeparator is used to create tool names in an aggregated proxy server.
 const NamespaceSeparator = "___"
+
+// parseAggregatedToolName validates an aggregated tool name and returns the
+// downstream tool name that should be used for processing and dispatch.
+//
+// Note: this is to be used BEFORE processing the request, otherwise it
+// might return false-positive errors!
+func parseAggregatedToolName(rawName, expectedServer string) (string, error) {
+	parts := strings.SplitN(rawName, NamespaceSeparator, 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("invalid aggregated tool name %q", rawName)
+	}
+	if strings.Contains(parts[1], NamespaceSeparator) {
+		return "", fmt.Errorf("invalid aggregated tool name %q", rawName)
+	}
+	if expectedServer != "" && parts[0] != expectedServer {
+		return "", fmt.Errorf("aggregated tool %q targets server %q, expected %q", rawName, parts[0], expectedServer)
+	}
+	return parts[1], nil
+}
 
 var newUUIDV7 = uuid.NewV7
 

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -1,9 +1,7 @@
 package proxy
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/T4cceptor/centian/internal/common"
@@ -12,22 +10,6 @@ import (
 
 // NamespaceSeparator is used to create tool names in an aggregated proxy server.
 const NamespaceSeparator = "___"
-
-var (
-	// ErrMalformedAggregatedToolName indicates that an aggregated tool name does
-	// not match the expected `<server>___<tool>` shape.
-	ErrMalformedAggregatedToolName = errors.New("malformed aggregated tool name")
-	// ErrUnexpectedToolNamespace indicates that an aggregated tool name is
-	// namespaced for a different downstream server than expected.
-	ErrUnexpectedToolNamespace = errors.New("unexpected aggregated tool namespace")
-)
-
-// AggregatedToolName captures the parsed state of a tool name in aggregated mode.
-type AggregatedToolName struct {
-	ToolName        string
-	IsNamespaced    bool
-	NamespaceServer string
-}
 
 var newUUIDV7 = uuid.NewV7
 
@@ -40,43 +22,6 @@ func getNewUUIDV7() string {
 		result = fmt.Sprintf("req_%d", time.Now().UnixMicro())
 	}
 	return result
-}
-
-// ParseAggregatedToolName parses an aggregated tool name and optionally validates
-// that the namespace matches the expected server.
-func ParseAggregatedToolName(rawName, expectedServer string) (AggregatedToolName, error) {
-	if rawName == "" {
-		return AggregatedToolName{}, ErrMalformedAggregatedToolName
-	}
-
-	if !strings.Contains(rawName, NamespaceSeparator) {
-		return AggregatedToolName{ToolName: rawName}, nil
-	}
-
-	parts := strings.Split(rawName, NamespaceSeparator)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return AggregatedToolName{ToolName: rawName}, ErrMalformedAggregatedToolName
-	}
-
-	result := AggregatedToolName{
-		ToolName:        parts[1],
-		IsNamespaced:    true,
-		NamespaceServer: parts[0],
-	}
-	if expectedServer != "" && result.NamespaceServer != expectedServer {
-		return result, fmt.Errorf("%w: got %q, expected %q", ErrUnexpectedToolNamespace, result.NamespaceServer, expectedServer)
-	}
-	return result, nil
-}
-
-func formatAggregatedToolName(serverName, toolName string) (string, error) {
-	if serverName == "" || toolName == "" {
-		return "", ErrMalformedAggregatedToolName
-	}
-	if strings.Contains(serverName, NamespaceSeparator) || strings.Contains(toolName, NamespaceSeparator) {
-		return "", ErrMalformedAggregatedToolName
-	}
-	return fmt.Sprintf("%s%s%s", serverName, NamespaceSeparator, toolName), nil
 }
 
 // getServerID returns a new serverID using the server name.

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -11,6 +12,11 @@ import (
 
 // NamespaceSeparator is used to create tool names in an aggregated proxy server.
 const NamespaceSeparator = "___"
+
+var (
+	forwardedAuthHeaders = []string{"Authorization", "X-API-Key", "X-Auth-Token"}
+	redactedAuthHeaders  = []string{"Authorization", "X-Centian-Auth", "X-API-Key", "X-Auth-Token"}
+)
 
 // parseAggregatedToolName validates an aggregated tool name and returns the
 // downstream tool name that should be used for processing and dispatch.
@@ -29,6 +35,42 @@ func parseAggregatedToolName(rawName, expectedServer string) (string, error) {
 		return "", fmt.Errorf("aggregated tool %q targets server %q, expected %q", rawName, parts[0], expectedServer)
 	}
 	return parts[1], nil
+}
+
+func getAuthHeaders(headers http.Header, excludedHeader string) map[string]string {
+	authHeaders := make(map[string]string)
+	for _, headerName := range forwardedAuthHeaders {
+		if excludedHeader != "" && strings.EqualFold(headerName, excludedHeader) {
+			continue
+		}
+		if value := headers.Get(headerName); value != "" {
+			authHeaders[headerName] = value
+		}
+	}
+	return authHeaders
+}
+
+func redactHeaders(headers http.Header) http.Header {
+	redacted := make(http.Header, len(headers))
+	for key, values := range headers {
+		if headerNameInList(key, redactedAuthHeaders) {
+			redacted[key] = []string{"<redacted>"}
+			continue
+		}
+		copied := make([]string, len(values))
+		copy(copied, values)
+		redacted[key] = copied
+	}
+	return redacted
+}
+
+func headerNameInList(headerName string, candidates []string) bool {
+	for _, candidate := range candidates {
+		if strings.EqualFold(headerName, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 var newUUIDV7 = uuid.NewV7

--- a/internal/proxy/utils_test.go
+++ b/internal/proxy/utils_test.go
@@ -61,6 +61,51 @@ func TestGetEndpointString(t *testing.T) {
 	assert.Assert(t, err != nil)
 }
 
+func TestParseAggregatedToolName(t *testing.T) {
+	cases := []struct {
+		name           string
+		rawName        string
+		expectedServer string
+		expectedTool   string
+		wantErr        bool
+	}{
+		{
+			name:           "valid namespaced tool",
+			rawName:        "server___query",
+			expectedServer: "server",
+			expectedTool:   "query",
+		},
+		{
+			name:           "wrong server namespace",
+			rawName:        "other___query",
+			expectedServer: "server",
+			wantErr:        true,
+		},
+		{
+			name:    "malformed separator",
+			rawName: "server___nested___query",
+			wantErr: true,
+		},
+		{
+			name:    "missing namespace",
+			rawName: "query",
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			toolName, err := parseAggregatedToolName(testCase.rawName, testCase.expectedServer)
+			if testCase.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, toolName, testCase.expectedTool)
+		})
+	}
+}
+
 func TestExtractAuthToken(t *testing.T) {
 	// Given: header values
 	cases := []struct {

--- a/internal/proxy/utils_test.go
+++ b/internal/proxy/utils_test.go
@@ -61,61 +61,6 @@ func TestGetEndpointString(t *testing.T) {
 	assert.Assert(t, err != nil)
 }
 
-func TestParseAggregatedToolName(t *testing.T) {
-	cases := []struct {
-		name           string
-		rawName        string
-		expectedServer string
-		expectedTool   string
-		namespaced     bool
-		namespace      string
-		expectedErr    error
-	}{
-		{
-			name:           "valid namespaced tool",
-			rawName:        "server___query",
-			expectedServer: "server",
-			expectedTool:   "query",
-			namespaced:     true,
-			namespace:      "server",
-		},
-		{
-			name:         "plain tool name",
-			rawName:      "query",
-			expectedTool: "query",
-		},
-		{
-			name:           "wrong server namespace",
-			rawName:        "other___query",
-			expectedServer: "server",
-			expectedTool:   "query",
-			namespaced:     true,
-			namespace:      "other",
-			expectedErr:    ErrUnexpectedToolNamespace,
-		},
-		{
-			name:         "malformed separator",
-			rawName:      "server___nested___query",
-			expectedTool: "server___nested___query",
-			expectedErr:  ErrMalformedAggregatedToolName,
-		},
-	}
-
-	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
-			parsed, err := ParseAggregatedToolName(testCase.rawName, testCase.expectedServer)
-			if testCase.expectedErr != nil {
-				assert.Assert(t, errors.Is(err, testCase.expectedErr))
-			} else {
-				assert.NilError(t, err)
-			}
-			assert.Equal(t, parsed.ToolName, testCase.expectedTool)
-			assert.Equal(t, parsed.IsNamespaced, testCase.namespaced)
-			assert.Equal(t, parsed.NamespaceServer, testCase.namespace)
-		})
-	}
-}
-
 func TestExtractAuthToken(t *testing.T) {
 	// Given: header values
 	cases := []struct {

--- a/internal/proxy/utils_test.go
+++ b/internal/proxy/utils_test.go
@@ -127,7 +127,7 @@ func TestRedactHeaders(t *testing.T) {
 	headers := http.Header{
 		"Authorization":  []string{"Bearer upstream"},
 		"X-Centian-Auth": []string{"centian-secret"},
-		"X-API-Key":      []string{"api-key"},
+		"X-Api-Key":      []string{"api-key"},
 		"X-Auth-Token":   []string{"auth-token"},
 		"X-Other":        []string{"visible"},
 	}
@@ -136,7 +136,7 @@ func TestRedactHeaders(t *testing.T) {
 
 	assert.DeepEqual(t, redacted["Authorization"], []string{"<redacted>"})
 	assert.DeepEqual(t, redacted["X-Centian-Auth"], []string{"<redacted>"})
-	assert.DeepEqual(t, redacted["X-API-Key"], []string{"<redacted>"})
+	assert.DeepEqual(t, redacted["X-Api-Key"], []string{"<redacted>"})
 	assert.DeepEqual(t, redacted["X-Auth-Token"], []string{"<redacted>"})
 	assert.DeepEqual(t, redacted["X-Other"], []string{"visible"})
 	assert.DeepEqual(t, headers["Authorization"], []string{"Bearer upstream"})

--- a/internal/proxy/utils_test.go
+++ b/internal/proxy/utils_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -104,6 +105,47 @@ func TestParseAggregatedToolName(t *testing.T) {
 			assert.Equal(t, toolName, testCase.expectedTool)
 		})
 	}
+}
+
+func TestGetAuthHeaders(t *testing.T) {
+	headers := http.Header{
+		"Authorization": []string{"Bearer upstream"},
+		"X-API-Key":     []string{"api-key"},
+		"X-Auth-Token":  []string{"auth-token"},
+		"X-Other":       []string{"ignored"},
+	}
+
+	authHeaders := getAuthHeaders(headers, "X-API-Key")
+
+	assert.Equal(t, authHeaders["Authorization"], "Bearer upstream")
+	assert.Equal(t, authHeaders["X-Auth-Token"], "auth-token")
+	assert.Assert(t, authHeaders["X-API-Key"] == "")
+	assert.Assert(t, authHeaders["X-Other"] == "")
+}
+
+func TestRedactHeaders(t *testing.T) {
+	headers := http.Header{
+		"Authorization":  []string{"Bearer upstream"},
+		"X-Centian-Auth": []string{"centian-secret"},
+		"X-API-Key":      []string{"api-key"},
+		"X-Auth-Token":   []string{"auth-token"},
+		"X-Other":        []string{"visible"},
+	}
+
+	redacted := redactHeaders(headers)
+
+	assert.DeepEqual(t, redacted["Authorization"], []string{"<redacted>"})
+	assert.DeepEqual(t, redacted["X-Centian-Auth"], []string{"<redacted>"})
+	assert.DeepEqual(t, redacted["X-API-Key"], []string{"<redacted>"})
+	assert.DeepEqual(t, redacted["X-Auth-Token"], []string{"<redacted>"})
+	assert.DeepEqual(t, redacted["X-Other"], []string{"visible"})
+	assert.DeepEqual(t, headers["Authorization"], []string{"Bearer upstream"})
+}
+
+func TestHeaderNameInList(t *testing.T) {
+	assert.Assert(t, headerNameInList("Authorization", redactedAuthHeaders))
+	assert.Assert(t, headerNameInList("authorization", redactedAuthHeaders))
+	assert.Assert(t, !headerNameInList("X-Other", redactedAuthHeaders))
 }
 
 func TestExtractAuthToken(t *testing.T) {

--- a/internal/proxy/utils_test.go
+++ b/internal/proxy/utils_test.go
@@ -61,6 +61,61 @@ func TestGetEndpointString(t *testing.T) {
 	assert.Assert(t, err != nil)
 }
 
+func TestParseAggregatedToolName(t *testing.T) {
+	cases := []struct {
+		name           string
+		rawName        string
+		expectedServer string
+		expectedTool   string
+		namespaced     bool
+		namespace      string
+		expectedErr    error
+	}{
+		{
+			name:           "valid namespaced tool",
+			rawName:        "server___query",
+			expectedServer: "server",
+			expectedTool:   "query",
+			namespaced:     true,
+			namespace:      "server",
+		},
+		{
+			name:         "plain tool name",
+			rawName:      "query",
+			expectedTool: "query",
+		},
+		{
+			name:           "wrong server namespace",
+			rawName:        "other___query",
+			expectedServer: "server",
+			expectedTool:   "query",
+			namespaced:     true,
+			namespace:      "other",
+			expectedErr:    ErrUnexpectedToolNamespace,
+		},
+		{
+			name:         "malformed separator",
+			rawName:      "server___nested___query",
+			expectedTool: "server___nested___query",
+			expectedErr:  ErrMalformedAggregatedToolName,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			parsed, err := ParseAggregatedToolName(testCase.rawName, testCase.expectedServer)
+			if testCase.expectedErr != nil {
+				assert.Assert(t, errors.Is(err, testCase.expectedErr))
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.Equal(t, parsed.ToolName, testCase.expectedTool)
+			assert.Equal(t, parsed.IsNamespaced, testCase.namespaced)
+			assert.Equal(t, parsed.NamespaceServer, testCase.namespace)
+		})
+	}
+}
+
 func TestExtractAuthToken(t *testing.T) {
 	// Given: header values
 	cases := []struct {


### PR DESCRIPTION
Implemented a fix for aggregated tool-name routing in gateway mode.

- Added explicit aggregated tool-name parsing and validation.
- Separated raw request tool names from downstream dispatch tool names.
- Prevented routing round-trips from rewriting server___tool into plain tool unless a processor intentionally changes the route.
- Stopped malformed aggregated names from collapsing to an empty tool name; they now fall back safely and log warnings.
- Added regression tests for valid, plain, malformed, wrong-namespace, and processor round-trip cases.
- Documented exported sentinel errors in proxy utils to satisfy linting.