### PR TITLE
Add resource and prompt discovery tests with mock support

### DIFF
--- a/internal/proxy/downstream_connection.go
+++ b/internal/proxy/downstream_connection.go
@@ -291,6 +291,11 @@ func (dc *DownstreamConnection) discoverTools(ctx context.Context) error {
 	return nil
 }
 
+// discoverResources and discoverPrompts are the internal (lock-unsafe) variants of
+// DiscoverResources and DiscoverPrompts. They must only be called by code that already
+// holds dc.mu for writing (e.g. during Connect or SyncClientState).
+// The exported DiscoverResources/DiscoverPrompts are the pool-facing public API that
+// acquire the lock themselves and are safe to call concurrently from outside this struct.
 func (dc *DownstreamConnection) discoverResources(ctx context.Context) error {
 	result, err := dc.session.ListResources(ctx, nil)
 	if err != nil {

--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -13,6 +13,8 @@ type MockDownstreamConnection struct {
 	mu           sync.RWMutex
 	serverName   string
 	tools        []*mcp.Tool
+	resources    []*mcp.Resource
+	prompts      []*mcp.Prompt
 	cfg          *config.MCPServerConfig
 	ConnectCalls int
 	CloseCalls   int
@@ -129,11 +131,15 @@ func (m *MockDownstreamConnection) GetConfig() *config.MCPServerConfig {
 }
 
 func (m *MockDownstreamConnection) Resources() []*mcp.Resource {
-	return nil
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.resources
 }
 
 func (m *MockDownstreamConnection) Prompts() []*mcp.Prompt {
-	return nil
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.prompts
 }
 
 func (m *MockDownstreamConnection) DiscoverResources(_ context.Context) error {

--- a/internal/proxy/proxy_http.go
+++ b/internal/proxy/proxy_http.go
@@ -88,6 +88,15 @@ func (p *CentianEndpoint) observeMCPRequests(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			if sseSessionID := r.Header.Get("Mcp-Session-Id"); sseSessionID != "" {
+				// bootstrapUpstreamSessionState runs asynchronously to resolve the
+				// initial roots list before the first downstream pool is established.
+				// There is a known window between this goroutine being spawned and
+				// bootstrap completing during which incoming requests are served with
+				// an un-bootstrapped session (no roots, no resources, no prompts).
+				// This is acceptable because the MCP client is expected to retry
+				// after the SSE stream is open; however, callers that depend on
+				// immediate availability of roots-dependent resources should wait for
+				// the bootstrap to complete on the client side.
 				go p.bootstrapUpstreamSessionState(r.Context(), sseSessionID)
 			}
 			next.ServeHTTP(w, r)

--- a/internal/proxy/proxy_resources_test.go
+++ b/internal/proxy/proxy_resources_test.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gotest.tools/assert"
+)
+
+// TestFindConnectionForResourceURI_DuplicateURIAcrossServers verifies the documented
+// "first match wins" behaviour when the same resource URI is advertised by more than
+// one downstream server.
+func TestFindConnectionForResourceURI_DuplicateURIAcrossServers(t *testing.T) {
+	const sharedURI = "file:///shared/resource"
+
+	// Given: two connected downstream servers that both advertise the same resource URI
+	connA := &MockDownstreamConnection{
+		serverName: "server-a",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: sharedURI, Name: "resource-on-a"},
+		},
+	}
+	connB := &MockDownstreamConnection{
+		serverName: "server-b",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: sharedURI, Name: "resource-on-b"},
+		},
+	}
+
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id: "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": connA,
+			"server-b": connB,
+		},
+	}
+
+	// When: looking up the connection for the shared URI
+	found := proxy.findConnectionForResourceURI(session, sharedURI)
+
+	// Then: exactly one connection is returned (first match in iteration order) –
+	// the caller must be aware that URI uniqueness across downstreams is not enforced.
+	assert.Assert(t, found != nil, "expected a connection to be found for the shared URI")
+	assert.Assert(t,
+		found.GetServerName() == "server-a" || found.GetServerName() == "server-b",
+		"returned connection should belong to one of the two servers",
+	)
+}
+
+// TestFindConnectionForResourceURI_ReturnsNilForUnknownURI verifies that nil is
+// returned when no downstream server advertises the requested URI.
+func TestFindConnectionForResourceURI_ReturnsNilForUnknownURI(t *testing.T) {
+	// Given: a connected downstream server with a different resource URI
+	conn := &MockDownstreamConnection{
+		serverName: "server-a",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: "file:///other/resource"},
+		},
+	}
+
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id: "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": conn,
+		},
+	}
+
+	// When: looking up an unknown URI
+	found := proxy.findConnectionForResourceURI(session, "file:///unknown/resource")
+
+	// Then: nil is returned
+	assert.Assert(t, found == nil)
+}
+
+// TestSyncAvailableResources_DuplicateURILastServerWins verifies that when two
+// downstream servers expose the same URI, syncAvailableResources registers the
+// resource exactly once (last-one-wins during collection) without panicking.
+func TestSyncAvailableResources_DuplicateURILastServerWins(t *testing.T) {
+	const sharedURI = "file:///shared/resource"
+
+	// Given: two connected servers that both expose the same resource URI
+	connA := &MockDownstreamConnection{
+		serverName: "server-a",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: sharedURI, Name: "resource-on-a"},
+		},
+	}
+	connB := &MockDownstreamConnection{
+		serverName: "server-b",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: sharedURI, Name: "resource-on-b"},
+		},
+	}
+
+	proxy := &CentianEndpoint{name: "test"}
+	upstreamServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, &mcp.ServerOptions{
+		HasResources: true,
+	})
+	session := &UpstreamSession{
+		id:                  "session-1",
+		upstreamServer:      upstreamServer,
+		registeredResources: make(map[string]struct{}),
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": connA,
+			"server-b": connB,
+		},
+	}
+
+	// When: syncing available resources
+	proxy.syncAvailableResources(session)
+
+	// Then: the shared URI is registered exactly once
+	assert.Equal(t, len(session.registeredResources), 1,
+		"duplicate URI should be collapsed to a single registration")
+	_, registered := session.registeredResources[sharedURI]
+	assert.Assert(t, registered, "the shared URI must appear in registeredResources")
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for resource URI lookup and synchronization in the proxy layer, along with improvements to the mock downstream connection to support testing resource and prompt discovery.

## Key Changes

- **New test file** (`proxy_resources_test.go`): Added three test cases covering resource URI resolution:
  - `TestFindConnectionForResourceURI_DuplicateURIAcrossServers`: Verifies "first match wins" behavior when multiple servers advertise the same resource URI
  - `TestFindConnectionForResourceURI_ReturnsNilForUnknownURI`: Confirms nil is returned for unknown URIs
  - `TestSyncAvailableResources_DuplicateURILastServerWins`: Validates that duplicate URIs are collapsed to a single registration without panicking

- **Enhanced mock connection** (`downstream_connection_mock_test.go`): 
  - Added `resources` and `prompts` fields to `MockDownstreamConnection`
  - Implemented thread-safe `Resources()` and `Prompts()` methods with proper mutex locking

- **Documentation improvements** (`proxy_http.go` and `downstream_connection.go`):
  - Added clarifying comments about the asynchronous bootstrap window in SSE session initialization
  - Documented the distinction between internal lock-unsafe discovery methods and public pool-facing APIs

## Notable Implementation Details

The tests use a "Given-When-Then" structure for clarity and explicitly document the expected behavior when resource URIs are duplicated across downstream servers. The mock enhancements enable realistic testing of resource discovery scenarios while maintaining thread safety.

https://claude.ai/code/session_01DcBBYacuwwdqhGdVKaHv3S