### PR TITLE
Added realworld integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
-    name: Test
+  unit-test:
+    name: Unit Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,11 +37,11 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
-      - name: Run all tests (unit + integration)
-        run: make test-all
+      - name: Run unit tests
+        run: make test
 
       - name: Generate coverage
-        run: go test -coverprofile=coverage.out ./...
+        run: go test -coverprofile=coverage.out ./internal/... ./cmd/...
 
       - name: Generate coverage report
         run: go tool cover -html=coverage.out -o coverage.html
@@ -51,6 +51,79 @@ jobs:
         with:
           file: ./coverage.out
           fail_ci_if_error: false
+
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.25]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Run integration tests
+        run: make test-integration
+
+  integration-test-extended:
+    name: Extended Integration Tests
+    if: github.event_name == 'pull_request'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Run all integration tests
+        run: |
+          make test-integration
+          make test-everything
+          make test-realworld
 
   lint:
     name: Lint

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Build flags
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
-.PHONY: help build clean test test-integration test-everything test-all test-coverage test-coverage-html lint fmt vet tidy run dev tag-release release major minor patch
+.PHONY: help build clean test test-integration test-everything test-realworld test-all test-coverage test-coverage-html lint fmt vet tidy run dev tag-release release major minor patch
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -57,6 +57,16 @@ test-everything: ## Run everything MCP integration tests via npx
 		echo "Note: gotestsum not found, using default go test output"; \
 		echo "Install with: go install gotest.tools/gotestsum@latest"; \
 		CENTIAN_RUN_EVERYTHING_INTEGRATION=1 GOCACHE=/tmp/go-build go test -v ./tests/integrationtests/everything/...; \
+	fi
+
+test-realworld: ## Run opt-in real-world MCP integration tests
+	@echo "Running real-world MCP integration tests..."
+	@if command -v gotestsum >/dev/null 2>&1; then \
+		CENTIAN_RUN_REALWORLD_INTEGRATION=1 GOCACHE=/tmp/go-build gotestsum --format testname -- ./tests/integrationtests/realworld/...; \
+	else \
+		echo "Note: gotestsum not found, using default go test output"; \
+		echo "Install with: go install gotest.tools/gotestsum@latest"; \
+		CENTIAN_RUN_REALWORLD_INTEGRATION=1 GOCACHE=/tmp/go-build go test -v ./tests/integrationtests/realworld/...; \
 	fi
 
 test-all: test test-integration ## Run all tests (unit + integration)

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,6 +71,12 @@ The integration tests cover several major processor patterns:
 make test-integration
 ```
 
+#### Run Real-World MCP Integration Tests
+
+```bash
+make test-realworld
+```
+
 Or directly with Go:
 
 ```bash

--- a/tests/integrationtests/realworld/fetch_test.go
+++ b/tests/integrationtests/realworld/fetch_test.go
@@ -1,0 +1,121 @@
+package realworld
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+var fetchManifest = serverManifest{
+	Name:           "fetch",
+	GatewayID:      "fetch",
+	ServerID:       "fetch",
+	CommandEnvVar:  "CENTIAN_FETCH_SERVER_CMD",
+	ArgsEnvVar:     "CENTIAN_FETCH_SERVER_ARGS",
+	DefaultCommand: "uvx",
+	DefaultArgs:    []string{"mcp-server-fetch"},
+	ExpectedTools:  []string{"fetch"},
+	BuildFixture:   buildFetchFixture,
+}
+
+func TestFetchToolCatalogParity(t *testing.T) {
+	runServerComparison(t, fetchManifest, "tool_catalog", func(ctx context.Context, t *testing.T, pair *connectionPair, _ *fixtureBundle) {
+		assertToolCatalogParity(ctx, t, fetchManifest, pair)
+	})
+}
+
+func TestFetchMarkdownParity(t *testing.T) {
+	runServerComparison(t, fetchManifest, "markdown_html", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		assertToolCallParity(
+			ctx,
+			t,
+			fetchManifest,
+			fixture,
+			pair,
+			"fetch",
+			map[string]any{"url": fixture.Shared["html_url"]},
+			map[string]any{"url": fixture.Shared["html_url"]},
+		)
+	})
+}
+
+func TestFetchRawParity(t *testing.T) {
+	runServerComparison(t, fetchManifest, "raw_text", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		assertToolCallParity(
+			ctx,
+			t,
+			fetchManifest,
+			fixture,
+			pair,
+			"fetch",
+			map[string]any{"url": fixture.Shared["raw_url"], "raw": true},
+			map[string]any{"url": fixture.Shared["raw_url"], "raw": true},
+		)
+	})
+}
+
+func TestFetchChunkedParity(t *testing.T) {
+	runServerComparison(t, fetchManifest, "chunked", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		assertToolCallParity(
+			ctx,
+			t,
+			fetchManifest,
+			fixture,
+			pair,
+			"fetch",
+			map[string]any{"url": fixture.Shared["long_url"], "start_index": 40, "max_length": 80},
+			map[string]any{"url": fixture.Shared["long_url"], "start_index": 40, "max_length": 80},
+		)
+	})
+}
+
+func TestFetchErrorParity(t *testing.T) {
+	runServerComparison(t, fetchManifest, "missing", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		assertToolCallParity(
+			ctx,
+			t,
+			fetchManifest,
+			fixture,
+			pair,
+			"fetch",
+			map[string]any{"url": fixture.Shared["missing_url"]},
+			map[string]any{"url": fixture.Shared["missing_url"]},
+		)
+	})
+}
+
+func buildFetchFixture(t *testing.T) *fixtureBundle {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/page.html", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, "<html><body><h1>Centian Fetch Fixture</h1><p>This is deterministic HTML.</p></body></html>")
+	})
+	mux.HandleFunc("/raw.txt", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprint(w, "raw fixture line 1\nraw fixture line 2\n")
+	})
+	mux.HandleFunc("/long.html", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, "<html><body><p>%s</p></body></html>", strings.Repeat("chunked-content-", 80))
+	})
+	mux.HandleFunc("/missing", func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return &fixtureBundle{
+		Shared: map[string]string{
+			"html_url":    server.URL + "/page.html",
+			"raw_url":     server.URL + "/raw.txt",
+			"long_url":    server.URL + "/long.html",
+			"missing_url": server.URL + "/missing",
+		},
+	}
+}

--- a/tests/integrationtests/realworld/fetch_test.go
+++ b/tests/integrationtests/realworld/fetch_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-var fetchManifest = serverManifest{
+var fetchManifest = &serverManifest{
 	Name:           "fetch",
 	GatewayID:      "fetch",
 	ServerID:       "fetch",

--- a/tests/integrationtests/realworld/filesystem_test.go
+++ b/tests/integrationtests/realworld/filesystem_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-var filesystemManifest = serverManifest{
+var filesystemManifest = &serverManifest{
 	Name:           "filesystem",
 	GatewayID:      "filesystem",
 	ServerID:       "filesystem",

--- a/tests/integrationtests/realworld/filesystem_test.go
+++ b/tests/integrationtests/realworld/filesystem_test.go
@@ -1,0 +1,318 @@
+package realworld
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var filesystemManifest = serverManifest{
+	Name:           "filesystem",
+	GatewayID:      "filesystem",
+	ServerID:       "filesystem",
+	CommandEnvVar:  "CENTIAN_FILESYSTEM_SERVER_CMD",
+	ArgsEnvVar:     "CENTIAN_FILESYSTEM_SERVER_ARGS",
+	DefaultCommand: "npx",
+	DefaultArgs:    []string{"-y", "@modelcontextprotocol/server-filesystem"},
+	ExpectedTools: []string{
+		"create_directory",
+		"directory_tree",
+		"edit_file",
+		"get_file_info",
+		"list_allowed_directories",
+		"list_directory",
+		"list_directory_with_sizes",
+		"move_file",
+		"read_media_file",
+		"read_multiple_files",
+		"read_text_file",
+		"search_files",
+		"write_file",
+	},
+	BuildFixture: buildFilesystemFixture,
+	Normalize:    normalizeFilesystemResult,
+}
+
+func TestFilesystemToolCatalogParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "tool_catalog", func(ctx context.Context, t *testing.T, pair *connectionPair, _ *fixtureBundle) {
+		assertToolCatalogParity(ctx, t, filesystemManifest, pair)
+	})
+}
+
+func TestFilesystemListAllowedDirectoriesParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "list_allowed_directories", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		assertToolCallParity(ctx, t, filesystemManifest, fixture, pair, "list_allowed_directories", map[string]any{}, map[string]any{})
+	})
+}
+
+func TestFilesystemListDirectoryParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "list_directory", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"list_directory",
+			map[string]any{"path": fixture.Direct.RootDir},
+			map[string]any{"path": fixture.Proxied.RootDir},
+		)
+	})
+}
+
+func TestFilesystemDirectoryTreeParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "directory_tree", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"directory_tree",
+			map[string]any{"path": fixture.Direct.RootDir},
+			map[string]any{"path": fixture.Proxied.RootDir},
+		)
+	})
+}
+
+func TestFilesystemReadTextFileParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "read_text_file", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		readRel := fixture.Expected["read_rel"]
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"read_text_file",
+			map[string]any{"path": modePath(fixture.Direct, readRel)},
+			map[string]any{"path": modePath(fixture.Proxied, readRel)},
+		)
+	})
+}
+
+func TestFilesystemSearchFilesParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "search_files", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"search_files",
+			map[string]any{
+				"path":    fixture.Direct.RootDir,
+				"pattern": fixture.Expected["search_pattern"],
+			},
+			map[string]any{
+				"path":    fixture.Proxied.RootDir,
+				"pattern": fixture.Expected["search_pattern"],
+			},
+		)
+	})
+}
+
+func TestFilesystemGetFileInfoParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "get_file_info", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		infoRel := fixture.Expected["info_rel"]
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"get_file_info",
+			map[string]any{"path": modePath(fixture.Direct, infoRel)},
+			map[string]any{"path": modePath(fixture.Proxied, infoRel)},
+		)
+	})
+}
+
+func TestFilesystemCreateDirectoryParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "create_directory", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		targetRel := fixture.Expected["create_dir_rel"]
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"create_directory",
+			map[string]any{"path": modePath(fixture.Direct, targetRel)},
+			map[string]any{"path": modePath(fixture.Proxied, targetRel)},
+		)
+	})
+}
+
+func TestFilesystemWriteFileParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "write_file", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		targetRel := fixture.Expected["write_rel"]
+		content := fixture.Expected["write_content"]
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"write_file",
+			map[string]any{"path": modePath(fixture.Direct, targetRel), "content": content},
+			map[string]any{"path": modePath(fixture.Proxied, targetRel), "content": content},
+		)
+	})
+}
+
+func TestFilesystemEditFileDryRunParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "edit_file_dry_run", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		editRel := fixture.Expected["edit_rel"]
+		oldText := fixture.Expected["edit_old"]
+		newText := fixture.Expected["edit_new"]
+
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"edit_file",
+			map[string]any{
+				"path":   modePath(fixture.Direct, editRel),
+				"edits":  []map[string]any{{"oldText": oldText, "newText": newText}},
+				"dryRun": true,
+			},
+			map[string]any{
+				"path":   modePath(fixture.Proxied, editRel),
+				"edits":  []map[string]any{{"oldText": oldText, "newText": newText}},
+				"dryRun": true,
+			},
+		)
+	})
+}
+
+func TestFilesystemMoveFileParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "move_file", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		sourceRel := fixture.Expected["move_source_rel"]
+		destRel := fixture.Expected["move_dest_rel"]
+		assertToolCallParity(
+			ctx,
+			t,
+			filesystemManifest,
+			fixture,
+			pair,
+			"move_file",
+			map[string]any{
+				"source":      modePath(fixture.Direct, sourceRel),
+				"destination": modePath(fixture.Direct, destRel),
+			},
+			map[string]any{
+				"source":      modePath(fixture.Proxied, sourceRel),
+				"destination": modePath(fixture.Proxied, destRel),
+			},
+		)
+	})
+}
+
+func TestFilesystemRootsUpdateParity(t *testing.T) {
+	runServerComparison(t, filesystemManifest, "roots_update", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		directExtraRoot := modePath(fixture.Direct, fixture.Expected["extra_root_rel"])
+		proxiedExtraRoot := modePath(fixture.Proxied, fixture.Expected["extra_root_rel"])
+
+		pair.Direct.client.AddRoots(&mcp.Root{Name: "filesystem-extra", URI: fileURI(directExtraRoot)})
+		pair.Proxied.client.AddRoots(&mcp.Root{Name: "filesystem-extra", URI: fileURI(proxiedExtraRoot)})
+
+		directResult, directErr := waitForCallResult(ctx, pair.Direct.session, "list_allowed_directories", map[string]any{}, func(result *mcp.CallToolResult, err error) bool {
+			if err != nil || result == nil {
+				return false
+			}
+			return strings.Contains(prettyJSON(t, normalizeResultForComparison(t, filesystemManifest, modeDirect, fixture, result)), "/__EXTRA_ROOT__")
+		})
+		proxiedResult, proxiedErr := waitForCallResult(ctx, pair.Proxied.session, "list_allowed_directories", map[string]any{}, func(result *mcp.CallToolResult, err error) bool {
+			if err != nil || result == nil {
+				return false
+			}
+			return strings.Contains(prettyJSON(t, normalizeResultForComparison(t, filesystemManifest, modeProxied, fixture, result)), "/__EXTRA_ROOT__")
+		})
+
+		assertCallOutcomeParity(t, filesystemManifest, fixture, directResult, directErr, proxiedResult, proxiedErr)
+	})
+}
+
+func buildFilesystemFixture(t *testing.T) *fixtureBundle {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	seedDir := filepath.Join(baseDir, "seed")
+	if err := os.MkdirAll(filepath.Join(seedDir, "docs"), 0o755); err != nil {
+		t.Fatalf("failed to create seed docs dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(seedDir, "workspace"), 0o755); err != nil {
+		t.Fatalf("failed to create seed workspace dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(seedDir, "docs", "readme.txt"), []byte("Hello from filesystem fixture.\nSecond line.\n"), 0o644); err != nil {
+		t.Fatalf("failed to seed readme: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(seedDir, "workspace", "move_me.txt"), []byte("Move me.\n"), 0o644); err != nil {
+		t.Fatalf("failed to seed move file: %v", err)
+	}
+
+	directRoot := filepath.Join(baseDir, "direct-root")
+	proxiedRoot := filepath.Join(baseDir, "proxied-root")
+	copyTree(t, seedDir, directRoot)
+	copyTree(t, seedDir, proxiedRoot)
+
+	if err := os.MkdirAll(filepath.Join(directRoot, "extra"), 0o755); err != nil {
+		t.Fatalf("failed to create direct extra root: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(proxiedRoot, "extra"), 0o755); err != nil {
+		t.Fatalf("failed to create proxied extra root: %v", err)
+	}
+
+	return &fixtureBundle{
+		Direct: modeFixture{
+			RootDir: directRoot,
+			Roots: []*mcp.Root{
+				{Name: "filesystem-root", URI: fileURI(directRoot)},
+			},
+			Normalization: map[string]string{
+				directRoot:                                  "/__ROOT__",
+				fileURI(directRoot):                         "file:///__ROOT__",
+				filepath.Join(directRoot, "extra"):          "/__EXTRA_ROOT__",
+				fileURI(filepath.Join(directRoot, "extra")): "file:///__EXTRA_ROOT__",
+			},
+		},
+		Proxied: modeFixture{
+			RootDir: proxiedRoot,
+			Roots: []*mcp.Root{
+				{Name: "filesystem-root", URI: fileURI(proxiedRoot)},
+			},
+			Normalization: map[string]string{
+				proxiedRoot:                                  "/__ROOT__",
+				fileURI(proxiedRoot):                         "file:///__ROOT__",
+				filepath.Join(proxiedRoot, "extra"):          "/__EXTRA_ROOT__",
+				fileURI(filepath.Join(proxiedRoot, "extra")): "file:///__EXTRA_ROOT__",
+			},
+		},
+		Expected: map[string]string{
+			"read_rel":        "docs/readme.txt",
+			"info_rel":        "docs/readme.txt",
+			"search_pattern":  "readme",
+			"create_dir_rel":  "workspace/generated",
+			"write_rel":       "workspace/new_file.txt",
+			"write_content":   "Created by Centian realworld test.\n",
+			"edit_rel":        "docs/readme.txt",
+			"edit_old":        "Second line.",
+			"edit_new":        "Updated line.",
+			"move_source_rel": "workspace/move_me.txt",
+			"move_dest_rel":   "workspace/moved/move_me.txt",
+			"extra_root_rel":  "extra",
+		},
+	}
+}
+
+func normalizeFilesystemResult(mode serverMode, value any, fixture *fixtureBundle) any {
+	modeFixture := fixtureForMode(fixture, mode)
+	return replaceStrings(value, modeFixture.Normalization)
+}

--- a/tests/integrationtests/realworld/harness_test.go
+++ b/tests/integrationtests/realworld/harness_test.go
@@ -1,0 +1,743 @@
+package realworld
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/T4cceptor/centian/internal/config"
+	"github.com/T4cceptor/centian/internal/proxy"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	runRealworldIntegrationEnv = "CENTIAN_RUN_REALWORLD_INTEGRATION"
+	defaultSessionTimeout      = 30 * time.Second
+	defaultToolsWaitTimeout    = 20 * time.Second
+)
+
+type serverMode string
+
+const (
+	modeDirect  serverMode = "direct"
+	modeProxied serverMode = "proxied"
+)
+
+type serverCommand struct {
+	Command string
+	Args    []string
+	Env     map[string]string
+}
+
+type modeFixture struct {
+	RootDir       string
+	Roots         []*mcp.Root
+	Env           map[string]string
+	Normalization map[string]string
+}
+
+type fixtureBundle struct {
+	Direct   modeFixture
+	Proxied  modeFixture
+	Shared   map[string]string
+	Expected map[string]string
+}
+
+type resultNormalizer func(serverMode, any, *fixtureBundle) any
+
+type serverManifest struct {
+	Name           string
+	GatewayID      string
+	ServerID       string
+	CommandEnvVar  string
+	ArgsEnvVar     string
+	DefaultCommand string
+	DefaultArgs    []string
+	ExpectedTools  []string
+	BuildFixture   func(*testing.T) *fixtureBundle
+	Normalize      resultNormalizer
+}
+
+type instrumentedSession struct {
+	mode    serverMode
+	client  *mcp.Client
+	session *mcp.ClientSession
+}
+
+type connectionPair struct {
+	Direct  *instrumentedSession
+	Proxied *instrumentedSession
+}
+
+type realworldHarness struct {
+	manifest serverManifest
+	fixture  *fixtureBundle
+	proxyURL string
+}
+
+func newRealworldHarness(t *testing.T, manifest serverManifest) *realworldHarness {
+	t.Helper()
+
+	requireRealworldEnabled(t)
+
+	fixture := manifest.BuildFixture(t)
+	proxiedCommand := loadServerCommand(t, manifest, modeProxied, fixture)
+	proxyURL := startCentianProxyForRealworld(t, manifest, proxiedCommand)
+
+	return &realworldHarness{
+		manifest: manifest,
+		fixture:  fixture,
+		proxyURL: proxyURL,
+	}
+}
+
+func requireRealworldEnabled(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv(runRealworldIntegrationEnv) != "1" {
+		t.Skipf("set %s=1 to run real-world integration tests", runRealworldIntegrationEnv)
+	}
+}
+
+func loadServerCommand(t *testing.T, manifest serverManifest, mode serverMode, fixture *fixtureBundle) serverCommand {
+	t.Helper()
+
+	command := strings.TrimSpace(os.Getenv(manifest.CommandEnvVar))
+	if command == "" {
+		command = manifest.DefaultCommand
+	}
+
+	argsEnv := strings.TrimSpace(os.Getenv(manifest.ArgsEnvVar))
+	args := append([]string(nil), manifest.DefaultArgs...)
+	if argsEnv != "" {
+		args = strings.Fields(argsEnv)
+	}
+
+	if _, err := exec.LookPath(command); err != nil {
+		t.Skipf("%s command %q is not available: %v", manifest.Name, command, err)
+	}
+
+	return serverCommand{
+		Command: command,
+		Args:    args,
+		Env:     fixtureForMode(fixture, mode).Env,
+	}
+}
+
+func (h *realworldHarness) connectPair(t *testing.T) *connectionPair {
+	t.Helper()
+
+	return &connectionPair{
+		Direct:  h.connectDirect(t),
+		Proxied: h.connectViaCentian(t),
+	}
+}
+
+func (h *realworldHarness) connectDirect(t *testing.T) *instrumentedSession {
+	t.Helper()
+
+	command := loadServerCommand(t, h.manifest, modeDirect, h.fixture)
+	cmd := exec.Command(command.Command, command.Args...)
+	cmd.Env = mergeEnv(os.Environ(), command.Env)
+
+	return connectInstrumentedSession(
+		t,
+		modeDirect,
+		fixtureForMode(h.fixture, modeDirect).Roots,
+		&mcp.CommandTransport{Command: cmd},
+	)
+}
+
+func (h *realworldHarness) connectViaCentian(t *testing.T) *instrumentedSession {
+	t.Helper()
+
+	return connectInstrumentedSession(
+		t,
+		modeProxied,
+		fixtureForMode(h.fixture, modeProxied).Roots,
+		&mcp.StreamableClientTransport{
+			Endpoint:   h.proxyURL,
+			HTTPClient: &http.Client{Timeout: defaultSessionTimeout},
+		},
+	)
+}
+
+func connectInstrumentedSession(
+	t *testing.T,
+	mode serverMode,
+	roots []*mcp.Root,
+	transport mcp.Transport,
+) *instrumentedSession {
+	t.Helper()
+
+	client := newClientWithRoots(roots)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultSessionTimeout)
+	defer cancel()
+
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("failed to connect %s session: %v", mode, err)
+	}
+	t.Cleanup(func() {
+		if closeErr := session.Close(); closeErr != nil {
+			t.Fatalf("failed to close %s session: %v", mode, closeErr)
+		}
+	})
+
+	return &instrumentedSession{
+		mode:    mode,
+		client:  client,
+		session: session,
+	}
+}
+
+func newClientWithRoots(roots []*mcp.Root) *mcp.Client {
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "centian-realworld-test-client",
+		Version: "1.0.0",
+	}, &mcp.ClientOptions{
+		Capabilities: &mcp.ClientCapabilities{
+			RootsV2: &mcp.RootCapabilities{ListChanged: true},
+		},
+	})
+
+	if len(roots) > 0 {
+		client.AddRoots(roots...)
+	}
+
+	return client
+}
+
+func startCentianProxyForRealworld(t *testing.T, manifest serverManifest, downstream serverCommand) string {
+	t.Helper()
+
+	authDisabled := false
+	port := allocateFreePort(t)
+
+	globalConfig := &config.GlobalConfig{
+		Name:        manifest.Name + " Integration Proxy",
+		Version:     "1.0.0",
+		AuthEnabled: &authDisabled,
+		Proxy: &config.ProxySettings{
+			Host:    "127.0.0.1",
+			Port:    port,
+			Timeout: int(defaultSessionTimeout.Seconds()),
+		},
+		Gateways: map[string]*config.GatewayConfig{
+			manifest.GatewayID: {
+				MCPServers: map[string]*config.MCPServerConfig{
+					manifest.ServerID: {
+						Command: downstream.Command,
+						Args:    downstream.Args,
+						Env:     downstream.Env,
+					},
+				},
+			},
+		},
+	}
+
+	server, err := proxy.NewCentianServer(globalConfig)
+	if err != nil {
+		t.Fatalf("failed to create centian proxy: %v", err)
+	}
+	if err := server.Setup(); err != nil {
+		t.Fatalf("failed to setup centian proxy: %v", err)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() {
+		if err := server.Server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
+		}
+	}()
+
+	waitForProxyListener(t, server.Server.Addr)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := server.Server.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("failed to shutdown centian proxy: %v", err)
+		}
+
+		select {
+		case err := <-serveErr:
+			if err != nil {
+				t.Fatalf("centian proxy server failed: %v", err)
+			}
+		default:
+		}
+	})
+
+	return fmt.Sprintf("http://127.0.0.1:%s/mcp/%s/%s", port, manifest.GatewayID, manifest.ServerID)
+}
+
+func runServerComparison(
+	t *testing.T,
+	manifest serverManifest,
+	testName string,
+	testFn func(context.Context, *testing.T, *connectionPair, *fixtureBundle),
+) {
+	t.Helper()
+
+	t.Run(testName, func(t *testing.T) {
+		harness := newRealworldHarness(t, manifest)
+		pair := harness.connectPair(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), defaultSessionTimeout)
+		defer cancel()
+
+		testFn(ctx, t, pair, harness.fixture)
+	})
+}
+
+func assertToolCatalogParity(
+	ctx context.Context,
+	t *testing.T,
+	manifest serverManifest,
+	pair *connectionPair,
+) {
+	t.Helper()
+
+	directTools, err := waitForTools(ctx, pair.Direct.session, defaultToolsWaitTimeout, 250*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to list direct tools: %v", err)
+	}
+	proxiedTools, err := waitForTools(ctx, pair.Proxied.session, defaultToolsWaitTimeout, 250*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to list proxied tools: %v", err)
+	}
+
+	directNames := toolNames(directTools.Tools)
+	proxiedNames := toolNames(proxiedTools.Tools)
+	slices.Sort(directNames)
+	slices.Sort(proxiedNames)
+
+	expected := append([]string(nil), manifest.ExpectedTools...)
+	slices.Sort(expected)
+
+	if !slices.Equal(expected, directNames) || !slices.Equal(expected, proxiedNames) {
+		t.Fatalf(
+			"unexpected tool catalog for %s\nexpected: %v\ndirect: %v\nproxied: %v",
+			manifest.Name,
+			expected,
+			directNames,
+			proxiedNames,
+		)
+	}
+
+	directToolMap := toolMap(directTools.Tools)
+	proxiedToolMap := toolMap(proxiedTools.Tools)
+	for _, name := range expected {
+		directTool := directToolMap[name]
+		proxiedTool := proxiedToolMap[name]
+		if proxiedTool == nil {
+			t.Fatalf("missing proxied tool metadata for %q", name)
+		}
+		if !jsonEqual(t, directTool, proxiedTool) {
+			t.Fatalf(
+				"tool metadata mismatch for %q\ndirect:\n%s\nproxied:\n%s",
+				name,
+				prettyJSON(t, directTool),
+				prettyJSON(t, proxiedTool),
+			)
+		}
+	}
+}
+
+func assertToolCallParity(
+	ctx context.Context,
+	t *testing.T,
+	manifest serverManifest,
+	fixture *fixtureBundle,
+	pair *connectionPair,
+	toolName string,
+	directArgs map[string]any,
+	proxiedArgs map[string]any,
+) {
+	t.Helper()
+
+	directTools, err := waitForTools(ctx, pair.Direct.session, defaultToolsWaitTimeout, 250*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to list direct tools before calling %q: %v", toolName, err)
+	}
+	proxiedTools, err := waitForTools(ctx, pair.Proxied.session, defaultToolsWaitTimeout, 250*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to list proxied tools before calling %q: %v", toolName, err)
+	}
+	if _, ok := toolMap(directTools.Tools)[toolName]; !ok {
+		t.Fatalf("direct tool catalog does not contain %q", toolName)
+	}
+	if _, ok := toolMap(proxiedTools.Tools)[toolName]; !ok {
+		t.Fatalf("proxied tool catalog does not contain %q", toolName)
+	}
+
+	directResult, directErr := pair.Direct.session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: directArgs,
+	})
+	proxiedResult, proxiedErr := pair.Proxied.session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: proxiedArgs,
+	})
+
+	assertCallOutcomeParity(t, manifest, fixture, directResult, directErr, proxiedResult, proxiedErr)
+}
+
+func assertCallOutcomeParity(
+	t *testing.T,
+	manifest serverManifest,
+	fixture *fixtureBundle,
+	directResult *mcp.CallToolResult,
+	directErr error,
+	proxiedResult *mcp.CallToolResult,
+	proxiedErr error,
+) {
+	t.Helper()
+
+	if !sameErrorMessage(directErr, proxiedErr) {
+		t.Fatalf(
+			"call error mismatch\ndirect error: %v\nproxied error: %v\ndirect result:\n%s\nproxied result:\n%s",
+			directErr,
+			proxiedErr,
+			prettyJSON(t, directResult),
+			prettyJSON(t, proxiedResult),
+		)
+	}
+
+	if !compareNormalizedResults(t, manifest, fixture, directResult, proxiedResult) {
+		t.Fatalf(
+			"call result mismatch\ndirect:\n%s\nproxied:\n%s",
+			prettyJSON(t, normalizeResultForComparison(t, manifest, modeDirect, fixture, directResult)),
+			prettyJSON(t, normalizeResultForComparison(t, manifest, modeProxied, fixture, proxiedResult)),
+		)
+	}
+}
+
+func compareNormalizedResults(
+	t *testing.T,
+	manifest serverManifest,
+	fixture *fixtureBundle,
+	directResult *mcp.CallToolResult,
+	proxiedResult *mcp.CallToolResult,
+) bool {
+	t.Helper()
+
+	directNormalized := normalizeResultForComparison(t, manifest, modeDirect, fixture, directResult)
+	proxiedNormalized := normalizeResultForComparison(t, manifest, modeProxied, fixture, proxiedResult)
+	return jsonEqual(t, directNormalized, proxiedNormalized)
+}
+
+func normalizeResultForComparison(
+	t *testing.T,
+	manifest serverManifest,
+	mode serverMode,
+	fixture *fixtureBundle,
+	value any,
+) any {
+	t.Helper()
+
+	if value == nil {
+		return nil
+	}
+
+	if manifest.Normalize == nil {
+		return value
+	}
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("failed to marshal normalized value: %v", err)
+	}
+
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal normalized value: %v", err)
+	}
+
+	return manifest.Normalize(mode, decoded, fixture)
+}
+
+func fixtureForMode(fixture *fixtureBundle, mode serverMode) modeFixture {
+	if mode == modeDirect {
+		return fixture.Direct
+	}
+	return fixture.Proxied
+}
+
+func modePath(fixture modeFixture, rel string) string {
+	if rel == "" {
+		return fixture.RootDir
+	}
+	return filepath.Join(fixture.RootDir, filepath.FromSlash(rel))
+}
+
+func fileURI(path string) string {
+	return (&url.URL{
+		Scheme: "file",
+		Path:   filepath.ToSlash(path),
+	}).String()
+}
+
+func mergeEnv(base []string, extra map[string]string) []string {
+	if len(extra) == 0 {
+		return base
+	}
+
+	values := make(map[string]string, len(base)+len(extra))
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	for key, value := range extra {
+		values[key] = value
+	}
+
+	merged := make([]string, 0, len(values))
+	for key, value := range values {
+		merged = append(merged, key+"="+value)
+	}
+	slices.Sort(merged)
+	return merged
+}
+
+func waitForTools(
+	ctx context.Context,
+	session *mcp.ClientSession,
+	timeout time.Duration,
+	interval time.Duration,
+) (*mcp.ListToolsResult, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		toolsResult, err := session.ListTools(ctx, nil)
+		if err == nil && len(toolsResult.Tools) > 0 {
+			return toolsResult, nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+		time.Sleep(interval)
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return &mcp.ListToolsResult{}, nil
+}
+
+func waitForCallResult(
+	ctx context.Context,
+	session *mcp.ClientSession,
+	toolName string,
+	args map[string]any,
+	accept func(*mcp.CallToolResult, error) bool,
+) (*mcp.CallToolResult, error) {
+	deadline := time.Now().Add(10 * time.Second)
+	var lastResult *mcp.CallToolResult
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: toolName, Arguments: args})
+		lastResult = result
+		lastErr = err
+		if accept(result, err) {
+			return result, err
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return lastResult, lastErr
+}
+
+func toolNames(tools []*mcp.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+func toolMap(tools []*mcp.Tool) map[string]*mcp.Tool {
+	result := make(map[string]*mcp.Tool, len(tools))
+	for _, tool := range tools {
+		result[tool.Name] = tool
+	}
+	return result
+}
+
+func prettyJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal json: %v", err)
+	}
+
+	return string(data)
+}
+
+func jsonEqual(t *testing.T, a, b any) bool {
+	t.Helper()
+
+	aJSON, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("failed to marshal first value: %v", err)
+	}
+	bJSON, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("failed to marshal second value: %v", err)
+	}
+
+	return string(aJSON) == string(bJSON)
+}
+
+func sameErrorMessage(left, right error) bool {
+	switch {
+	case left == nil && right == nil:
+		return true
+	case left == nil || right == nil:
+		return false
+	default:
+		return left.Error() == right.Error()
+	}
+}
+
+func allocateFreePort(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate free port: %v", err)
+	}
+	defer listener.Close()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected listener address type: %T", listener.Addr())
+	}
+
+	return strconv.Itoa(tcpAddr.Port)
+}
+
+func waitForProxyListener(t *testing.T, address string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Fatalf("proxy listener %s did not become ready in time", address)
+}
+
+func copyTree(t *testing.T, srcDir, dstDir string) {
+	t.Helper()
+
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatalf("failed to create destination dir %s: %v", dstDir, err)
+	}
+
+	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dstDir, rel)
+
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+
+		if err := copyFile(path, target, info.Mode()); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to copy fixture tree from %s to %s: %v", srcDir, dstDir, err)
+	}
+}
+
+func copyFile(srcPath, dstPath string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+		return err
+	}
+
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, src)
+	return err
+}
+
+func replaceStrings(value any, replacements map[string]string) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+
+		normalized := make(map[string]any, len(typed))
+		for _, key := range keys {
+			normalized[key] = replaceStrings(typed[key], replacements)
+		}
+		return normalized
+	case []any:
+		items := make([]any, len(typed))
+		for i := range typed {
+			items[i] = replaceStrings(typed[i], replacements)
+		}
+		return items
+	case string:
+		replaced := typed
+		keys := make([]string, 0, len(replacements))
+		for key := range replacements {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+		for _, key := range keys {
+			replaced = strings.ReplaceAll(replaced, key, replacements[key])
+		}
+		return replaced
+	default:
+		return typed
+	}
+}

--- a/tests/integrationtests/realworld/harness_test.go
+++ b/tests/integrationtests/realworld/harness_test.go
@@ -1,6 +1,7 @@
 package realworld
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -83,12 +84,12 @@ type connectionPair struct {
 }
 
 type realworldHarness struct {
-	manifest serverManifest
+	manifest *serverManifest
 	fixture  *fixtureBundle
 	proxyURL string
 }
 
-func newRealworldHarness(t *testing.T, manifest serverManifest) *realworldHarness {
+func newRealworldHarness(t *testing.T, manifest *serverManifest) *realworldHarness {
 	t.Helper()
 
 	requireRealworldEnabled(t)
@@ -112,7 +113,7 @@ func requireRealworldEnabled(t *testing.T) {
 	}
 }
 
-func loadServerCommand(t *testing.T, manifest serverManifest, mode serverMode, fixture *fixtureBundle) serverCommand {
+func loadServerCommand(t *testing.T, manifest *serverManifest, mode serverMode, fixture *fixtureBundle) serverCommand {
 	t.Helper()
 
 	command := strings.TrimSpace(os.Getenv(manifest.CommandEnvVar))
@@ -221,7 +222,7 @@ func newClientWithRoots(roots []*mcp.Root) *mcp.Client {
 	return client
 }
 
-func startCentianProxyForRealworld(t *testing.T, manifest serverManifest, downstream serverCommand) string {
+func startCentianProxyForRealworld(t *testing.T, manifest *serverManifest, downstream serverCommand) string {
 	t.Helper()
 
 	authDisabled := false
@@ -288,7 +289,7 @@ func startCentianProxyForRealworld(t *testing.T, manifest serverManifest, downst
 
 func runServerComparison(
 	t *testing.T,
-	manifest serverManifest,
+	manifest *serverManifest,
 	testName string,
 	testFn func(context.Context, *testing.T, *connectionPair, *fixtureBundle),
 ) {
@@ -308,16 +309,16 @@ func runServerComparison(
 func assertToolCatalogParity(
 	ctx context.Context,
 	t *testing.T,
-	manifest serverManifest,
+	manifest *serverManifest,
 	pair *connectionPair,
 ) {
 	t.Helper()
 
-	directTools, err := waitForTools(ctx, pair.Direct.session, defaultToolsWaitTimeout, 250*time.Millisecond)
+	directTools, err := waitForTools(ctx, pair.Direct.session)
 	if err != nil {
 		t.Fatalf("failed to list direct tools: %v", err)
 	}
-	proxiedTools, err := waitForTools(ctx, pair.Proxied.session, defaultToolsWaitTimeout, 250*time.Millisecond)
+	proxiedTools, err := waitForTools(ctx, pair.Proxied.session)
 	if err != nil {
 		t.Fatalf("failed to list proxied tools: %v", err)
 	}
@@ -362,7 +363,7 @@ func assertToolCatalogParity(
 func assertToolCallParity(
 	ctx context.Context,
 	t *testing.T,
-	manifest serverManifest,
+	manifest *serverManifest,
 	fixture *fixtureBundle,
 	pair *connectionPair,
 	toolName string,
@@ -371,11 +372,11 @@ func assertToolCallParity(
 ) {
 	t.Helper()
 
-	directTools, err := waitForTools(ctx, pair.Direct.session, defaultToolsWaitTimeout, 250*time.Millisecond)
+	directTools, err := waitForTools(ctx, pair.Direct.session)
 	if err != nil {
 		t.Fatalf("failed to list direct tools before calling %q: %v", toolName, err)
 	}
-	proxiedTools, err := waitForTools(ctx, pair.Proxied.session, defaultToolsWaitTimeout, 250*time.Millisecond)
+	proxiedTools, err := waitForTools(ctx, pair.Proxied.session)
 	if err != nil {
 		t.Fatalf("failed to list proxied tools before calling %q: %v", toolName, err)
 	}
@@ -400,7 +401,7 @@ func assertToolCallParity(
 
 func assertCallOutcomeParity(
 	t *testing.T,
-	manifest serverManifest,
+	manifest *serverManifest,
 	fixture *fixtureBundle,
 	directResult *mcp.CallToolResult,
 	directErr error,
@@ -430,7 +431,7 @@ func assertCallOutcomeParity(
 
 func compareNormalizedResults(
 	t *testing.T,
-	manifest serverManifest,
+	manifest *serverManifest,
 	fixture *fixtureBundle,
 	directResult *mcp.CallToolResult,
 	proxiedResult *mcp.CallToolResult,
@@ -444,7 +445,7 @@ func compareNormalizedResults(
 
 func normalizeResultForComparison(
 	t *testing.T,
-	manifest serverManifest,
+	manifest *serverManifest,
 	mode serverMode,
 	fixture *fixtureBundle,
 	value any,
@@ -517,13 +518,8 @@ func mergeEnv(base []string, extra map[string]string) []string {
 	return merged
 }
 
-func waitForTools(
-	ctx context.Context,
-	session *mcp.ClientSession,
-	timeout time.Duration,
-	interval time.Duration,
-) (*mcp.ListToolsResult, error) {
-	deadline := time.Now().Add(timeout)
+func waitForTools(ctx context.Context, session *mcp.ClientSession) (*mcp.ListToolsResult, error) {
+	deadline := time.Now().Add(defaultToolsWaitTimeout)
 	var lastErr error
 
 	for time.Now().Before(deadline) {
@@ -534,7 +530,7 @@ func waitForTools(
 		if err != nil {
 			lastErr = err
 		}
-		time.Sleep(interval)
+		time.Sleep(250 * time.Millisecond)
 	}
 
 	if lastErr != nil {
@@ -606,7 +602,7 @@ func jsonEqual(t *testing.T, a, b any) bool {
 		t.Fatalf("failed to marshal second value: %v", err)
 	}
 
-	return string(aJSON) == string(bJSON)
+	return bytes.Equal(aJSON, bJSON)
 }
 
 func sameErrorMessage(left, right error) bool {

--- a/tests/integrationtests/realworld/memory_test.go
+++ b/tests/integrationtests/realworld/memory_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-var memoryManifest = serverManifest{
+var memoryManifest = &serverManifest{
 	Name:           "memory",
 	GatewayID:      "memory",
 	ServerID:       "memory",

--- a/tests/integrationtests/realworld/memory_test.go
+++ b/tests/integrationtests/realworld/memory_test.go
@@ -1,0 +1,236 @@
+package realworld
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var memoryManifest = serverManifest{
+	Name:           "memory",
+	GatewayID:      "memory",
+	ServerID:       "memory",
+	CommandEnvVar:  "CENTIAN_MEMORY_SERVER_CMD",
+	ArgsEnvVar:     "CENTIAN_MEMORY_SERVER_ARGS",
+	DefaultCommand: "npx",
+	DefaultArgs:    []string{"-y", "@modelcontextprotocol/server-memory"},
+	ExpectedTools: []string{
+		"add_observations",
+		"create_entities",
+		"create_relations",
+		"delete_entities",
+		"delete_observations",
+		"delete_relations",
+		"open_nodes",
+		"read_graph",
+		"search_nodes",
+	},
+	BuildFixture: buildMemoryFixture,
+	Normalize:    normalizeMemoryResult,
+}
+
+func TestMemoryToolCatalogParity(t *testing.T) {
+	runServerComparison(t, memoryManifest, "tool_catalog", func(ctx context.Context, t *testing.T, pair *connectionPair, _ *fixtureBundle) {
+		assertToolCatalogParity(ctx, t, memoryManifest, pair)
+	})
+}
+
+func TestMemoryScenarioParity(t *testing.T) {
+	runServerComparison(t, memoryManifest, "scenario", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+		steps := []struct {
+			tool string
+			args map[string]any
+		}{
+			{
+				tool: "create_entities",
+				args: map[string]any{
+					"entities": []map[string]any{
+						{
+							"name":         "Alice",
+							"entityType":   "person",
+							"observations": []string{"Likes Go", "Maintains Centian"},
+						},
+						{
+							"name":         "Centian",
+							"entityType":   "project",
+							"observations": []string{"Is an MCP proxy"},
+						},
+					},
+				},
+			},
+			{
+				tool: "create_relations",
+				args: map[string]any{
+					"relations": []map[string]any{
+						{"from": "Alice", "to": "Centian", "relationType": "maintains"},
+					},
+				},
+			},
+			{
+				tool: "add_observations",
+				args: map[string]any{
+					"observations": []map[string]any{
+						{"entityName": "Alice", "contents": []string{"Prefers concise plans"}},
+					},
+				},
+			},
+			{
+				tool: "search_nodes",
+				args: map[string]any{
+					"query": "Centian",
+				},
+			},
+			{
+				tool: "open_nodes",
+				args: map[string]any{
+					"names": []string{"Alice", "Centian"},
+				},
+			},
+			{
+				tool: "delete_observations",
+				args: map[string]any{
+					"deletions": []map[string]any{
+						{"entityName": "Alice", "observations": []string{"Likes Go"}},
+					},
+				},
+			},
+			{
+				tool: "delete_relations",
+				args: map[string]any{
+					"relations": []map[string]any{
+						{"from": "Alice", "to": "Centian", "relationType": "maintains"},
+					},
+				},
+			},
+			{
+				tool: "delete_entities",
+				args: map[string]any{
+					"entityNames": []string{"Centian"},
+				},
+			},
+			{
+				tool: "read_graph",
+				args: map[string]any{},
+			},
+		}
+
+		for _, step := range steps {
+			directResult, directErr := pair.Direct.session.CallTool(ctx, &mcp.CallToolParams{Name: step.tool, Arguments: step.args})
+			proxiedResult, proxiedErr := pair.Proxied.session.CallTool(ctx, &mcp.CallToolParams{Name: step.tool, Arguments: step.args})
+			assertCallOutcomeParity(t, memoryManifest, fixture, directResult, directErr, proxiedResult, proxiedErr)
+		}
+	})
+}
+
+func buildMemoryFixture(t *testing.T) *fixtureBundle {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	directMemoryPath := filepath.Join(baseDir, "direct-memory.jsonl")
+	proxiedMemoryPath := filepath.Join(baseDir, "proxied-memory.jsonl")
+	if err := os.WriteFile(directMemoryPath, nil, 0o644); err != nil {
+		t.Fatalf("failed to create direct memory file: %v", err)
+	}
+	if err := os.WriteFile(proxiedMemoryPath, nil, 0o644); err != nil {
+		t.Fatalf("failed to create proxied memory file: %v", err)
+	}
+
+	return &fixtureBundle{
+		Direct: modeFixture{
+			Env: map[string]string{
+				"MEMORY_FILE_PATH": directMemoryPath,
+			},
+		},
+		Proxied: modeFixture{
+			Env: map[string]string{
+				"MEMORY_FILE_PATH": proxiedMemoryPath,
+			},
+		},
+	}
+}
+
+func normalizeMemoryResult(_ serverMode, value any, _ *fixtureBundle) any {
+	return normalizeMemoryGraphValue(value)
+}
+
+func normalizeMemoryGraphValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		if entities, ok := typed["entities"].([]any); ok {
+			typed["entities"] = normalizeEntities(entities)
+		}
+		if relations, ok := typed["relations"].([]any); ok {
+			typed["relations"] = normalizeRelations(relations)
+		}
+
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+
+		normalized := make(map[string]any, len(typed))
+		for _, key := range keys {
+			normalized[key] = normalizeMemoryGraphValue(typed[key])
+		}
+		return normalized
+	case []any:
+		items := make([]any, len(typed))
+		for i := range typed {
+			items[i] = normalizeMemoryGraphValue(typed[i])
+		}
+		return items
+	default:
+		return typed
+	}
+}
+
+func normalizeEntities(values []any) []any {
+	normalized := make([]any, 0, len(values))
+	for _, value := range values {
+		entity, ok := value.(map[string]any)
+		if !ok {
+			normalized = append(normalized, normalizeMemoryGraphValue(value))
+			continue
+		}
+		if observations, ok := entity["observations"].([]any); ok {
+			sort.Slice(observations, func(i, j int) bool {
+				return stringifyJSONValue(observations[i]) < stringifyJSONValue(observations[j])
+			})
+			entity["observations"] = observations
+		}
+		normalized = append(normalized, normalizeMemoryGraphValue(entity))
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		left := normalized[i].(map[string]any)["name"]
+		right := normalized[j].(map[string]any)["name"]
+		return stringifyJSONValue(left) < stringifyJSONValue(right)
+	})
+	return normalized
+}
+
+func normalizeRelations(values []any) []any {
+	normalized := make([]any, 0, len(values))
+	for _, value := range values {
+		normalized = append(normalized, normalizeMemoryGraphValue(value))
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		left := normalized[i].(map[string]any)
+		right := normalized[j].(map[string]any)
+		leftKey := stringifyJSONValue(left["from"]) + "|" + stringifyJSONValue(left["relationType"]) + "|" + stringifyJSONValue(left["to"])
+		rightKey := stringifyJSONValue(right["from"]) + "|" + stringifyJSONValue(right["relationType"]) + "|" + stringifyJSONValue(right["to"])
+		return leftKey < rightKey
+	})
+	return normalized
+}
+
+func stringifyJSONValue(value any) string {
+	data, _ := json.Marshal(value)
+	return string(data)
+}

--- a/tests/integrationtests/realworld/sequential_thinking_test.go
+++ b/tests/integrationtests/realworld/sequential_thinking_test.go
@@ -1,0 +1,81 @@
+package realworld
+
+import (
+	"context"
+	"testing"
+)
+
+var sequentialThinkingManifest = serverManifest{
+	Name:           "sequentialthinking",
+	GatewayID:      "sequentialthinking",
+	ServerID:       "sequentialthinking",
+	CommandEnvVar:  "CENTIAN_SEQ_THINKING_SERVER_CMD",
+	ArgsEnvVar:     "CENTIAN_SEQ_THINKING_SERVER_ARGS",
+	DefaultCommand: "npx",
+	DefaultArgs:    []string{"-y", "@modelcontextprotocol/server-sequential-thinking"},
+	ExpectedTools:  []string{"sequentialthinking"},
+	BuildFixture: func(t *testing.T) *fixtureBundle {
+		t.Helper()
+		return &fixtureBundle{}
+	},
+}
+
+func TestSequentialThinkingToolCatalogParity(t *testing.T) {
+	runServerComparison(t, sequentialThinkingManifest, "tool_catalog", func(ctx context.Context, t *testing.T, pair *connectionPair, _ *fixtureBundle) {
+		assertToolCatalogParity(ctx, t, sequentialThinkingManifest, pair)
+	})
+}
+
+func TestSequentialThinkingToolParity(t *testing.T) {
+	testCases := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "linear",
+			args: map[string]any{
+				"thought":           "Break the work into two implementation steps.",
+				"thoughtNumber":     1,
+				"totalThoughts":     2,
+				"nextThoughtNeeded": true,
+			},
+		},
+		{
+			name: "revision",
+			args: map[string]any{
+				"thought":           "Revising the earlier plan to remove a risky migration.",
+				"thoughtNumber":     2,
+				"totalThoughts":     3,
+				"nextThoughtNeeded": true,
+				"isRevision":        true,
+				"revisesThought":    1,
+			},
+		},
+		{
+			name: "branch",
+			args: map[string]any{
+				"thought":           "Explore a browser-based alternative in a branch.",
+				"thoughtNumber":     3,
+				"totalThoughts":     3,
+				"nextThoughtNeeded": true,
+				"branchFromThought": 2,
+				"branchId":          "browser-path",
+			},
+		},
+		{
+			name: "complete",
+			args: map[string]any{
+				"thought":           "The solution is good enough to finalize.",
+				"thoughtNumber":     4,
+				"totalThoughts":     4,
+				"nextThoughtNeeded": false,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		runServerComparison(t, sequentialThinkingManifest, tc.name, func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
+			assertToolCallParity(ctx, t, sequentialThinkingManifest, fixture, pair, "sequentialthinking", tc.args, tc.args)
+		})
+	}
+}

--- a/tests/integrationtests/realworld/sequential_thinking_test.go
+++ b/tests/integrationtests/realworld/sequential_thinking_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var sequentialThinkingManifest = serverManifest{
+var sequentialThinkingManifest = &serverManifest{
 	Name:           "sequentialthinking",
 	GatewayID:      "sequentialthinking",
 	ServerID:       "sequentialthinking",


### PR DESCRIPTION
## Summary

Add a new opt-in real-world MCP integration test suite for official “easy” servers and wire it into `make`.

This introduces a shared test harness under `tests/integrationtests/realworld` and first coverage for:
- filesystem
- fetch
- memory
- sequential thinking

The new suites compare a direct connection to the real downstream MCP server with the same server accessed through Centian, with strict parity checks for tool catalogs and tool results.

## What changed

- Added a shared real-world integration harness in `tests/integrationtests/realworld/harness_test.go`
- Added hermetic suites for:
  - `filesystem`
  - `fetch`
  - `memory`
  - `sequential thinking`
- Added fixture isolation for mutating servers:
  - cloned temp directories for filesystem
  - separate `MEMORY_FILE_PATH` files for direct vs proxied memory runs
- Added result normalization where needed:
  - filesystem path normalization
  - memory graph sorting/normalization
- Added local `httptest.Server` coverage for fetch so the suite stays offline and deterministic
- Added filesystem roots update coverage to exercise `roots/list_changed` passthrough through Centian
- Added `make test-realworld`
- Updated `tests/README.md` with the new command

## Why

The existing `everything` integration suite is useful for gap discovery, but it does not cover the most practical MCP usage patterns Centian will see in real deployments.

These new suites focus on green-path conformance for common server types:
- local filesystem access
- local/stateful graph memory
- deterministic reasoning tools
- local HTTP fetch flows

## Test coverage

New tests include:
- tool catalog parity for all four servers
- direct vs proxied tool result parity
- filesystem read/write/move/dry-run edit flows
- filesystem roots update propagation
- fetch markdown/raw/chunked/error paths
- memory multi-step scenario parity
- sequential thinking linear/revision/branch/completion cases

## Known issue

The live `memory` suite currently exposes a Centian proxy issue:
- proxied memory tool catalog is empty in the live run
- proxied `create_entities` can fail with `unknown tool "create_entities"`

The test remains strict so it can serve as a regression check once that proxy behavior is fixed.
