### PR TITLE
Feature/auth context handler

### DIFF
--- a/internal/auth/apikeys.go
+++ b/internal/auth/apikeys.go
@@ -35,9 +35,10 @@ type APIKeyFile struct {
 
 // APIKeyEntry represents a stored API key hash and metadata.
 type APIKeyEntry struct {
-	ID        string `json:"id"`
-	Hash      string `json:"hash"`
-	CreatedAt string `json:"created_at"`
+	ID        string   `json:"id"`
+	Hash      string   `json:"hash"`
+	CreatedAt string   `json:"created_at"`
+	Gateways  []string `json:"gateways,omitempty"`
 }
 
 // APIKeyStore stores API keys loaded from disk for quick validation.
@@ -99,6 +100,26 @@ func (s *APIKeyStore) Lookup(key string) (*APIKeyEntry, bool) {
 		}
 	}
 	return nil, false
+}
+
+// AllowsGateway checks whether this key is allowed to access the given gateway.
+//
+// Backward compatibility:
+// - Empty Gateway lists are treated as allow-all.
+// - "*" is treated as allow-all.
+func (e *APIKeyEntry) AllowsGateway(gateway string) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.Gateways) == 0 {
+		return true
+	}
+	for _, gw := range e.Gateways {
+		if gw == "*" || strings.EqualFold(strings.TrimSpace(gw), strings.TrimSpace(gateway)) {
+			return true
+		}
+	}
+	return false
 }
 
 // Validate returns true if the provided API key exists in the store.

--- a/internal/auth/apikeys_test.go
+++ b/internal/auth/apikeys_test.go
@@ -50,7 +50,7 @@ func TestLoadDefaultAPIKeys(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, store.Path(), path)
 	assert.Equal(t, store.Count(), 1)
-	if !store.Validate(plain) {
+	if _, ok := store.Resolve(plain); !ok {
 		t.Fatalf("expected key to validate")
 	}
 }
@@ -110,10 +110,13 @@ func TestLoadAPIKeys_ObjectFormat(t *testing.T) {
 	if store.Count() != 2 {
 		t.Fatalf("expected 2 keys, got %d", store.Count())
 	}
-	if !store.Validate("key-1") || !store.Validate("key-2") {
+	if _, ok := store.Resolve("key-1"); !ok {
+		t.Fatalf("expected key-1 to be present")
+	}
+	if _, ok := store.Resolve("key-2"); !ok {
 		t.Fatalf("expected keys to be present")
 	}
-	if store.Validate("missing") {
+	if _, ok := store.Resolve("missing"); ok {
 		t.Fatalf("expected missing key to be invalid")
 	}
 }
@@ -188,9 +191,44 @@ func TestAppendAPIKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load api keys: %v", err)
 	}
-	if !store.Validate(plain) {
+	if _, ok := store.Resolve(plain); !ok {
 		t.Fatalf("expected key to validate")
 	}
+}
+
+func TestResolve(t *testing.T) {
+	plain := "sk-test-resolve"
+	path := writeTempFile(t, `{"keys":[{"id":"key_resolve","hash":"`+hashKey(t, plain)+`","created_at":"2025-01-01T00:00:00Z"}]}`)
+	store, err := LoadAPIKeys(path)
+	assert.NilError(t, err)
+
+	entry, ok := store.Resolve(plain)
+	assert.Assert(t, ok)
+	assert.Assert(t, entry != nil)
+	assert.Equal(t, entry.ID, "key_resolve")
+
+	_, ok = store.Resolve("sk-missing")
+	assert.Assert(t, !ok)
+}
+
+func TestAPIKeyEntryAllowsGateway(t *testing.T) {
+	t.Run("empty gateways allows all", func(t *testing.T) {
+		entry := &APIKeyEntry{ID: "key_any"}
+		assert.Assert(t, entry.AllowsGateway("default"))
+		assert.Assert(t, entry.AllowsGateway("other"))
+	})
+
+	t.Run("explicit gateway is enforced", func(t *testing.T) {
+		entry := &APIKeyEntry{ID: "key_scope", Gateways: []string{"alpha"}}
+		assert.Assert(t, entry.AllowsGateway("alpha"))
+		assert.Assert(t, !entry.AllowsGateway("beta"))
+	})
+
+	t.Run("wildcard allows all", func(t *testing.T) {
+		entry := &APIKeyEntry{ID: "key_star", Gateways: []string{"*"}}
+		assert.Assert(t, entry.AllowsGateway("alpha"))
+		assert.Assert(t, entry.AllowsGateway("beta"))
+	})
 }
 
 func writeTempFile(t *testing.T, contents string) string {

--- a/internal/auth/apikeys_test.go
+++ b/internal/auth/apikeys_test.go
@@ -50,7 +50,7 @@ func TestLoadDefaultAPIKeys(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, store.Path(), path)
 	assert.Equal(t, store.Count(), 1)
-	if _, ok := store.Resolve(plain); !ok {
+	if _, ok := store.Lookup(plain); !ok {
 		t.Fatalf("expected key to validate")
 	}
 }
@@ -110,13 +110,13 @@ func TestLoadAPIKeys_ObjectFormat(t *testing.T) {
 	if store.Count() != 2 {
 		t.Fatalf("expected 2 keys, got %d", store.Count())
 	}
-	if _, ok := store.Resolve("key-1"); !ok {
+	if _, ok := store.Lookup("key-1"); !ok {
 		t.Fatalf("expected key-1 to be present")
 	}
-	if _, ok := store.Resolve("key-2"); !ok {
+	if _, ok := store.Lookup("key-2"); !ok {
 		t.Fatalf("expected keys to be present")
 	}
-	if _, ok := store.Resolve("missing"); ok {
+	if _, ok := store.Lookup("missing"); ok {
 		t.Fatalf("expected missing key to be invalid")
 	}
 }
@@ -191,7 +191,7 @@ func TestAppendAPIKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load api keys: %v", err)
 	}
-	if _, ok := store.Resolve(plain); !ok {
+	if _, ok := store.Lookup(plain); !ok {
 		t.Fatalf("expected key to validate")
 	}
 }
@@ -202,12 +202,12 @@ func TestResolve(t *testing.T) {
 	store, err := LoadAPIKeys(path)
 	assert.NilError(t, err)
 
-	entry, ok := store.Resolve(plain)
+	entry, ok := store.Lookup(plain)
 	assert.Assert(t, ok)
 	assert.Assert(t, entry != nil)
 	assert.Equal(t, entry.ID, "key_resolve")
 
-	_, ok = store.Resolve("sk-missing")
+	_, ok = store.Lookup("sk-missing")
 	assert.Assert(t, !ok)
 }
 

--- a/internal/common/auth_context.go
+++ b/internal/common/auth_context.go
@@ -1,0 +1,17 @@
+package common
+
+// AuthContext captures authenticated principal information for a request.
+//
+// This context is intended for policy, compliance, and processor-level decisions.
+// It must never include raw credentials.
+type AuthContext struct {
+	Authenticated         bool   `json:"authenticated"`
+	PrincipalID           string `json:"principal_id,omitempty"`
+	PrincipalType         string `json:"principal_type,omitempty"` // e.g. "api_key"
+	KeyID                 string `json:"key_id,omitempty"`
+	Gateway               string `json:"gateway,omitempty"`
+	AuthHeader            string `json:"auth_header,omitempty"`
+	CredentialFingerprint string `json:"credential_fingerprint,omitempty"`
+	InternalSessionID     string `json:"internal_session_id,omitempty"`
+	TransportSessionID    string `json:"transport_session_id,omitempty"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,7 +225,7 @@ type ProcessorConfig struct {
 	Type    string                 `json:"type"`              // Processor type: "cli" (future: "http", "builtin")
 	Enabled bool                   `json:"enabled"`           // Whether processor is active
 	Timeout int                    `json:"timeout,omitempty"` // Timeout in seconds (default: 15)
-	Parts   []string               `json:"parts,omitempty"`   // Which context parts to provide: "payload", "meta", "routing" (default: ["payload"])
+	Parts   []string               `json:"parts,omitempty"`   // Which context parts to provide: "payload", "meta", "routing", "auth" (default: ["payload","meta"])
 	Config  map[string]interface{} `json:"config"`            // Type-specific configuration
 
 	// Determines if processor is required to run, "false" by default,
@@ -580,6 +580,10 @@ func validateProcessor(index int, processor *ProcessorConfig, processorNames map
 		processor.Timeout = 15 // Default 15 seconds
 	}
 
+	if err := validateProcessorParts(processor); err != nil {
+		return err
+	}
+
 	// Validate config field is present.
 	if processor.Config == nil {
 		return fmt.Errorf("processor '%s': config is required", processor.Name)
@@ -587,6 +591,21 @@ func validateProcessor(index int, processor *ProcessorConfig, processorNames map
 
 	// Validate type-specific config.
 	return validateProcessorTypeConfig(processor)
+}
+
+func validateProcessorParts(processor *ProcessorConfig) error {
+	allowedParts := map[string]bool{
+		"payload": true,
+		"meta":    true,
+		"routing": true,
+		"auth":    true,
+	}
+	for _, part := range processor.GetParts() {
+		if !allowedParts[part] {
+			return fmt.Errorf("processor '%s': unsupported part '%s' (allowed: payload, meta, routing, auth)", processor.Name, part)
+		}
+	}
+	return nil
 }
 
 // HasProcessor returns true if a processor with the given name exists in the global config.

--- a/internal/config/config_processor_test.go
+++ b/internal/config/config_processor_test.go
@@ -141,6 +141,26 @@ func TestProcessorValidation(t *testing.T) {
 			errorMsg:  "config is required",
 		},
 		{
+			name: "invalid processor part",
+			config: &GlobalConfig{
+				Version:  "1.0.0",
+				Gateways: defaultGateways,
+				Processors: []*ProcessorConfig{
+					{
+						Name:    "bad-part",
+						Type:    "cli",
+						Enabled: true,
+						Parts:   []string{"payload", "unknown-part"},
+						Config: map[string]interface{}{
+							"command": "python",
+						},
+					},
+				},
+			},
+			wantError: true,
+			errorMsg:  "unsupported part 'unknown-part'",
+		},
+		{
 			name: "cli processor missing command",
 			config: &GlobalConfig{
 				Version:  "1.0.0",

--- a/internal/processor/cli_processor.go
+++ b/internal/processor/cli_processor.go
@@ -120,10 +120,11 @@ func (e *CLIProcessor) Process(input *DataContext) (*DataContext, error) {
 }
 
 type processorInputDTO struct {
-	Version string           `json:"version,omitempty"`
-	Event   *common.MCPEvent `json:"event,omitempty"`
-	Payload *payloadPartDTO  `json:"payload,omitempty"`
-	Routing *RoutingPart     `json:"routing,omitempty"`
+	Version string              `json:"version,omitempty"`
+	Event   *common.MCPEvent    `json:"event,omitempty"`
+	Payload *payloadPartDTO     `json:"payload,omitempty"`
+	Routing *RoutingPart        `json:"routing,omitempty"`
+	Auth    *common.AuthContext `json:"auth,omitempty"`
 }
 
 type payloadPartDTO struct {
@@ -146,6 +147,7 @@ func marshalProcessorInput(input *DataContext) ([]byte, error) {
 		Version: input.Version,
 		Event:   input.Event,
 		Routing: input.Routing,
+		Auth:    input.Auth,
 	}
 
 	if input.Payload != nil {

--- a/internal/processor/cli_processor_test.go
+++ b/internal/processor/cli_processor_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/assert"
@@ -164,6 +165,31 @@ func TestMarshalProcessorInput_StripsUnmarshalableRequestFields(t *testing.T) {
 	assert.Assert(t, !hasExtra)
 	_, hasSession := request["Session"]
 	assert.Assert(t, !hasSession)
+}
+
+func TestMarshalProcessorInput_IncludesAuthPart(t *testing.T) {
+	input := &DataContext{
+		Version: "1.0",
+		Auth: &common.AuthContext{
+			Authenticated: true,
+			PrincipalID:   "principal-1",
+			PrincipalType: "api_key",
+			KeyID:         "key_1",
+			Gateway:       "default",
+		},
+	}
+
+	encoded, err := marshalProcessorInput(input)
+	assert.NilError(t, err)
+
+	var decoded map[string]any
+	assert.NilError(t, json.Unmarshal(encoded, &decoded))
+
+	authPart, ok := decoded["auth"].(map[string]any)
+	assert.Assert(t, ok)
+	assert.Equal(t, authPart["principal_id"], "principal-1")
+	assert.Equal(t, authPart["principal_type"], "api_key")
+	assert.Equal(t, authPart["key_id"], "key_1")
 }
 
 func TestCLIProcessorProcess(t *testing.T) {

--- a/internal/processor/processor_context.go
+++ b/internal/processor/processor_context.go
@@ -11,10 +11,11 @@ type DataContext struct {
 	Version string `json:"version"` // "1.0" - for evolution
 
 	// Parts - only populated based on processor config
-	Event   *common.MCPEvent `json:"event,omitempty"`   // Contains event metadata
-	Payload *PayloadPart     `json:"payload,omitempty"` // Payload of the request and result
-	Routing *RoutingPart     `json:"routing,omitempty"`
-	// Future: Headers, Auth, etc.
+	Event   *common.MCPEvent    `json:"event,omitempty"`   // Contains event metadata
+	Payload *PayloadPart        `json:"payload,omitempty"` // Payload of the request and result
+	Routing *RoutingPart        `json:"routing,omitempty"`
+	Auth    *common.AuthContext `json:"auth,omitempty"` // Auth identity and principal context
+	// Future: Headers, etc.
 }
 
 // PayloadPart holds payload information in ProcessorContext.

--- a/internal/proxy/auth_context.go
+++ b/internal/proxy/auth_context.go
@@ -1,0 +1,61 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/T4cceptor/centian/internal/auth"
+)
+
+// AuthData stores raw auth-related references/snapshots for internal use.
+//
+// This struct intentionally does not match processor contracts. Handlers are
+// responsible for mapping AuthData to processor-facing context.
+type AuthData struct {
+	AuthHeaderName string
+	Gateway        string
+	Headers        http.Header
+	KeyEntry       *auth.APIKeyEntry
+}
+
+// Clone creates a deep copy of AuthData to ensure immutability when attached to contexts.
+func (a *AuthData) Clone() *AuthData {
+	if a == nil {
+		return nil
+	}
+	var headersCopy http.Header
+	if a.Headers != nil {
+		headersCopy = a.Headers.Clone()
+	}
+	var keyEntryCopy *auth.APIKeyEntry
+	if a.KeyEntry != nil {
+		entry := *a.KeyEntry
+		if entry.Gateways != nil {
+			entry.Gateways = append([]string(nil), entry.Gateways...)
+		}
+		keyEntryCopy = &entry
+	}
+	return &AuthData{
+		AuthHeaderName: a.AuthHeaderName,
+		Gateway:        a.Gateway,
+		Headers:        headersCopy,
+		KeyEntry:       keyEntryCopy,
+	}
+}
+
+type authDataKey struct{}
+
+func withAuthData(ctx context.Context, authData *AuthData) context.Context {
+	if authData == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, authDataKey{}, authData)
+}
+
+func getAuthData(ctx context.Context) *AuthData {
+	if ctx == nil {
+		return nil
+	}
+	authData, _ := ctx.Value(authDataKey{}).(*AuthData)
+	return authData
+}

--- a/internal/proxy/call_context.go
+++ b/internal/proxy/call_context.go
@@ -52,6 +52,7 @@ type CallContext interface {
 	// Session and request identification
 	GetRequestID() string // Returns unique request ID
 	GetSessionID() string // Returns session ID
+	GetAuthData() *AuthData
 
 	// Direction (processors need to know request vs response phase)
 	GetDirection() common.McpEventDirection

--- a/internal/proxy/handle_tool_call_test.go
+++ b/internal/proxy/handle_tool_call_test.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/T4cceptor/centian/internal/common"
@@ -253,4 +255,98 @@ func TestHandleToolCall_AggregatedPassthroughProcessorKeepsNormalizedToolName(t 
 	assert.Equal(t, req.Params.Name, "test-tool")
 	assert.Equal(t, mockDownstream.CapturedToolName, "test-tool")
 	assert.Equal(t, mockDownstream.CapturedArgs["original"], "value")
+}
+
+// TestHandleToolCall_ProcessorReceivesAuthContextFromMiddlewareSession verifies
+// the auth flow end-to-end: the auth middleware annotates the request, session
+// creation snapshots that auth data, and the processor receives the sanitized
+// auth context during a real tool call.
+func TestHandleToolCall_ProcessorReceivesAuthContextFromMiddlewareSession(t *testing.T) {
+	mockProcessor := &passthroughProcessor{
+		cfg: &config.ProcessorConfig{
+			Name:  "auth-passthrough",
+			Parts: []string{"auth"},
+		},
+	}
+
+	mockDownstream := &MockDownstreamConnection{
+		serverName: "test-server",
+		cfg:        &config.MCPServerConfig{URL: "http://test"},
+		tools: []*mcp.Tool{
+			{Name: "test-tool", Description: "test tool", InputSchema: map[string]any{"type": "object"}},
+		},
+		ResultToReturn: &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "ok"},
+			},
+		},
+		Status: StatusConnected,
+	}
+
+	proxy := createTestProxy(t, &ProcessingController{
+		processors: []processor.ProcessorInterface{mockProcessor},
+	})
+	proxy.endpoint = "/mcp/gateway-a/test-server"
+	proxy.downstreams = map[string]*DownstreamConnection{
+		"test-server": NewDownstreamConnection("test-server", &config.MCPServerConfig{URL: "http://test"}),
+	}
+	proxy.upstreamSessions = make(map[string]*UpstreamSession)
+	proxy.downstreamPools = make(map[string]*DownstreamConnectionPool)
+	proxy.connectionFactory = func(_ string, _ *config.MCPServerConfig) DownstreamConnectionInterface {
+		return mockDownstream
+	}
+	proxy.server.APIKeys = createTestAPIKeyStore(t)
+	proxy.server.AuthHeader = "Authorization"
+	proxy.server.Config = &config.GlobalConfig{Version: "1.0.0"}
+
+	handler := apiKeyMiddlewareWithHeader(proxy.server.APIKeys, proxy.server.AuthHeader, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := proxy.GetServerForRequest(r)
+		assert.Assert(t, server != nil)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-a/test-server", http.NoBody)
+	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Mcp-Session-Id", "sess-auth")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	assert.Equal(t, recorder.Result().StatusCode, http.StatusOK)
+
+	proxy.mu.RLock()
+	session := proxy.upstreamSessions["sess-auth"]
+	proxy.mu.RUnlock()
+
+	assert.Assert(t, session != nil)
+	assert.Assert(t, session.authData != nil)
+	assert.Equal(t, session.authData.AuthHeaderName, "Authorization")
+	assert.Equal(t, session.authData.Gateway, "gateway-a")
+	assert.Assert(t, session.authData.KeyEntry != nil)
+	assert.Equal(t, session.authData.KeyEntry.ID, "key_test")
+
+	req := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "test-tool",
+			Arguments: json.RawMessage(`{"hello":"world"}`),
+		},
+	}
+
+	result, err := proxy.handleToolCall(context.Background(), session, "test-server", req)
+
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.Assert(t, mockProcessor.lastInput != nil)
+	assert.Assert(t, mockProcessor.lastInput.Auth != nil)
+	assert.Assert(t, mockProcessor.lastInput.Auth.Authenticated)
+	assert.Equal(t, mockProcessor.lastInput.Auth.PrincipalType, "api_key")
+	assert.Equal(t, mockProcessor.lastInput.Auth.KeyID, "key_test")
+	assert.Equal(t, mockProcessor.lastInput.Auth.Gateway, "gateway-a")
+	assert.Equal(t, mockProcessor.lastInput.Auth.AuthHeader, "Authorization")
+	assert.Equal(t, mockProcessor.lastInput.Auth.InternalSessionID, "sess-auth")
+	assert.Equal(t, mockProcessor.lastInput.Auth.TransportSessionID, "sess-auth")
+	assert.Equal(t, mockProcessor.lastInput.Auth.PrincipalID, getPrincipalID("key_test", "gateway-a"))
+	assert.Equal(t, mockProcessor.lastInput.Auth.CredentialFingerprint, getCredentialFingerprint("plain-key"))
+	assert.Equal(t, mockDownstream.CapturedToolName, "test-tool")
+	assert.Equal(t, mockDownstream.CapturedArgs["hello"], "world")
 }

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -141,6 +141,68 @@ func (h *DefaultRoutingHandler) Apply(callCtx CallContext, result *processor.Dat
 }
 
 // =============================================================================
+// AuthHandler - provides read-only auth context to processors
+// =============================================================================
+
+// DefaultAuthHandler attaches auth context and treats it as immutable.
+type DefaultAuthHandler struct{}
+
+// AttachPart attaches auth information from CallContext to input ProcessorContext.
+func (h *DefaultAuthHandler) AttachPart(callCtx CallContext, input *processor.DataContext) {
+	if input == nil || callCtx == nil {
+		return
+	}
+	input.Auth = h.buildAuthContext(callCtx)
+}
+
+func (h *DefaultAuthHandler) buildAuthContext(callCtx CallContext) *common.AuthContext {
+	if callCtx == nil {
+		return nil
+	}
+	authData := callCtx.GetAuthData()
+	if authData == nil {
+		return nil
+	}
+
+	authCtx := &common.AuthContext{
+		Authenticated: true,
+		PrincipalType: "api_key",
+		Gateway:       authData.Gateway,
+		AuthHeader:    authData.AuthHeaderName,
+		// Internal session ID comes from proxy session mapping.
+		InternalSessionID: callCtx.GetSessionID(),
+	}
+
+	if authData.KeyEntry != nil {
+		authCtx.KeyID = authData.KeyEntry.ID
+		authCtx.PrincipalID = getPrincipalID(authData.KeyEntry.ID, authData.Gateway)
+	}
+
+	token := ""
+	if authData.Headers != nil {
+		token = extractAuthToken(authData.Headers.Get(authData.AuthHeaderName))
+		if token == "" {
+			token = extractAuthToken(authData.Headers.Get("Authorization"))
+		}
+		authCtx.TransportSessionID = authData.Headers.Get("Mcp-Session-Id")
+	}
+	if token != "" {
+		authCtx.CredentialFingerprint = getCredentialFingerprint(token)
+	}
+
+	// Prefer request-bound MCP session ID if available.
+	if req := callCtx.GetRequest(); req != nil && req.Session != nil {
+		authCtx.TransportSessionID = req.Session.ID()
+	}
+	return authCtx
+}
+
+// Apply ignores auth modifications from processors to keep auth context read-only.
+func (h *DefaultAuthHandler) Apply(_ CallContext, _ *processor.DataContext) error {
+	return nil
+}
+
+// =============================================================================
 // DefaultLogHandler - produces MCPEvent-compatible log entries
 // =============================================================================
 

--- a/internal/proxy/handlers_test.go
+++ b/internal/proxy/handlers_test.go
@@ -2,10 +2,12 @@ package proxy
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/T4cceptor/centian/internal/auth"
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/logging"
 	"github.com/T4cceptor/centian/internal/processor"
@@ -31,6 +33,12 @@ func newHandlerTestCallContext() *ToolCallContext {
 		originalResult:     &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "result-original"}}},
 		event:              common.NewMCPRequestEvent("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
 		routingContext:     &common.RoutingContext{ServerName: "server-current"},
+		authData: &AuthData{
+			AuthHeaderName: "Authorization",
+			Gateway:        "gateway-a",
+			Headers:        http.Header{"Authorization": []string{"Bearer plain-key"}},
+			KeyEntry:       &auth.APIKeyEntry{ID: "key_1"},
+		},
 	}
 }
 
@@ -187,6 +195,31 @@ func TestDefaultRoutingHandlerApply(t *testing.T) {
 
 		assert.Assert(t, err != nil)
 	})
+}
+
+func TestDefaultAuthHandlerAttachPartAndApply(t *testing.T) {
+	callCtx := newHandlerTestCallContext()
+	input := &processor.DataContext{}
+	handler := &DefaultAuthHandler{}
+
+	handler.AttachPart(callCtx, input)
+	assert.Assert(t, input.Auth != nil)
+	assert.Assert(t, input.Auth.Authenticated)
+	assert.Equal(t, input.Auth.KeyID, "key_1")
+	assert.Equal(t, input.Auth.Gateway, "gateway-a")
+	assert.Equal(t, input.Auth.AuthHeader, "Authorization")
+	assert.Equal(t, input.Auth.InternalSessionID, "sess-1")
+	assert.Assert(t, input.Auth.PrincipalID != "")
+	assert.Assert(t, input.Auth.CredentialFingerprint != "")
+
+	// Auth is read-only and ignored on apply.
+	output := &processor.DataContext{
+		Auth: &common.AuthContext{PrincipalID: "modified"},
+	}
+	err := handler.Apply(callCtx, output)
+	assert.NilError(t, err)
+	assert.Assert(t, callCtx.GetAuthData() != nil)
+	assert.Equal(t, callCtx.GetAuthData().KeyEntry.ID, "key_1")
 }
 
 func TestDefaultLogHandlerToLogEntry(t *testing.T) {

--- a/internal/proxy/proxy_event_processor_test.go
+++ b/internal/proxy/proxy_event_processor_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/T4cceptor/centian/internal/auth"
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
 	"github.com/T4cceptor/centian/internal/processor"
@@ -20,6 +22,7 @@ type mockCallContext struct {
 	originalResult     *mcp.CallToolResult
 	event              *common.MCPEvent
 	routing            *common.RoutingContext
+	authData           *AuthData
 	handlers           map[string]CallContextHandler
 	logHandler         LogHandler
 	serverName         string
@@ -35,10 +38,16 @@ func newMockCallContext() *mockCallContext {
 	}
 
 	return &mockCallContext{
-		request:            req,
-		originalRequest:    deepCloneRequest(req),
-		event:              common.NewMCPRequestEvent("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
-		routing:            &common.RoutingContext{ServerName: "server-a", Transport: common.StdioTransport},
+		request:         req,
+		originalRequest: deepCloneRequest(req),
+		event:           common.NewMCPRequestEvent("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
+		routing:         &common.RoutingContext{ServerName: "server-a", Transport: common.StdioTransport},
+		authData: &AuthData{
+			AuthHeaderName: "Authorization",
+			Gateway:        "gateway-a",
+			Headers:        http.Header{"Authorization": []string{"Bearer test-token"}},
+			KeyEntry:       &auth.APIKeyEntry{ID: "key_1"},
+		},
 		handlers:           map[string]CallContextHandler{},
 		serverName:         "server-a",
 		originalServerName: "server-a",
@@ -91,6 +100,9 @@ func (m *mockCallContext) GetError() string     { return m.event.Error }
 func (m *mockCallContext) SetError(msg string)  { m.event.Error = msg }
 func (m *mockCallContext) GetRequestID() string { return m.event.RequestID }
 func (m *mockCallContext) GetSessionID() string { return m.event.SessionID }
+func (m *mockCallContext) GetAuthData() *AuthData {
+	return m.authData
+}
 func (m *mockCallContext) GetDirection() common.McpEventDirection {
 	return m.event.Direction
 }
@@ -225,6 +237,26 @@ func TestGetInput_UsesConfiguredHandlers(t *testing.T) {
 	assert.Assert(t, input.Event != nil)
 	assert.Equal(t, 1, payloadHandler.getCalls)
 	assert.Equal(t, 1, metaHandler.getCalls)
+}
+
+func TestGetInput_WithAuthPart(t *testing.T) {
+	callCtx := newMockCallContext()
+
+	authHandler := &mockHandler{
+		getFn: func(callCtx CallContext, input *processor.DataContext) {
+			input.Auth = (&DefaultAuthHandler{}).buildAuthContext(callCtx)
+		},
+	}
+	callCtx.SetHandler("auth", authHandler)
+
+	processorConfig := &config.ProcessorConfig{
+		Parts: []string{"auth"},
+	}
+	input := GetInput(processorConfig, callCtx)
+
+	assert.Assert(t, input.Auth != nil)
+	assert.Equal(t, input.Auth.KeyID, "key_1")
+	assert.Equal(t, 1, authHandler.getCalls)
 }
 
 func TestGetInput_SkipsMissingHandler(t *testing.T) {

--- a/internal/proxy/proxy_server.go
+++ b/internal/proxy/proxy_server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -128,6 +129,7 @@ type UpstreamSession struct {
 	authHeaders     map[string]string                        // Forwarded auth headers captured from the client request that created this session.
 	identityKey     string                                   // Stable caller identity used when choosing a reusable downstream pool.
 	poolKey         string                                   // Lookup key of the DownstreamConnectionPool backing this upstream session.
+	authData        *AuthData                                // Raw auth mapping data for handlers/processors
 }
 
 // DownstreamConnectionPool owns the reusable downstream connection set for one
@@ -309,6 +311,7 @@ func (p *MCPProxy) createUpstreamSession(id string, r *http.Request, identityKey
 		authHeaders:     authHeaders,
 		identityKey:     identityKey,
 		poolKey:         p.getDownstreamPoolKey(identityKey, authHeaders),
+		authData:        authData.Clone(),
 	}
 }
 
@@ -664,7 +667,7 @@ func (p *MCPProxy) ProcessCall(callCtx CallContext, direction common.McpEventDir
 
 func (p *MCPProxy) handleToolCall(ctx context.Context, upstreamSession *UpstreamSession, serverName string, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// 1. Create CallContext
-	callCtx, err := NewToolCallContext(ctx, p, upstreamSession, serverName, req)
+	callCtx, err := NewToolCallContext(p, upstreamSession, serverName, req)
 	if err != nil {
 		return nil, err
 	}
@@ -757,9 +760,44 @@ func apiKeyMiddlewareWithHeader(store *centauth.APIKeyStore, headerName string, 
 			return
 		}
 
+		gatewayName := getGatewayFromPath(r.URL.Path)
+		if !entry.AllowsGateway(gatewayName) {
+			writeUnauthorized(w, headerName)
+			common.LogWarn("Unauthorized request: key '%s' not allowed for gateway '%s' from %s", entry.ID, gatewayName, r.RemoteAddr)
+			return
+		}
 		ctx := withRequestIdentity(r.Context(), "auth:"+entry.ID)
+		authData := &AuthData{
+			AuthHeaderName: headerName,
+			Gateway:        gatewayName,
+			Headers:        r.Header.Clone(),
+			KeyEntry:       entry,
+		}
+		r = r.WithContext(withAuthData(r.Context(), authData))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func getGatewayFromPath(requestPath string) string {
+	normalized := path.Clean("/" + strings.TrimSpace(requestPath))
+	parts := strings.Split(normalized, "/")
+	// Expected:
+	// /mcp/<gateway>
+	// /mcp/<gateway>/<server>
+	if len(parts) >= 3 && parts[1] == "mcp" {
+		return parts[2]
+	}
+	return ""
+}
+
+func getCredentialFingerprint(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
+}
+
+func getPrincipalID(keyID, gateway string) string {
+	hash := sha256.Sum256([]byte(strings.TrimSpace(keyID) + ":" + strings.TrimSpace(gateway)))
+	return hex.EncodeToString(hash[:])
 }
 
 func extractAuthToken(header string) string {

--- a/internal/proxy/proxy_server.go
+++ b/internal/proxy/proxy_server.go
@@ -311,7 +311,7 @@ func (p *MCPProxy) createUpstreamSession(id string, r *http.Request, identityKey
 		authHeaders:     authHeaders,
 		identityKey:     identityKey,
 		poolKey:         p.getDownstreamPoolKey(identityKey, authHeaders),
-		authData:        authData.Clone(),
+		// authData:        authData.Clone(),
 	}
 }
 

--- a/internal/proxy/proxy_server.go
+++ b/internal/proxy/proxy_server.go
@@ -304,6 +304,7 @@ func (p *MCPProxy) createUpstreamSession(id string, r *http.Request, identityKey
 		excludedAuthHeader = p.server.AuthHeader
 	}
 	authHeaders := getAuthHeaders(r.Header, excludedAuthHeader)
+	authData := getAuthData(r.Context())
 	return &UpstreamSession{
 		id:              id,
 		downstreamConns: make(map[string]DownstreamConnectionInterface),
@@ -311,7 +312,7 @@ func (p *MCPProxy) createUpstreamSession(id string, r *http.Request, identityKey
 		authHeaders:     authHeaders,
 		identityKey:     identityKey,
 		poolKey:         p.getDownstreamPoolKey(identityKey, authHeaders),
-		// authData:        authData.Clone(),
+		authData:        authData.Clone(),
 	}
 }
 
@@ -773,7 +774,7 @@ func apiKeyMiddlewareWithHeader(store *centauth.APIKeyStore, headerName string, 
 			Headers:        r.Header.Clone(),
 			KeyEntry:       entry,
 		}
-		r = r.WithContext(withAuthData(r.Context(), authData))
+		ctx = withAuthData(ctx, authData)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/proxy/proxy_server_unit_test.go
+++ b/internal/proxy/proxy_server_unit_test.go
@@ -148,6 +148,53 @@ func TestRegisterHandler_WithAuthMiddleware(t *testing.T) {
 	assert.Equal(t, recorder.Result().StatusCode, http.StatusUnauthorized)
 }
 
+func TestAPIKeyMiddlewareWithHeader_AttachesAuthData(t *testing.T) {
+	store := createTestAPIKeyStore(t)
+	called := false
+	handler := apiKeyMiddlewareWithHeader(store, "Authorization", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		authData := getAuthData(r.Context())
+		assert.Assert(t, authData != nil)
+		assert.Equal(t, authData.AuthHeaderName, "Authorization")
+		assert.Equal(t, authData.Gateway, "gateway-a")
+		assert.Assert(t, authData.Headers != nil)
+		assert.Assert(t, authData.KeyEntry != nil)
+		assert.Equal(t, authData.KeyEntry.ID, "key_test")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-a", http.NoBody)
+	request.Header.Set("Authorization", "Bearer plain-key")
+	handler.ServeHTTP(recorder, request)
+
+	assert.Assert(t, called)
+	assert.Equal(t, recorder.Result().StatusCode, http.StatusOK)
+}
+
+func TestAPIKeyMiddlewareWithHeader_EnforcesGatewayScope(t *testing.T) {
+	store := createScopedAPIKeyStore(t, "plain-key", []string{"gateway-a"})
+	called := false
+	handler := apiKeyMiddlewareWithHeader(store, "Authorization", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-b", http.NoBody)
+	request.Header.Set("Authorization", "Bearer plain-key")
+	handler.ServeHTTP(recorder, request)
+
+	assert.Assert(t, !called)
+	assert.Equal(t, recorder.Result().StatusCode, http.StatusUnauthorized)
+}
+
+func TestGetGatewayFromPath(t *testing.T) {
+	assert.Equal(t, getGatewayFromPath("/mcp/default"), "default")
+	assert.Equal(t, getGatewayFromPath("/mcp/default/server"), "default")
+	assert.Equal(t, getGatewayFromPath("/other/path"), "")
+}
+
 func TestNewCentianProxy_RequiresAuthWhenBindingAllInterfaces(t *testing.T) {
 	// Given: proxy settings that bind to all interfaces with auth unset
 	globalConfig := &config.GlobalConfig{
@@ -534,6 +581,20 @@ func createTestAPIKeyStore(t *testing.T) *auth.APIKeyStore {
 	t.Helper()
 	entry, err := auth.NewAPIKeyEntry("plain-key")
 	assert.NilError(t, err)
+	entry.ID = "key_test"
+	path := filepath.Join(t.TempDir(), "api_keys.json")
+	assert.NilError(t, auth.WriteAPIKeyFile(path, &auth.APIKeyFile{Keys: []auth.APIKeyEntry{entry}}))
+	store, err := auth.LoadAPIKeys(path)
+	assert.NilError(t, err)
+	return store
+}
+
+func createScopedAPIKeyStore(t *testing.T, plain string, gateways []string) *auth.APIKeyStore {
+	t.Helper()
+	entry, err := auth.NewAPIKeyEntry(plain)
+	assert.NilError(t, err)
+	entry.ID = "key_test"
+	entry.Gateways = gateways
 	path := filepath.Join(t.TempDir(), "api_keys.json")
 	assert.NilError(t, auth.WriteAPIKeyFile(path, &auth.APIKeyFile{Keys: []auth.APIKeyEntry{entry}}))
 	store, err := auth.LoadAPIKeys(path)

--- a/internal/proxy/tool_call_context.go
+++ b/internal/proxy/tool_call_context.go
@@ -32,6 +32,7 @@ type ToolCallContext struct {
 
 	// Routing context (reuses common.RoutingContext)
 	routingContext *common.RoutingContext
+	authData       *AuthData
 
 	// Handlers
 	handlers   map[string]CallContextHandler
@@ -41,7 +42,6 @@ type ToolCallContext struct {
 // NewToolCallContext creates a new ToolCallContext.
 // Returns CallContext interface to allow implementation swapping.
 func NewToolCallContext(
-	ctx context.Context,
 	proxy *MCPProxy,
 	upstreamSession *UpstreamSession,
 	serverName string,
@@ -91,12 +91,14 @@ func NewToolCallContext(
 		request:            req,             // Mutable, will be modified by handlers
 		routingContext:     routingCtx,
 		event:              event,
+		authData:           upstreamSession.authData.Clone(),
 	}
 
 	// Register handlers
 	toolCallCtx.SetHandler("payload", &DefaultPayloadHandler{})
 	toolCallCtx.SetHandler("meta", &DefaultMetaHandler{})
 	toolCallCtx.SetHandler("routing", &DefaultRoutingHandler{})
+	toolCallCtx.SetHandler("auth", &DefaultAuthHandler{})
 
 	// Set default log handler - proxy.server nil check was done above
 	if proxy.server.Logger == nil {
@@ -311,6 +313,11 @@ func (c *ToolCallContext) GetSessionID() string {
 	return c.upstreamSession.id
 }
 
+// GetAuthData returns auth mapping data attached to this call.
+func (c *ToolCallContext) GetAuthData() *AuthData {
+	return c.authData
+}
+
 // Routing context
 
 // GetRoutingContext returns the attached RoutingLog.
@@ -331,7 +338,7 @@ func (c *ToolCallContext) GetHandler(part string) (CallContextHandler, bool) {
 
 // SetHandler sets the provided handler for the provided part.
 //
-// Automatically creates the handlers slice if its nil.
+// Automatically creates the handlers map if it is nil.
 func (c *ToolCallContext) SetHandler(part string, h CallContextHandler) {
 	if c.handlers == nil {
 		c.handlers = make(map[string]CallContextHandler)
@@ -344,7 +351,7 @@ func (c *ToolCallContext) GetLogHandler() LogHandler {
 	return c.logHandler
 }
 
-// SetLogHandler sets the provided longer handler.
+// SetLogHandler sets the provided log handler.
 func (c *ToolCallContext) SetLogHandler(l LogHandler) {
 	c.logHandler = l
 }

--- a/internal/proxy/tool_call_context_test.go
+++ b/internal/proxy/tool_call_context_test.go
@@ -82,7 +82,7 @@ func TestNewToolCallContext(t *testing.T) {
 		session := &UpstreamSession{id: "sess-1", downstreamConns: map[string]DownstreamConnectionInterface{}}
 
 		// When: constructing context without server.
-		_, err := NewToolCallContext(context.Background(), proxy, session, "srv", request)
+		_, err := NewToolCallContext(proxy, session, "srv", request)
 
 		// Then: construction fails.
 		assert.Assert(t, err != nil)
@@ -97,7 +97,7 @@ func TestNewToolCallContext(t *testing.T) {
 		session := &UpstreamSession{id: "sess-1", downstreamConns: map[string]DownstreamConnectionInterface{}}
 
 		// When: constructing context without logger.
-		_, err := NewToolCallContext(context.Background(), proxy, session, "srv", request)
+		_, err := NewToolCallContext(proxy, session, "srv", request)
 
 		// Then: construction fails.
 		assert.Assert(t, err != nil)
@@ -121,6 +121,10 @@ func TestNewToolCallContext(t *testing.T) {
 		}
 		session := &UpstreamSession{
 			id: "sess-1",
+			authData: &AuthData{
+				AuthHeaderName: "Authorization",
+				Gateway:        "gw",
+			},
 			downstreamConns: map[string]DownstreamConnectionInterface{
 				"srv": &MockDownstreamConnection{
 					cfg: &config.MCPServerConfig{URL: "https://example.com/mcp"},
@@ -129,7 +133,7 @@ func TestNewToolCallContext(t *testing.T) {
 		}
 
 		// When: constructing a valid tool call context.
-		callCtxIface, err := NewToolCallContext(context.Background(), proxy, session, "srv", request)
+		callCtxIface, err := NewToolCallContext(proxy, session, "srv", request)
 		assert.NilError(t, err)
 
 		callCtx, ok := callCtxIface.(*ToolCallContext)
@@ -142,14 +146,18 @@ func TestNewToolCallContext(t *testing.T) {
 		assert.Equal(t, callCtx.GetMessageType(), common.MessageTypeRequest)
 		assert.Assert(t, callCtx.GetRequestID() != "")
 		assert.Assert(t, callCtx.GetLogHandler() != nil)
+		assert.Assert(t, callCtx.GetAuthData() != nil)
+		assert.Equal(t, callCtx.GetAuthData().Gateway, "gw")
 
 		// And: handlers are registered.
 		_, hasPayload := callCtx.GetHandler("payload")
 		_, hasMeta := callCtx.GetHandler("meta")
 		_, hasRouting := callCtx.GetHandler("routing")
+		_, hasAuth := callCtx.GetHandler("auth")
 		assert.Assert(t, hasPayload)
 		assert.Assert(t, hasMeta)
 		assert.Assert(t, hasRouting)
+		assert.Assert(t, hasAuth)
 
 		// And: original request was deep-cloned.
 		assert.Assert(t, callCtx.GetOriginalRequest() != callCtx.GetRequest())
@@ -189,7 +197,7 @@ func TestNewToolCallContext(t *testing.T) {
 			},
 		}
 
-		callCtxIface, err := NewToolCallContext(context.Background(), proxy, session, "srv", req)
+		callCtxIface, err := NewToolCallContext(proxy, session, "srv", req)
 		assert.NilError(t, err)
 
 		callCtx := callCtxIface.(*ToolCallContext)
@@ -231,7 +239,7 @@ func TestNewToolCallContext(t *testing.T) {
 			},
 		}
 
-		_, err = NewToolCallContext(context.Background(), proxy, session, "srv", req)
+		_, err = NewToolCallContext(proxy, session, "srv", req)
 		assert.Assert(t, err != nil)
 	})
 }
@@ -436,6 +444,7 @@ func TestToolCallContextSessionAndOriginalAccessors(t *testing.T) {
 
 	// Given: nil session and nil original request.
 	assert.Equal(t, toolCtx.GetSessionID(), "")
+	assert.Assert(t, toolCtx.GetAuthData() == nil)
 	assert.Equal(t, toolCtx.GetOriginalToolName(), "")
 	assert.Equal(t, toolCtx.GetRequestID(), "req-1")
 	assert.Equal(t, toolCtx.GetOriginalServerName(), "")


### PR DESCRIPTION
## Summary

This PR adds proxy auth context support for processors and tightens API key authorization around gateway access, while keeping downstream session reuse based on authenticated identity.

## Changes

- Added configurable proxy auth behavior via `auth` and `authHeader` in global config.
- Extended API keys with optional `gateways` scoping and added `AllowsGateway()` validation.
- Enforced gateway-level API key authorization in the HTTP auth middleware.
- Added internal `AuthData` to carry raw auth metadata safely through proxy/session state.
- Added processor-facing `auth` context support via `common.AuthContext`.
- Added `auth` as a valid processor part and wired it into processor input generation.
- Added an `AuthHandler` that exposes sanitized auth metadata to processors as read-only context.
- Preserved the separation of concerns between:
  - request identity for session/pool management
  - auth context for processor visibility
- Fixed auth propagation so middleware now attaches both request identity and auth data to the same request context.
- Fixed session wiring so authenticated requests snapshot auth data onto `UpstreamSession`, allowing tool-call processors to receive auth context during real calls.

## Behavior

After this change, a processor configured with `parts: ["auth"]` can access:
- whether the request was authenticated
- API key ID
- derived principal ID
- gateway name
- auth header name
- credential fingerprint
- internal proxy session ID
- transport/MCP session ID

No raw credentials are exposed to processors.

## Tests

Added and updated tests covering:
- API key gateway scoping
- auth middleware identity and auth-data attachment
- auth handler behavior
- auth processor input generation
- end-to-end auth propagation from middleware -> session -> tool call context -> processor