### PR TITLE
Feature/65 additional capabilities

### DIFF
--- a/internal/proxy/downstream_client_state.go
+++ b/internal/proxy/downstream_client_state.go
@@ -36,6 +36,14 @@ type DownstreamConnectOptions struct {
 	ElicitationHandler DownstreamElicitationHandler
 }
 
+type clientCapabilitiesWire struct {
+	Experimental map[string]any               `json:"experimental,omitempty"`
+	Extensions   map[string]any               `json:"extensions,omitempty"`
+	Roots        *mcp.RootCapabilities        `json:"roots,omitempty"`
+	Sampling     *mcp.SamplingCapabilities    `json:"sampling,omitempty"`
+	Elicitation  *mcp.ElicitationCapabilities `json:"elicitation,omitempty"`
+}
+
 func cloneDownstreamConnectOptions(options *DownstreamConnectOptions) *DownstreamConnectOptions {
 	if options == nil {
 		return &DownstreamConnectOptions{}
@@ -68,21 +76,17 @@ func cloneClientCapabilities(capabilities *mcp.ClientCapabilities) *mcp.ClientCa
 		return nil
 	}
 
-	encoded, err := json.Marshal(capabilities)
+	wire := clientCapabilitiesToWire(capabilities)
+	encoded, err := json.Marshal(wire)
 	if err != nil {
 		return &mcp.ClientCapabilities{}
 	}
 
-	var cloned mcp.ClientCapabilities
-	if err := json.Unmarshal(encoded, &cloned); err != nil {
+	var clonedWire clientCapabilitiesWire
+	if err := json.Unmarshal(encoded, &clonedWire); err != nil {
 		return &mcp.ClientCapabilities{}
 	}
-	if capabilities.RootsV2 != nil {
-		rootsV2 := *capabilities.RootsV2
-		cloned.RootsV2 = &rootsV2
-		cloned.Roots.ListChanged = rootsV2.ListChanged
-	}
-	return &cloned
+	return clientCapabilitiesFromWire(&clonedWire)
 }
 
 func normalizeRoots(roots []*mcp.Root) []*mcp.Root {
@@ -109,7 +113,7 @@ func normalizeRoots(roots []*mcp.Root) []*mcp.Root {
 }
 
 func fingerprintClientCapabilities(capabilities *mcp.ClientCapabilities) string {
-	return fingerprintJSON(normalizeClientCapabilities(capabilities))
+	return fingerprintJSON(clientCapabilitiesToWire(normalizeClientCapabilities(capabilities)))
 }
 
 func fingerprintRoots(roots []*mcp.Root) string {
@@ -131,6 +135,34 @@ func clientSupportsRoots(capabilities *mcp.ClientCapabilities) bool {
 		return false
 	}
 	return capabilities.RootsV2 != nil
+}
+
+func clientCapabilitiesToWire(capabilities *mcp.ClientCapabilities) *clientCapabilitiesWire {
+	if capabilities == nil {
+		return &clientCapabilitiesWire{}
+	}
+
+	return &clientCapabilitiesWire{
+		Experimental: capabilities.Experimental,
+		Extensions:   capabilities.Extensions,
+		Roots:        capabilities.RootsV2,
+		Sampling:     capabilities.Sampling,
+		Elicitation:  capabilities.Elicitation,
+	}
+}
+
+func clientCapabilitiesFromWire(wire *clientCapabilitiesWire) *mcp.ClientCapabilities {
+	if wire == nil {
+		return &mcp.ClientCapabilities{}
+	}
+
+	return &mcp.ClientCapabilities{
+		Experimental: wire.Experimental,
+		Extensions:   wire.Extensions,
+		RootsV2:      wire.Roots,
+		Sampling:     wire.Sampling,
+		Elicitation:  wire.Elicitation,
+	}
 }
 
 func buildDownstreamClientState(protocolVersion string, capabilities *mcp.ClientCapabilities, roots []*mcp.Root) *DownstreamClientState {

--- a/internal/proxy/downstream_client_state.go
+++ b/internal/proxy/downstream_client_state.go
@@ -77,6 +77,11 @@ func cloneClientCapabilities(capabilities *mcp.ClientCapabilities) *mcp.ClientCa
 	if err := json.Unmarshal(encoded, &cloned); err != nil {
 		return &mcp.ClientCapabilities{}
 	}
+	if capabilities.RootsV2 != nil {
+		rootsV2 := *capabilities.RootsV2
+		cloned.RootsV2 = &rootsV2
+		cloned.Roots.ListChanged = rootsV2.ListChanged
+	}
 	return &cloned
 }
 

--- a/internal/proxy/downstream_client_state_test.go
+++ b/internal/proxy/downstream_client_state_test.go
@@ -24,6 +24,20 @@ func TestFingerprintClientCapabilitiesDeterministic(t *testing.T) {
 	assert.Equal(t, fingerprintClientCapabilities(capabilitiesA), fingerprintClientCapabilities(capabilitiesB))
 }
 
+func TestCloneClientCapabilitiesPreservesRootsV2(t *testing.T) {
+	capabilities := &mcp.ClientCapabilities{
+		RootsV2: &mcp.RootCapabilities{ListChanged: true},
+	}
+
+	cloned := cloneClientCapabilities(capabilities)
+
+	assert.Assert(t, cloned != nil)
+	assert.Assert(t, cloned.RootsV2 != nil)
+	assert.Assert(t, cloned.RootsV2 != capabilities.RootsV2)
+	assert.Equal(t, cloned.RootsV2.ListChanged, true)
+	assert.Equal(t, cloned.Roots.ListChanged, true)
+}
+
 func TestFingerprintRootsDeterministic(t *testing.T) {
 	rootsA := []*mcp.Root{
 		{Name: "b", URI: "file://b"},

--- a/internal/proxy/downstream_client_state_test.go
+++ b/internal/proxy/downstream_client_state_test.go
@@ -35,7 +35,6 @@ func TestCloneClientCapabilitiesPreservesRootsV2(t *testing.T) {
 	assert.Assert(t, cloned.RootsV2 != nil)
 	assert.Assert(t, cloned.RootsV2 != capabilities.RootsV2)
 	assert.Equal(t, cloned.RootsV2.ListChanged, true)
-	assert.Equal(t, cloned.Roots.ListChanged, true)
 }
 
 func TestFingerprintRootsDeterministic(t *testing.T) {

--- a/internal/proxy/downstream_connection.go
+++ b/internal/proxy/downstream_connection.go
@@ -291,6 +291,11 @@ func (dc *DownstreamConnection) discoverTools(ctx context.Context) error {
 	return nil
 }
 
+// discoverResources and discoverPrompts are the internal (lock-unsafe) variants of
+// DiscoverResources and DiscoverPrompts. They must only be called by code that already
+// holds dc.mu for writing (e.g. during Connect or SyncClientState).
+// The exported DiscoverResources/DiscoverPrompts are the pool-facing public API that
+// acquire the lock themselves and are safe to call concurrently from outside this struct.
 func (dc *DownstreamConnection) discoverResources(ctx context.Context) error {
 	result, err := dc.session.ListResources(ctx, nil)
 	if err != nil {

--- a/internal/proxy/downstream_connection.go
+++ b/internal/proxy/downstream_connection.go
@@ -59,6 +59,8 @@ type DownstreamConnection struct {
 	client     *mcp.Client
 	session    *mcp.ClientSession
 	tools      []*mcp.Tool
+	resources  []*mcp.Resource
+	prompts    []*mcp.Prompt
 	mu         sync.RWMutex
 
 	clientState DownstreamClientState
@@ -287,6 +289,115 @@ func (dc *DownstreamConnection) discoverTools(ctx context.Context) error {
 	}
 	dc.tools = result.Tools
 	return nil
+}
+
+func (dc *DownstreamConnection) discoverResources(ctx context.Context) error {
+	result, err := dc.session.ListResources(ctx, nil)
+	if err != nil {
+		return err
+	}
+	dc.resources = result.Resources
+	return nil
+}
+
+func (dc *DownstreamConnection) discoverPrompts(ctx context.Context) error {
+	result, err := dc.session.ListPrompts(ctx, nil)
+	if err != nil {
+		return err
+	}
+	dc.prompts = result.Prompts
+	return nil
+}
+
+// DiscoverResources fetches and caches the resource list from the downstream server.
+// Safe to call after Connect returns; acquires the write lock for the duration of the RPC.
+func (dc *DownstreamConnection) DiscoverResources(ctx context.Context) error {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.session == nil {
+		return nil
+	}
+	return dc.discoverResources(ctx)
+}
+
+// DiscoverPrompts fetches and caches the prompt list from the downstream server.
+// Safe to call after Connect returns; acquires the write lock for the duration of the RPC.
+func (dc *DownstreamConnection) DiscoverPrompts(ctx context.Context) error {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.session == nil {
+		return nil
+	}
+	return dc.discoverPrompts(ctx)
+}
+
+// Resources returns the cached resources discovered on connect (nil if not connected or unsupported).
+func (dc *DownstreamConnection) Resources() []*mcp.Resource {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	return dc.resources
+}
+
+// Prompts returns the cached prompts discovered on connect (nil if not connected or unsupported).
+func (dc *DownstreamConnection) Prompts() []*mcp.Prompt {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	return dc.prompts
+}
+
+// ReadResource reads a resource by URI from the downstream server.
+func (dc *DownstreamConnection) ReadResource(ctx context.Context, uri string) (*mcp.ReadResourceResult, error) {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+
+	if !dc.status.IsConnected() || dc.session == nil {
+		return nil, fmt.Errorf("not connected to %s", dc.serverName)
+	}
+	return dc.session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+}
+
+// GetPrompt retrieves a prompt by name from the downstream server.
+func (dc *DownstreamConnection) GetPrompt(ctx context.Context, name string, args map[string]string) (*mcp.GetPromptResult, error) {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+
+	if !dc.status.IsConnected() || dc.session == nil {
+		return nil, fmt.Errorf("not connected to %s", dc.serverName)
+	}
+	return dc.session.GetPrompt(ctx, &mcp.GetPromptParams{Name: name, Arguments: args})
+}
+
+// Complete forwards a completion request to the downstream server.
+func (dc *DownstreamConnection) Complete(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+
+	if !dc.status.IsConnected() || dc.session == nil {
+		return nil, fmt.Errorf("not connected to %s", dc.serverName)
+	}
+	return dc.session.Complete(ctx, req.Params)
+}
+
+// Subscribe requests resource update notifications for the given URI from the downstream server.
+func (dc *DownstreamConnection) Subscribe(ctx context.Context, uri string) error {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+
+	if !dc.status.IsConnected() || dc.session == nil {
+		return fmt.Errorf("not connected to %s", dc.serverName)
+	}
+	return dc.session.Subscribe(ctx, &mcp.SubscribeParams{URI: uri})
+}
+
+// Unsubscribe cancels resource update notifications for the given URI from the downstream server.
+func (dc *DownstreamConnection) Unsubscribe(ctx context.Context, uri string) error {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+
+	if !dc.status.IsConnected() || dc.session == nil {
+		return fmt.Errorf("not connected to %s", dc.serverName)
+	}
+	return dc.session.Unsubscribe(ctx, &mcp.UnsubscribeParams{URI: uri})
 }
 
 // CallTool forwards a tool call to the downstream server.

--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -13,6 +13,8 @@ type MockDownstreamConnection struct {
 	mu           sync.RWMutex
 	serverName   string
 	tools        []*mcp.Tool
+	resources    []*mcp.Resource
+	prompts      []*mcp.Prompt
 	cfg          *config.MCPServerConfig
 	ConnectCalls int
 	CloseCalls   int
@@ -129,11 +131,15 @@ func (m *MockDownstreamConnection) GetConfig() *config.MCPServerConfig {
 }
 
 func (m *MockDownstreamConnection) Resources() []*mcp.Resource {
-	return nil
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.resources
 }
 
 func (m *MockDownstreamConnection) Prompts() []*mcp.Prompt {
-	return nil
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.prompts
 }
 
 func (m *MockDownstreamConnection) DiscoverResources(_ context.Context) error {

--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -128,6 +128,42 @@ func (m *MockDownstreamConnection) GetConfig() *config.MCPServerConfig {
 	return m.cfg
 }
 
+func (m *MockDownstreamConnection) Resources() []*mcp.Resource {
+	return nil
+}
+
+func (m *MockDownstreamConnection) Prompts() []*mcp.Prompt {
+	return nil
+}
+
+func (m *MockDownstreamConnection) DiscoverResources(_ context.Context) error {
+	return nil
+}
+
+func (m *MockDownstreamConnection) DiscoverPrompts(_ context.Context) error {
+	return nil
+}
+
+func (m *MockDownstreamConnection) ReadResource(_ context.Context, _ string) (*mcp.ReadResourceResult, error) {
+	return nil, nil
+}
+
+func (m *MockDownstreamConnection) GetPrompt(_ context.Context, _ string, _ map[string]string) (*mcp.GetPromptResult, error) {
+	return nil, nil
+}
+
+func (m *MockDownstreamConnection) Complete(_ context.Context, _ *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+	return nil, nil
+}
+
+func (m *MockDownstreamConnection) Subscribe(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *MockDownstreamConnection) Unsubscribe(_ context.Context, _ string) error {
+	return nil
+}
+
 func (m *MockDownstreamConnection) SyncClientState(_ context.Context, state *DownstreamClientState) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -145,15 +145,15 @@ func (m *MockDownstreamConnection) DiscoverPrompts(_ context.Context) error {
 }
 
 func (m *MockDownstreamConnection) ReadResource(_ context.Context, _ string) (*mcp.ReadResourceResult, error) {
-	return nil, nil
+	return &mcp.ReadResourceResult{}, nil
 }
 
 func (m *MockDownstreamConnection) GetPrompt(_ context.Context, _ string, _ map[string]string) (*mcp.GetPromptResult, error) {
-	return nil, nil
+	return &mcp.GetPromptResult{}, nil
 }
 
 func (m *MockDownstreamConnection) Complete(_ context.Context, _ *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
-	return nil, nil
+	return &mcp.CompleteResult{}, nil
 }
 
 func (m *MockDownstreamConnection) Subscribe(_ context.Context, _ string) error {

--- a/internal/proxy/interfaces.go
+++ b/internal/proxy/interfaces.go
@@ -27,6 +27,15 @@ type DownstreamConnectionInterface interface {
 	IsFailed() bool
 	IsPending() bool
 	Tools() []*mcp.Tool
+	Resources() []*mcp.Resource
+	Prompts() []*mcp.Prompt
+	DiscoverResources(ctx context.Context) error
+	DiscoverPrompts(ctx context.Context) error
+	ReadResource(ctx context.Context, uri string) (*mcp.ReadResourceResult, error)
+	GetPrompt(ctx context.Context, name string, args map[string]string) (*mcp.GetPromptResult, error)
+	Complete(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error)
+	Subscribe(ctx context.Context, uri string) error
+	Unsubscribe(ctx context.Context, uri string) error
 	Close() error
 	GetConfig() *config.MCPServerConfig
 	GetStatus() ConnectionStatus

--- a/internal/proxy/proxy_downstream_pool.go
+++ b/internal/proxy/proxy_downstream_pool.go
@@ -177,11 +177,21 @@ func (p *CentianEndpoint) connectDownstreamPool(
 	}
 	p.mu.Unlock()
 
+	if err := conn.DiscoverResources(context.Background()); err != nil {
+		common.LogWarn("ProxyEndpoint[%s]: resource discovery failed for %s: %v", p.name, sanitizeLogValue(serverName), err)
+	}
+	if err := conn.DiscoverPrompts(context.Background()); err != nil {
+		common.LogWarn("ProxyEndpoint[%s]: prompt discovery failed for %s: %v", p.name, sanitizeLogValue(serverName), err)
+	}
+
 	p.toolRegMu.Lock()
 	for _, session := range sessions {
 		p.syncAvailableTools(session)
+		p.syncAvailableResources(session)
+		p.syncAvailablePrompts(session)
 	}
 	p.toolRegMu.Unlock()
 
-	common.LogInfo("ProxyEndpoint[%s]: connected pooled downstream %s with %d tools", p.name, sanitizeLogValue(serverName), len(conn.Tools()))
+	common.LogInfo("ProxyEndpoint[%s]: connected pooled downstream %s with %d tools, %d resources, %d prompts",
+		p.name, sanitizeLogValue(serverName), len(conn.Tools()), len(conn.Resources()), len(conn.Prompts()))
 }

--- a/internal/proxy/proxy_http.go
+++ b/internal/proxy/proxy_http.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -89,7 +88,7 @@ func (p *CentianEndpoint) observeMCPRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			if sseSessionID := r.Header.Get("Mcp-Session-Id"); sseSessionID != "" {
-				go p.bootstrapUpstreamSessionState(context.Background(), sseSessionID)
+				go p.bootstrapUpstreamSessionState(r.Context(), sseSessionID)
 			}
 			next.ServeHTTP(w, r)
 			return

--- a/internal/proxy/proxy_http.go
+++ b/internal/proxy/proxy_http.go
@@ -88,6 +88,15 @@ func (p *CentianEndpoint) observeMCPRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			if sseSessionID := r.Header.Get("Mcp-Session-Id"); sseSessionID != "" {
+				// bootstrapUpstreamSessionState runs asynchronously to resolve the
+				// initial roots list before the first downstream pool is established.
+				// There is a known window between this goroutine being spawned and
+				// bootstrap completing during which incoming requests are served with
+				// an un-bootstrapped session (no roots, no resources, no prompts).
+				// This is acceptable because the MCP client is expected to retry
+				// after the SSE stream is open; however, callers that depend on
+				// immediate availability of roots-dependent resources should wait for
+				// the bootstrap to complete on the client side.
 				go p.bootstrapUpstreamSessionState(r.Context(), sseSessionID)
 			}
 			next.ServeHTTP(w, r)

--- a/internal/proxy/proxy_http.go
+++ b/internal/proxy/proxy_http.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -86,6 +87,14 @@ func writeDelayedResponse(target http.ResponseWriter, source *delayedResponseWri
 
 func (p *CentianEndpoint) observeMCPRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			if sseSessionID := r.Header.Get("Mcp-Session-Id"); sseSessionID != "" {
+				go p.bootstrapUpstreamSessionState(context.Background(), sseSessionID)
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		observation := inspectMCPRequest(r)
 		responseWriter := w
 		var delayedWriter *delayedResponseWriter

--- a/internal/proxy/proxy_prompts.go
+++ b/internal/proxy/proxy_prompts.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// This file registers upstream prompt surfaces and routes proxied prompt
+// requests to downstream servers. It mirrors the pattern in proxy_tools.go.
+
+// syncAvailablePrompts reconciles the upstream server's registered prompts
+// against the set currently available from connected downstream servers.
+//
+// The collection step (building desiredPrompts) is deliberately separate from
+// the registration step so that a future capability-filtering processor can be
+// inserted between them (e.g. to redact prompts based on policy before
+// advertising them to upstream clients).
+func (p *CentianEndpoint) syncAvailablePrompts(session *UpstreamSession) {
+	if session == nil || session.upstreamServer == nil {
+		return
+	}
+	if session.registeredPrompts == nil {
+		session.registeredPrompts = make(map[string]struct{})
+	}
+
+	// --- Collection step ---
+	type promptEntry struct {
+		prompt     *mcp.Prompt
+		serverName string
+	}
+	desiredPrompts := make(map[string]promptEntry) // keyed by upstream prompt name
+	for serverName, conn := range session.downstreamConns {
+		if !conn.IsConnected() {
+			continue
+		}
+		for _, prompt := range conn.Prompts() {
+			if prompt == nil {
+				continue
+			}
+			upstreamName := prompt.Name
+			if p.isAggregatedProxy {
+				upstreamName = fmt.Sprintf("%s%s%s", serverName, NamespaceSeparator, prompt.Name)
+			}
+			desiredPrompts[upstreamName] = promptEntry{prompt: prompt, serverName: serverName}
+		}
+	}
+
+	// --- Registration step (future hook point for capability filtering) ---
+
+	staleNames := make([]string, 0)
+	for name := range session.registeredPrompts {
+		if _, ok := desiredPrompts[name]; !ok {
+			staleNames = append(staleNames, name)
+		}
+	}
+	if len(staleNames) > 0 {
+		session.upstreamServer.RemovePrompts(staleNames...)
+		for _, name := range staleNames {
+			delete(session.registeredPrompts, name)
+		}
+	}
+
+	for upstreamName, entry := range desiredPrompts {
+		if _, ok := session.registeredPrompts[upstreamName]; ok {
+			continue
+		}
+		p.registerPrompt(session, entry.serverName, entry.prompt, upstreamName)
+	}
+}
+
+// registerPrompt adds a single downstream prompt to the upstream-facing server.
+func (p *CentianEndpoint) registerPrompt(session *UpstreamSession, serverName string, prompt *mcp.Prompt, upstreamName string) {
+	if session.registeredPrompts == nil {
+		session.registeredPrompts = make(map[string]struct{})
+	}
+	if _, exists := session.registeredPrompts[upstreamName]; exists {
+		return
+	}
+	session.registeredPrompts[upstreamName] = struct{}{}
+
+	clonedPrompt := &mcp.Prompt{
+		Name:        upstreamName,
+		Description: prompt.Description,
+		Arguments:   prompt.Arguments,
+	}
+	if p.isAggregatedProxy {
+		clonedPrompt.Description = fmt.Sprintf("[%s] %s", serverName, prompt.Description)
+	}
+
+	downstreamName := prompt.Name
+	session.upstreamServer.AddPrompt(clonedPrompt, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return p.forwardGetPrompt(ctx, session, serverName, downstreamName, req)
+	})
+}
+
+// registerAvailablePrompts acquires the necessary locks and calls syncAvailablePrompts.
+func (p *CentianEndpoint) registerAvailablePrompts(session *UpstreamSession) {
+	if session == nil {
+		return
+	}
+
+	p.mu.RLock()
+	pool := p.downstreamPools[session.downstreamSessionKey]
+	p.mu.RUnlock()
+
+	if pool == nil {
+		return
+	}
+
+	p.toolRegMu.Lock()
+	p.syncAvailablePrompts(session)
+	p.toolRegMu.Unlock()
+}
+
+// forwardGetPrompt retrieves a prompt from the named downstream server.
+func (p *CentianEndpoint) forwardGetPrompt(ctx context.Context, session *UpstreamSession, serverName string, downstreamName string, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	conn, err := session.GetConnectionByServerName(serverName)
+	if err != nil {
+		return nil, fmt.Errorf("prompt %q: %w", downstreamName, err)
+	}
+	return conn.GetPrompt(ctx, downstreamName, req.Params.Arguments)
+}

--- a/internal/proxy/proxy_prompts.go
+++ b/internal/proxy/proxy_prompts.go
@@ -115,7 +115,7 @@ func (p *CentianEndpoint) registerAvailablePrompts(session *UpstreamSession) {
 }
 
 // forwardGetPrompt retrieves a prompt from the named downstream server.
-func (p *CentianEndpoint) forwardGetPrompt(ctx context.Context, session *UpstreamSession, serverName string, downstreamName string, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+func (p *CentianEndpoint) forwardGetPrompt(ctx context.Context, session *UpstreamSession, serverName, downstreamName string, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 	conn, err := session.GetConnectionByServerName(serverName)
 	if err != nil {
 		return nil, fmt.Errorf("prompt %q: %w", downstreamName, err)

--- a/internal/proxy/proxy_resources.go
+++ b/internal/proxy/proxy_resources.go
@@ -1,0 +1,162 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/T4cceptor/centian/internal/common"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// This file registers upstream resource surfaces and routes proxied resource
+// requests to downstream servers. It mirrors the pattern in proxy_tools.go.
+
+// syncAvailableResources reconciles the upstream server's registered resources
+// against the set currently available from connected downstream servers.
+//
+// The collection step (building desiredResources) is deliberately separate from
+// the registration step so that a future capability-filtering processor can be
+// inserted between them (e.g. to redact resources based on policy before
+// advertising them to upstream clients).
+func (p *CentianEndpoint) syncAvailableResources(session *UpstreamSession) {
+	if session == nil || session.upstreamServer == nil {
+		return
+	}
+	if session.registeredResources == nil {
+		session.registeredResources = make(map[string]struct{})
+	}
+
+	// --- Collection step ---
+	type resourceEntry struct {
+		resource   *mcp.Resource
+		serverName string
+	}
+	desiredResources := make(map[string]resourceEntry) // keyed by URI
+	for serverName, conn := range session.downstreamConns {
+		if !conn.IsConnected() {
+			continue
+		}
+		for _, resource := range conn.Resources() {
+			if resource == nil {
+				continue
+			}
+			// Edge case: if multiple downstreams expose the same URI in an aggregated
+			// proxy, the last one wins. URI namespacing across downstreams is not yet
+			// implemented; callers should be aware of this limitation.
+			desiredResources[resource.URI] = resourceEntry{resource: resource, serverName: serverName}
+		}
+	}
+
+	// --- Registration step (future hook point for capability filtering) ---
+
+	staleURIs := make([]string, 0)
+	for uri := range session.registeredResources {
+		if _, ok := desiredResources[uri]; !ok {
+			staleURIs = append(staleURIs, uri)
+		}
+	}
+	if len(staleURIs) > 0 {
+		session.upstreamServer.RemoveResources(staleURIs...)
+		for _, uri := range staleURIs {
+			delete(session.registeredResources, uri)
+		}
+	}
+
+	for uri, entry := range desiredResources {
+		if _, ok := session.registeredResources[uri]; ok {
+			continue
+		}
+		p.registerResource(session, entry.serverName, entry.resource)
+	}
+}
+
+// registerResource adds a single downstream resource to the upstream-facing server.
+func (p *CentianEndpoint) registerResource(session *UpstreamSession, serverName string, resource *mcp.Resource) {
+	if session.registeredResources == nil {
+		session.registeredResources = make(map[string]struct{})
+	}
+	if _, exists := session.registeredResources[resource.URI]; exists {
+		return
+	}
+	session.registeredResources[resource.URI] = struct{}{}
+
+	uri := resource.URI
+	session.upstreamServer.AddResource(resource, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return p.forwardReadResource(ctx, session, serverName, uri)
+	})
+}
+
+// registerAvailableResources acquires the necessary locks and calls syncAvailableResources.
+func (p *CentianEndpoint) registerAvailableResources(session *UpstreamSession) {
+	if session == nil {
+		return
+	}
+
+	p.mu.RLock()
+	pool := p.downstreamPools[session.downstreamSessionKey]
+	p.mu.RUnlock()
+
+	if pool == nil {
+		return
+	}
+
+	p.toolRegMu.Lock()
+	p.syncAvailableResources(session)
+	p.toolRegMu.Unlock()
+}
+
+// forwardReadResource reads a resource from the named downstream server.
+func (p *CentianEndpoint) forwardReadResource(ctx context.Context, session *UpstreamSession, serverName string, uri string) (*mcp.ReadResourceResult, error) {
+	conn, err := session.GetConnectionByServerName(serverName)
+	if err != nil {
+		return nil, fmt.Errorf("resource %q: %w", uri, err)
+	}
+	return conn.ReadResource(ctx, uri)
+}
+
+// forwardSubscribe forwards a resource subscription request to the downstream that owns the URI.
+func (p *CentianEndpoint) forwardSubscribe(ctx context.Context, session *UpstreamSession, req *mcp.SubscribeRequest) error {
+	uri := req.Params.URI
+	conn := p.findConnectionForResourceURI(session, uri)
+	if conn == nil {
+		return fmt.Errorf("no downstream connection found for resource URI %q", uri)
+	}
+	return conn.Subscribe(ctx, uri)
+}
+
+// forwardUnsubscribe forwards a resource unsubscription request to the downstream that owns the URI.
+func (p *CentianEndpoint) forwardUnsubscribe(ctx context.Context, session *UpstreamSession, req *mcp.UnsubscribeRequest) error {
+	uri := req.Params.URI
+	conn := p.findConnectionForResourceURI(session, uri)
+	if conn == nil {
+		return fmt.Errorf("no downstream connection found for resource URI %q", uri)
+	}
+	return conn.Unsubscribe(ctx, uri)
+}
+
+// forwardCompletion forwards a completion request to the first connected downstream.
+// Completions are not resource-specific, so any capable downstream can handle them.
+func (p *CentianEndpoint) forwardCompletion(ctx context.Context, session *UpstreamSession, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+	for _, conn := range session.downstreamConns {
+		if conn.IsConnected() {
+			return conn.Complete(ctx, req)
+		}
+	}
+	return nil, fmt.Errorf("no downstream connection available for completion request")
+}
+
+// findConnectionForResourceURI returns the first connected downstream that advertises the given URI.
+func (p *CentianEndpoint) findConnectionForResourceURI(session *UpstreamSession, uri string) DownstreamConnectionInterface {
+	for _, conn := range session.downstreamConns {
+		if !conn.IsConnected() {
+			continue
+		}
+		for _, resource := range conn.Resources() {
+			if resource != nil && resource.URI == uri {
+				return conn
+			}
+		}
+	}
+	common.LogWarn("ProxyEndpoint[%s]: no downstream found for resource URI %q", p.name, uri)
+	return nil
+}

--- a/internal/proxy/proxy_resources.go
+++ b/internal/proxy/proxy_resources.go
@@ -106,7 +106,7 @@ func (p *CentianEndpoint) registerAvailableResources(session *UpstreamSession) {
 }
 
 // forwardReadResource reads a resource from the named downstream server.
-func (p *CentianEndpoint) forwardReadResource(ctx context.Context, session *UpstreamSession, serverName string, uri string) (*mcp.ReadResourceResult, error) {
+func (p *CentianEndpoint) forwardReadResource(ctx context.Context, session *UpstreamSession, serverName, uri string) (*mcp.ReadResourceResult, error) {
 	conn, err := session.GetConnectionByServerName(serverName)
 	if err != nil {
 		return nil, fmt.Errorf("resource %q: %w", uri, err)

--- a/internal/proxy/proxy_resources_test.go
+++ b/internal/proxy/proxy_resources_test.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gotest.tools/assert"
+)
+
+// TestFindConnectionForResourceURI_DuplicateURIAcrossServers verifies the documented
+// "first match wins" behaviour when the same resource URI is advertised by more than
+// one downstream server.
+func TestFindConnectionForResourceURI_DuplicateURIAcrossServers(t *testing.T) {
+	const sharedURI = "file:///shared/resource"
+
+	// Given: two connected downstream servers that both advertise the same resource URI
+	connA := &MockDownstreamConnection{
+		serverName: "server-a",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: sharedURI, Name: "resource-on-a"},
+		},
+	}
+	connB := &MockDownstreamConnection{
+		serverName: "server-b",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: sharedURI, Name: "resource-on-b"},
+		},
+	}
+
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id: "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": connA,
+			"server-b": connB,
+		},
+	}
+
+	// When: looking up the connection for the shared URI
+	found := proxy.findConnectionForResourceURI(session, sharedURI)
+
+	// Then: exactly one connection is returned (first match in iteration order) –
+	// the caller must be aware that URI uniqueness across downstreams is not enforced.
+	assert.Assert(t, found != nil, "expected a connection to be found for the shared URI")
+	assert.Assert(t,
+		found.GetServerName() == "server-a" || found.GetServerName() == "server-b",
+		"returned connection should belong to one of the two servers",
+	)
+}
+
+// TestFindConnectionForResourceURI_ReturnsNilForUnknownURI verifies that nil is
+// returned when no downstream server advertises the requested URI.
+func TestFindConnectionForResourceURI_ReturnsNilForUnknownURI(t *testing.T) {
+	// Given: a connected downstream server with a different resource URI
+	conn := &MockDownstreamConnection{
+		serverName: "server-a",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: "file:///other/resource"},
+		},
+	}
+
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id: "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": conn,
+		},
+	}
+
+	// When: looking up an unknown URI
+	found := proxy.findConnectionForResourceURI(session, "file:///unknown/resource")
+
+	// Then: nil is returned
+	assert.Assert(t, found == nil)
+}
+
+// TestSyncAvailableResources_DuplicateURILastServerWins verifies that when two
+// downstream servers expose the same URI, syncAvailableResources registers the
+// resource exactly once (last-one-wins during collection) without panicking.
+func TestSyncAvailableResources_DuplicateURILastServerWins(t *testing.T) {
+	const sharedURI = "file:///shared/resource"
+
+	// Given: two connected servers that both expose the same resource URI
+	connA := &MockDownstreamConnection{
+		serverName: "server-a",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: sharedURI, Name: "resource-on-a"},
+		},
+	}
+	connB := &MockDownstreamConnection{
+		serverName: "server-b",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: sharedURI, Name: "resource-on-b"},
+		},
+	}
+
+	proxy := &CentianEndpoint{name: "test"}
+	upstreamServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, &mcp.ServerOptions{
+		HasResources: true,
+	})
+	session := &UpstreamSession{
+		id:                  "session-1",
+		upstreamServer:      upstreamServer,
+		registeredResources: make(map[string]struct{}),
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": connA,
+			"server-b": connB,
+		},
+	}
+
+	// When: syncing available resources
+	proxy.syncAvailableResources(session)
+
+	// Then: the shared URI is registered exactly once
+	assert.Equal(t, len(session.registeredResources), 1,
+		"duplicate URI should be collapsed to a single registration")
+	_, registered := session.registeredResources[sharedURI]
+	assert.Assert(t, registered, "the shared URI must appear in registeredResources")
+}

--- a/internal/proxy/proxy_sessions.go
+++ b/internal/proxy/proxy_sessions.go
@@ -13,6 +13,11 @@ import (
 // This file manages upstream session lifecycle, captured client state, and
 // downstream pool reconciliation.
 
+const (
+	initialRootsBootstrapTimeout  = 2 * time.Second
+	initialRootsBootstrapInterval = 25 * time.Millisecond
+)
+
 // downstreamPoolUpdate describes the side effects needed after pool reconciliation.
 type downstreamPoolUpdate struct {
 	pool         *DownstreamSessionPool
@@ -144,6 +149,23 @@ func (p *CentianEndpoint) syncUpstreamSessionState(ctx context.Context, sessionI
 	p.finalizeDownstreamPoolUpdate(ctx, session, update)
 }
 
+// bootstrapUpstreamSessionState retries the initial roots-dependent sync until
+// the first downstream pool can be established or the timeout is hit.
+func (p *CentianEndpoint) bootstrapUpstreamSessionState(ctx context.Context, sessionID string) {
+	deadline := time.Now().Add(initialRootsBootstrapTimeout)
+	for {
+		p.syncUpstreamSessionState(ctx, sessionID)
+		if !p.sessionNeedsInitialRootsBootstrap(sessionID) || time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(initialRootsBootstrapInterval):
+		}
+	}
+}
+
 // capturedUpstreamClientState is the upstream-facing client state observed from the SDK session.
 type capturedUpstreamClientState struct {
 	protocolVersion string
@@ -229,16 +251,20 @@ func (p *CentianEndpoint) fetchUpstreamRoots(ctx context.Context, session *Upstr
 
 // syncUpstreamSessionToDownstreamState copies mirrored downstream-facing client state onto the upstream session.
 func (p *CentianEndpoint) syncUpstreamSessionToDownstreamState(session *UpstreamSession, state *DownstreamClientState) {
-	session.protocolVersion = state.ProtocolVersion
-	session.clientCapabilities = state.ClientCapabilities
-	session.capabilitiesFingerprint = state.CapabilitiesFingerprint
-	session.roots = normalizeRoots(state.Roots)
-	session.rootsFingerprint = state.RootsFingerprint
+	p.storeMirroredClientState(session, state)
 	session.downstreamSessionKey = p.buildDownstreamSessionKey(
 		session.identityKey,
 		session.GetAuthHeaders(p.excludedClientAuthHeader()),
 		state,
 	)
+}
+
+func (p *CentianEndpoint) storeMirroredClientState(session *UpstreamSession, state *DownstreamClientState) {
+	session.protocolVersion = state.ProtocolVersion
+	session.clientCapabilities = state.ClientCapabilities
+	session.capabilitiesFingerprint = state.CapabilitiesFingerprint
+	session.roots = normalizeRoots(state.Roots)
+	session.rootsFingerprint = state.RootsFingerprint
 }
 
 // applyClientStateLocked stores mirrored client state on the session and plans any required pool transition.
@@ -259,6 +285,13 @@ func (p *CentianEndpoint) applyClientStateLocked(
 
 	// Persist the newly mirrored client state before making any pool decision.
 	// The downstream session key is derived from this snapshot.
+	if previousKey == "" && rootsDirty && clientSupportsRoots(state.ClientCapabilities) {
+		p.storeMirroredClientState(session, state)
+		session.downstreamSessionKey = ""
+		session.rootsDirty = true
+		return downstreamPoolUpdate{}
+	}
+
 	p.syncUpstreamSessionToDownstreamState(session, state)
 	session.rootsDirty = rootsDirty
 	if session.downstreamSessionKey == "" {
@@ -328,6 +361,19 @@ func (p *CentianEndpoint) applyClientStateLocked(
 		closePool:    closePool,
 		waitForReady: !reused,
 	}
+}
+
+func (p *CentianEndpoint) sessionNeedsInitialRootsBootstrap(sessionID string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	session := p.upstreamSessions[sessionID]
+	if session == nil {
+		return false
+	}
+	return session.downstreamSessionKey == "" &&
+		session.rootsDirty &&
+		clientSupportsRoots(session.clientCapabilities)
 }
 
 // finalizeDownstreamPoolUpdate executes the pool actions planned during reconciliation outside the mutex.

--- a/internal/proxy/proxy_sessions.go
+++ b/internal/proxy/proxy_sessions.go
@@ -55,7 +55,7 @@ func (p *CentianEndpoint) GetOrCreateServerForRequest(r *http.Request) *mcp.Serv
 	session, exists := p.upstreamSessions[sessionID]
 	if !exists {
 		session = p.createUpstreamSession(sessionID, r, identityKey)
-		session.upstreamServer = p.newUpstreamServer(sessionID)
+		session.upstreamServer = p.newUpstreamServer(session)
 		p.upstreamSessions[sessionID] = session
 		return session.upstreamServer
 	}
@@ -80,13 +80,15 @@ func (p *CentianEndpoint) createUpstreamSession(id string, r *http.Request, iden
 		clientHeaders = r.Header.Clone()
 	}
 	return &UpstreamSession{
-		id:              id,
-		downstreamConns: make(map[string]DownstreamConnectionInterface),
-		registeredTools: make(map[string]struct{}),
-		clientHeaders:   clientHeaders,
-		identityKey:     identityKey,
-		authData:        authData.Clone(),
-		rootsDirty:      true,
+		id:                  id,
+		downstreamConns:     make(map[string]DownstreamConnectionInterface),
+		registeredTools:     make(map[string]struct{}),
+		registeredResources: make(map[string]struct{}),
+		registeredPrompts:   make(map[string]struct{}),
+		clientHeaders:       clientHeaders,
+		identityKey:         identityKey,
+		authData:            authData.Clone(),
+		rootsDirty:          true,
 	}
 }
 
@@ -343,6 +345,8 @@ func (p *CentianEndpoint) finalizeDownstreamPoolUpdate(ctx context.Context, sess
 		p.waitForFirstUsableDownstream(update.pool, initialDownstreamReadyWait)
 	}
 	p.registerAvailableTools(session)
+	p.registerAvailableResources(session)
+	p.registerAvailablePrompts(session)
 }
 
 // syncPoolClientState pushes mirrored client state changes into every downstream connection in the pool.

--- a/internal/proxy/proxy_sessions.go
+++ b/internal/proxy/proxy_sessions.go
@@ -285,13 +285,6 @@ func (p *CentianEndpoint) applyClientStateLocked(
 
 	// Persist the newly mirrored client state before making any pool decision.
 	// The downstream session key is derived from this snapshot.
-	if previousKey == "" && rootsDirty && clientSupportsRoots(state.ClientCapabilities) {
-		p.storeMirroredClientState(session, state)
-		session.downstreamSessionKey = ""
-		session.rootsDirty = true
-		return downstreamPoolUpdate{}
-	}
-
 	p.syncUpstreamSessionToDownstreamState(session, state)
 	session.rootsDirty = rootsDirty
 	if session.downstreamSessionKey == "" {
@@ -371,8 +364,7 @@ func (p *CentianEndpoint) sessionNeedsInitialRootsBootstrap(sessionID string) bo
 	if session == nil {
 		return false
 	}
-	return session.downstreamSessionKey == "" &&
-		session.rootsDirty &&
+	return session.rootsDirty &&
 		clientSupportsRoots(session.clientCapabilities)
 }
 

--- a/internal/proxy/proxy_sessions_test.go
+++ b/internal/proxy/proxy_sessions_test.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"context"
 	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -10,35 +12,25 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestApplyClientStateLockedDefersInitialPoolUntilRootsResolve(t *testing.T) {
-	proxy := NewSingleEndpoint("server-a", "/mcp/server-a", &config.GatewayConfig{
-		MCPServers: map[string]*config.MCPServerConfig{
-			"server-a": {Command: "node"},
-		},
-	})
-	request, err := http.NewRequest(http.MethodPost, "http://example.com/mcp/server-a", http.NoBody)
-	assert.NilError(t, err)
-
-	session := proxy.createUpstreamSession("session-1", request, sharedLocalIdentity)
+func TestSessionNeedsInitialRootsBootstrap(t *testing.T) {
+	proxy := &CentianEndpoint{
+		upstreamSessions: make(map[string]*UpstreamSession),
+	}
+	session := &UpstreamSession{
+		id:                 "session-1",
+		clientCapabilities: &mcp.ClientCapabilities{RootsV2: &mcp.RootCapabilities{ListChanged: true}},
+		rootsDirty:         true,
+	}
 	proxy.upstreamSessions[session.id] = session
 
-	state := buildDownstreamClientState("2025-06-18", &mcp.ClientCapabilities{
-		RootsV2: &mcp.RootCapabilities{ListChanged: true},
-	}, nil)
-
-	proxy.mu.Lock()
-	update := proxy.applyClientStateLocked(session, state, true)
-	proxy.mu.Unlock()
-
-	assert.Assert(t, update.pool == nil)
-	assert.Equal(t, session.downstreamSessionKey, "")
-	assert.Assert(t, session.rootsDirty)
-	assert.Assert(t, clientSupportsRoots(session.clientCapabilities))
 	assert.Assert(t, proxy.sessionNeedsInitialRootsBootstrap(session.id))
 
-	proxy.mu.RLock()
-	assert.Equal(t, len(proxy.downstreamPools), 0)
-	proxy.mu.RUnlock()
+	session.rootsDirty = false
+	assert.Assert(t, !proxy.sessionNeedsInitialRootsBootstrap(session.id))
+
+	session.rootsDirty = true
+	session.clientCapabilities = &mcp.ClientCapabilities{}
+	assert.Assert(t, !proxy.sessionNeedsInitialRootsBootstrap(session.id))
 }
 
 func TestApplyClientStateLockedConnectsWithResolvedRoots(t *testing.T) {
@@ -63,9 +55,10 @@ func TestApplyClientStateLockedConnectsWithResolvedRoots(t *testing.T) {
 	}, nil)
 
 	proxy.mu.Lock()
-	deferred := proxy.applyClientStateLocked(session, initialState, true)
+	initial := proxy.applyClientStateLocked(session, initialState, true)
 	proxy.mu.Unlock()
-	assert.Assert(t, deferred.pool == nil)
+	assert.Assert(t, initial.pool != nil)
+	assert.Assert(t, proxy.sessionNeedsInitialRootsBootstrap(session.id))
 
 	resolvedRoots := []*mcp.Root{{
 		Name: "workspace",
@@ -78,6 +71,7 @@ func TestApplyClientStateLockedConnectsWithResolvedRoots(t *testing.T) {
 	proxy.mu.Lock()
 	update := proxy.applyClientStateLocked(session, resolvedState, false)
 	proxy.mu.Unlock()
+	proxy.finalizeDownstreamPoolUpdate(context.Background(), session, update)
 
 	assert.Assert(t, update.pool != nil)
 	assert.Assert(t, session.downstreamSessionKey != "")
@@ -87,14 +81,19 @@ func TestApplyClientStateLockedConnectsWithResolvedRoots(t *testing.T) {
 	for time.Now().Before(deadline) {
 		mockConn.mu.RLock()
 		connected := mockConn.ConnectCalls > 0
-		roots := []*mcp.Root(nil)
+		foundResolvedRoots := false
 		if connected {
-			roots = normalizeRoots(mockConn.CapturedConnects[0].ClientState.Roots)
+			for _, captured := range mockConn.CapturedConnects {
+				if reflect.DeepEqual(normalizeRoots(captured.ClientState.Roots), normalizeRoots(resolvedRoots)) {
+					foundResolvedRoots = true
+					break
+				}
+			}
 		}
 		mockConn.mu.RUnlock()
 
 		if connected {
-			assert.DeepEqual(t, roots, normalizeRoots(resolvedRoots))
+			assert.Assert(t, foundResolvedRoots)
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/proxy/proxy_sessions_test.go
+++ b/internal/proxy/proxy_sessions_test.go
@@ -1,0 +1,104 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/T4cceptor/centian/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gotest.tools/assert"
+)
+
+func TestApplyClientStateLockedDefersInitialPoolUntilRootsResolve(t *testing.T) {
+	proxy := NewSingleEndpoint("server-a", "/mcp/server-a", &config.GatewayConfig{
+		MCPServers: map[string]*config.MCPServerConfig{
+			"server-a": {Command: "node"},
+		},
+	})
+	request, err := http.NewRequest(http.MethodPost, "http://example.com/mcp/server-a", http.NoBody)
+	assert.NilError(t, err)
+
+	session := proxy.createUpstreamSession("session-1", request, sharedLocalIdentity)
+	proxy.upstreamSessions[session.id] = session
+
+	state := buildDownstreamClientState("2025-06-18", &mcp.ClientCapabilities{
+		RootsV2: &mcp.RootCapabilities{ListChanged: true},
+	}, nil)
+
+	proxy.mu.Lock()
+	update := proxy.applyClientStateLocked(session, state, true)
+	proxy.mu.Unlock()
+
+	assert.Assert(t, update.pool == nil)
+	assert.Equal(t, session.downstreamSessionKey, "")
+	assert.Assert(t, session.rootsDirty)
+	assert.Assert(t, clientSupportsRoots(session.clientCapabilities))
+	assert.Assert(t, proxy.sessionNeedsInitialRootsBootstrap(session.id))
+
+	proxy.mu.RLock()
+	assert.Equal(t, len(proxy.downstreamPools), 0)
+	proxy.mu.RUnlock()
+}
+
+func TestApplyClientStateLockedConnectsWithResolvedRoots(t *testing.T) {
+	proxy := NewSingleEndpoint("server-a", "/mcp/server-a", &config.GatewayConfig{
+		MCPServers: map[string]*config.MCPServerConfig{
+			"server-a": {Command: "node"},
+		},
+	})
+	request, err := http.NewRequest(http.MethodPost, "http://example.com/mcp/server-a", http.NoBody)
+	assert.NilError(t, err)
+
+	session := proxy.createUpstreamSession("session-1", request, sharedLocalIdentity)
+	proxy.upstreamSessions[session.id] = session
+
+	mockConn := &MockDownstreamConnection{serverName: "server-a"}
+	proxy.connectionFactory = func(string, *config.MCPServerConfig) DownstreamConnectionInterface {
+		return mockConn
+	}
+
+	initialState := buildDownstreamClientState("2025-06-18", &mcp.ClientCapabilities{
+		RootsV2: &mcp.RootCapabilities{ListChanged: true},
+	}, nil)
+
+	proxy.mu.Lock()
+	deferred := proxy.applyClientStateLocked(session, initialState, true)
+	proxy.mu.Unlock()
+	assert.Assert(t, deferred.pool == nil)
+
+	resolvedRoots := []*mcp.Root{{
+		Name: "workspace",
+		URI:  "file:///tmp/workspace",
+	}}
+	resolvedState := buildDownstreamClientState("2025-06-18", &mcp.ClientCapabilities{
+		RootsV2: &mcp.RootCapabilities{ListChanged: true},
+	}, resolvedRoots)
+
+	proxy.mu.Lock()
+	update := proxy.applyClientStateLocked(session, resolvedState, false)
+	proxy.mu.Unlock()
+
+	assert.Assert(t, update.pool != nil)
+	assert.Assert(t, session.downstreamSessionKey != "")
+	assert.Assert(t, !proxy.sessionNeedsInitialRootsBootstrap(session.id))
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		mockConn.mu.RLock()
+		connected := mockConn.ConnectCalls > 0
+		roots := []*mcp.Root(nil)
+		if connected {
+			roots = normalizeRoots(mockConn.CapturedConnects[0].ClientState.Roots)
+		}
+		mockConn.mu.RUnlock()
+
+		if connected {
+			assert.DeepEqual(t, roots, normalizeRoots(resolvedRoots))
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("expected downstream connect with resolved roots")
+}

--- a/internal/proxy/proxy_tools.go
+++ b/internal/proxy/proxy_tools.go
@@ -11,8 +11,10 @@ import (
 // This file registers upstream tool surfaces and routes proxied tool calls to
 // downstream servers.
 
-// newUpstreamServer returns a new upstream-facing MCP server.
-func (p *CentianEndpoint) newUpstreamServer(sessionID string) *mcp.Server {
+// newUpstreamServer returns a new upstream-facing MCP server for the given session.
+// The session is captured by the handler closures so that forwarding functions can
+// look up downstream connections at call time.
+func (p *CentianEndpoint) newUpstreamServer(session *UpstreamSession) *mcp.Server {
 	serverName := "centian-proxy-" + p.name
 	if p.isAggregatedProxy {
 		serverName = "centian-gateway-" + p.name
@@ -22,11 +24,29 @@ func (p *CentianEndpoint) newUpstreamServer(sessionID string) *mcp.Server {
 		Name:    serverName,
 		Version: p.server.Config.Version,
 	}, &mcp.ServerOptions{
+		// HasResources and HasPrompts tell the SDK to advertise these surfaces even
+		// before any individual resources or prompts have been registered (they are
+		// registered dynamically after downstream connections are established).
+		HasResources: true,
+		HasPrompts:   true,
 		Capabilities: &mcp.ServerCapabilities{
-			Tools: &mcp.ToolCapabilities{ListChanged: true},
+			Tools:       &mcp.ToolCapabilities{ListChanged: true},
+			Logging:     &mcp.LoggingCapabilities{},
+			Completions: &mcp.CompletionCapabilities{},
+		},
+		// SubscribeHandler non-nil causes the SDK to add resources.subscribe to capabilities.
+		// Both Subscribe and Unsubscribe must be set or unset together.
+		SubscribeHandler: func(ctx context.Context, req *mcp.SubscribeRequest) error {
+			return p.forwardSubscribe(ctx, session, req)
+		},
+		UnsubscribeHandler: func(ctx context.Context, req *mcp.UnsubscribeRequest) error {
+			return p.forwardUnsubscribe(ctx, session, req)
+		},
+		CompletionHandler: func(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+			return p.forwardCompletion(ctx, session, req)
 		},
 		GetSessionID: func() string {
-			return sessionID
+			return session.id
 		},
 	})
 }

--- a/internal/proxy/proxy_tools_test.go
+++ b/internal/proxy/proxy_tools_test.go
@@ -25,12 +25,12 @@ func TestSyncAvailableToolsRemovesStaleTools(t *testing.T) {
 	}
 
 	session := &UpstreamSession{
-		id:                   "session-1",
-		upstreamServer:       proxy.newUpstreamServer("session-1"),
-		registeredTools:      make(map[string]struct{}),
-		downstreamConns:      map[string]DownstreamConnectionInterface{"server-1": downstream},
+		id:              "session-1",
+		registeredTools: make(map[string]struct{}),
+		downstreamConns: map[string]DownstreamConnectionInterface{"server-1": downstream},
 		downstreamSessionKey: "pool-1",
 	}
+	session.upstreamServer = proxy.newUpstreamServer(session)
 
 	proxy.syncAvailableTools(session)
 	assert.Equal(t, len(session.registeredTools), 1)

--- a/internal/proxy/proxy_tools_test.go
+++ b/internal/proxy/proxy_tools_test.go
@@ -25,9 +25,9 @@ func TestSyncAvailableToolsRemovesStaleTools(t *testing.T) {
 	}
 
 	session := &UpstreamSession{
-		id:              "session-1",
-		registeredTools: make(map[string]struct{}),
-		downstreamConns: map[string]DownstreamConnectionInterface{"server-1": downstream},
+		id:                   "session-1",
+		registeredTools:      make(map[string]struct{}),
+		downstreamConns:      map[string]DownstreamConnectionInterface{"server-1": downstream},
 		downstreamSessionKey: "pool-1",
 	}
 	session.upstreamServer = proxy.newUpstreamServer(session)

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -36,9 +36,11 @@ type CentianServer struct {
 type UpstreamSession struct {
 	id string
 
-	upstreamServer  *mcp.Server
-	downstreamConns map[string]DownstreamConnectionInterface
-	registeredTools map[string]struct{}
+	upstreamServer     *mcp.Server
+	downstreamConns    map[string]DownstreamConnectionInterface
+	registeredTools    map[string]struct{}
+	registeredResources map[string]struct{} // keyed by resource URI
+	registeredPrompts   map[string]struct{} // keyed by prompt name
 
 	clientHeaders        http.Header
 	identityKey          string

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -36,9 +36,9 @@ type CentianServer struct {
 type UpstreamSession struct {
 	id string
 
-	upstreamServer     *mcp.Server
-	downstreamConns    map[string]DownstreamConnectionInterface
-	registeredTools    map[string]struct{}
+	upstreamServer      *mcp.Server
+	downstreamConns     map[string]DownstreamConnectionInterface
+	registeredTools     map[string]struct{}
 	registeredResources map[string]struct{} // keyed by resource URI
 	registeredPrompts   map[string]struct{} // keyed by prompt name
 


### PR DESCRIPTION
### Summary

This PR expands Centian’s proxy surface beyond basic tool forwarding and improves how upstream client capabilities are mirrored into downstream MCP sessions.

Centian now forwards prompts, resources, subscriptions, and completions in addition to tools. It also tracks more of the upstream client session state, including capabilities and roots, and uses that state when creating or reusing downstream connections. This fixes capability-dependent gaps that showed up in the `everything` integration suite, including the missing `get-roots-list` tool through the proxy.

### What Changed

- Added prompt discovery, registration, and forwarding through the proxy.
- Added resource discovery, registration, `resources/read`, subscribe/unsubscribe, and completion forwarding.
- Extended downstream connections to track prompts/resources alongside tools and to expose forwarding methods for those protocol surfaces.
- Introduced mirrored downstream client state for:
  - negotiated protocol version
  - client capabilities
  - roots and roots fingerprint
- Updated downstream pool/session reuse logic so pooling decisions include capability and roots state, not just identity/auth.
- Added mutable downstream client-state syncing so an existing pooled connection can be updated when roots change instead of always reconnecting.
- Added HTTP request observation/bootstrap logic so roots-dependent state is refreshed promptly once the streamable HTTP SSE channel is available.
- Fixed client capability cloning so `RootsV2` is preserved correctly when Centian mirrors capabilities downstream.
- Fixed the `get-roots-list` regression from the `everything` MCP tests while avoiding regressions for simpler proxy startup flows.
- Cleaned up proxy tests/mocks and resolved lint issues in the touched proxy code.

### Behavioral Impact

- Proxied MCP servers can now expose prompts and resources, not just tools.
- Downstream sessions are created with a more accurate view of the upstream client.
- Roots-aware downstream behavior is more reliable, especially for servers whose catalog depends on client roots.
- Tool/resource/prompt registration updates are better synchronized with downstream connection state.

### Testing

Validated with targeted proxy unit tests, CLI integration tests, and focused `everything` integration coverage. In particular:
- proxy unit tests for client capability cloning and roots/session syncing
- `TestServerStartIntegration`
- focused `everything` tests covering:
  - initialize + tool listing parity
  - tool catalog parity
  - `tool_call_get-roots-list`
  - expected tool set parity

