### PR TITLE
Feature/66 forward downstream logging

### DIFF
--- a/internal/proxy/downstream_client_state.go
+++ b/internal/proxy/downstream_client_state.go
@@ -19,6 +19,9 @@ type DownstreamSamplingHandler func(context.Context, *mcp.CreateMessageRequest) 
 // DownstreamElicitationHandler forwards elicitation requests from a downstream session.
 type DownstreamElicitationHandler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)
 
+// DownstreamLoggingHandler forwards logging notifications from a downstream session.
+type DownstreamLoggingHandler func(context.Context, *mcp.LoggingMessageRequest)
+
 // DownstreamClientState describes the effective upstream client state mirrored downstream.
 type DownstreamClientState struct {
 	ProtocolVersion         string
@@ -34,6 +37,7 @@ type DownstreamConnectOptions struct {
 	ClientState        DownstreamClientState
 	SamplingHandler    DownstreamSamplingHandler
 	ElicitationHandler DownstreamElicitationHandler
+	LoggingHandler     DownstreamLoggingHandler
 }
 
 type clientCapabilitiesWire struct {
@@ -60,6 +64,7 @@ func cloneDownstreamConnectOptions(options *DownstreamConnectOptions) *Downstrea
 		},
 		SamplingHandler:    options.SamplingHandler,
 		ElicitationHandler: options.ElicitationHandler,
+		LoggingHandler:     options.LoggingHandler,
 	}
 }
 

--- a/internal/proxy/downstream_connection.go
+++ b/internal/proxy/downstream_connection.go
@@ -137,6 +137,9 @@ func (dc *DownstreamConnection) buildClientOptions(options *DownstreamConnectOpt
 	if options.ElicitationHandler != nil {
 		clientOptions.ElicitationHandler = options.ElicitationHandler
 	}
+	if options.LoggingHandler != nil {
+		clientOptions.LoggingMessageHandler = options.LoggingHandler
+	}
 	return clientOptions
 }
 
@@ -403,6 +406,17 @@ func (dc *DownstreamConnection) Unsubscribe(ctx context.Context, uri string) err
 		return fmt.Errorf("not connected to %s", dc.serverName)
 	}
 	return dc.session.Unsubscribe(ctx, &mcp.UnsubscribeParams{URI: uri})
+}
+
+// SetLoggingLevel forwards a logging level request to the downstream server.
+func (dc *DownstreamConnection) SetLoggingLevel(ctx context.Context, params *mcp.SetLoggingLevelParams) error {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+
+	if !dc.status.IsConnected() || dc.session == nil {
+		return fmt.Errorf("not connected to %s", dc.serverName)
+	}
+	return dc.session.SetLoggingLevel(ctx, params)
 }
 
 // CallTool forwards a tool call to the downstream server.

--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -25,6 +25,7 @@ type MockDownstreamConnection struct {
 	CapturedArgs         map[string]any
 	CapturedConnects     []DownstreamConnectOptions
 	CapturedConnectAuths []map[string]string
+	CapturedLogLevels    []mcp.LoggingLevel
 
 	// Configurable downstream behavior.
 	ResultToReturn *mcp.CallToolResult
@@ -170,6 +171,15 @@ func (m *MockDownstreamConnection) Unsubscribe(_ context.Context, _ string) erro
 	return nil
 }
 
+func (m *MockDownstreamConnection) SetLoggingLevel(_ context.Context, params *mcp.SetLoggingLevelParams) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if params != nil {
+		m.CapturedLogLevels = append(m.CapturedLogLevels, params.Level)
+	}
+	return nil
+}
+
 func (m *MockDownstreamConnection) SyncClientState(_ context.Context, state *DownstreamClientState) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -192,6 +202,7 @@ func cloneConnectOptions(options *DownstreamConnectOptions) DownstreamConnectOpt
 		ForwardedHeaders:   cloneAuthHeaders(options.ForwardedHeaders),
 		SamplingHandler:    options.SamplingHandler,
 		ElicitationHandler: options.ElicitationHandler,
+		LoggingHandler:     options.LoggingHandler,
 	}
 	cloned.ClientState = DownstreamClientState{
 		ProtocolVersion:         options.ClientState.ProtocolVersion,

--- a/internal/proxy/downstream_connection_test.go
+++ b/internal/proxy/downstream_connection_test.go
@@ -189,6 +189,65 @@ func TestDownstreamConnectionDiscoverTools(t *testing.T) {
 	assert.Equal(t, dc.tools[0].Name, "ping")
 }
 
+func TestBuildClientOptions_IncludesLoggingHandler(t *testing.T) {
+	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
+	called := false
+
+	options := dc.buildClientOptions(&DownstreamConnectOptions{
+		LoggingHandler: func(_ context.Context, req *mcp.LoggingMessageRequest) {
+			called = req != nil && req.Params != nil && req.Params.Level == "info"
+		},
+	})
+
+	assert.Assert(t, options.LoggingMessageHandler != nil)
+	options.LoggingMessageHandler(context.Background(), &mcp.LoggingMessageRequest{
+		Params: &mcp.LoggingMessageParams{Level: "info"},
+	})
+	assert.Assert(t, called)
+}
+
+func TestDownstreamConnection_ForwardsLoggingNotifications(t *testing.T) {
+	ctx := context.Background()
+	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "1.0.0"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "log", Description: "log"}, func(ctx context.Context, req *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
+		if err := req.Session.Log(ctx, &mcp.LoggingMessageParams{Level: "info", Data: "hello"}); err != nil {
+			return nil, nil, err
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+		}, nil, nil
+	})
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	assert.NilError(t, err)
+	defer func() { _ = serverSession.Close() }()
+
+	received := make(chan *mcp.LoggingMessageParams, 1)
+	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
+	dc.client = mcp.NewClient(&mcp.Implementation{Name: "client", Version: "1.0.0"}, dc.buildClientOptions(&DownstreamConnectOptions{
+		LoggingHandler: func(_ context.Context, req *mcp.LoggingMessageRequest) {
+			received <- req.Params
+		},
+	}))
+	clientSession, err := dc.client.Connect(ctx, clientTransport, nil)
+	assert.NilError(t, err)
+	defer func() { _ = clientSession.Close() }()
+	dc.session = clientSession
+	dc.status = StatusConnected
+
+	assert.NilError(t, dc.SetLoggingLevel(ctx, &mcp.SetLoggingLevelParams{Level: "info"}))
+	_, err = dc.CallTool(ctx, "log", map[string]any{})
+	assert.NilError(t, err)
+
+	select {
+	case params := <-received:
+		assert.Equal(t, params.Data.(string), "hello")
+	case <-time.After(time.Second):
+		t.Fatal("expected downstream log notification")
+	}
+}
+
 func TestDownstreamConnectionCallTool_NotConnected(t *testing.T) {
 	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
 

--- a/internal/proxy/forwarded_method_error.go
+++ b/internal/proxy/forwarded_method_error.go
@@ -1,0 +1,37 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	mcpMethodCallTool     = "tools/call"
+	mcpMethodReadResource = "resources/read"
+	mcpMethodGetPrompt    = "prompts/get"
+	mcpMethodComplete     = "completion/complete"
+	mcpMethodSubscribe    = "resources/subscribe"
+	mcpMethodUnsubscribe  = "resources/unsubscribe"
+)
+
+func normalizeForwardedMethodError(method string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	prefix := fmt.Sprintf("calling %q: ", method)
+	if !strings.HasPrefix(err.Error(), prefix) {
+		return err
+	}
+
+	if unwrapped := errors.Unwrap(err); unwrapped != nil {
+		return unwrapped
+	}
+
+	inner := strings.TrimPrefix(err.Error(), prefix)
+	if inner == "" || inner == err.Error() {
+		return err
+	}
+	return errors.New(inner)
+}

--- a/internal/proxy/forwarded_method_error_test.go
+++ b/internal/proxy/forwarded_method_error_test.go
@@ -1,0 +1,121 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/T4cceptor/centian/internal/common"
+	"github.com/T4cceptor/centian/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gotest.tools/assert"
+)
+
+type plainError string
+
+func (e plainError) Error() string { return string(e) }
+
+type readResourceErrorConn struct {
+	*MockDownstreamConnection
+	err error
+}
+
+func (c *readResourceErrorConn) ReadResource(_ context.Context, _ string) (*mcp.ReadResourceResult, error) {
+	return nil, c.err
+}
+
+func TestNormalizeForwardedMethodError(t *testing.T) {
+	t.Run("unwraps matching sdk wrapper", func(t *testing.T) {
+		inner := errors.New("validation failed")
+		err := fmt.Errorf("calling %q: %w", mcpMethodCallTool, inner)
+
+		got := normalizeForwardedMethodError(mcpMethodCallTool, err)
+
+		assert.Assert(t, got == inner)
+	})
+
+	t.Run("unwraps matching non tool method", func(t *testing.T) {
+		inner := errors.New("resource missing")
+		err := fmt.Errorf("calling %q: %w", mcpMethodReadResource, inner)
+
+		got := normalizeForwardedMethodError(mcpMethodReadResource, err)
+
+		assert.Assert(t, got == inner)
+	})
+
+	t.Run("leaves mismatched method untouched", func(t *testing.T) {
+		inner := errors.New("validation failed")
+		err := fmt.Errorf("calling %q: %w", mcpMethodCallTool, inner)
+
+		got := normalizeForwardedMethodError(mcpMethodReadResource, err)
+
+		assert.Equal(t, got.Error(), err.Error())
+	})
+
+	t.Run("leaves unrelated errors untouched", func(t *testing.T) {
+		err := errors.New("plain downstream error")
+
+		got := normalizeForwardedMethodError(mcpMethodCallTool, err)
+
+		assert.Assert(t, got == err)
+	})
+
+	t.Run("falls back to trimming one matching prefix when unwrapping is unavailable", func(t *testing.T) {
+		err := plainError(`calling "resources/read": resource missing`)
+
+		got := normalizeForwardedMethodError(mcpMethodReadResource, err)
+
+		assert.Equal(t, got.Error(), "resource missing")
+	})
+}
+
+func TestToolCallContextSendRequestNormalizesDownstreamMethodWrapper(t *testing.T) {
+	inner := errors.New("validation failed")
+	toolCtx := &ToolCallContext{
+		proxy:              &CentianEndpoint{},
+		originalServerName: "orig-srv",
+		upstreamSession: &UpstreamSession{
+			downstreamConns: map[string]DownstreamConnectionInterface{
+				"srv": &MockDownstreamConnection{
+					cfg:           &config.MCPServerConfig{Command: "python3"},
+					Status:        StatusConnected,
+					ErrorToReturn: fmt.Errorf("calling %q: %w", mcpMethodCallTool, inner),
+				},
+			},
+		},
+		routingContext: &common.RoutingContext{ServerName: "srv"},
+		request: &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{
+				Name:      "tool_name",
+				Arguments: []byte(`{"a":1}`),
+			},
+		},
+		event: common.NewMCPRequestEvent("stdio"),
+	}
+
+	err := toolCtx.SendRequest(context.Background())
+
+	assert.Assert(t, err == inner)
+}
+
+func TestForwardReadResourceNormalizesDownstreamMethodWrapper(t *testing.T) {
+	inner := errors.New("resource missing")
+	conn := &readResourceErrorConn{
+		MockDownstreamConnection: &MockDownstreamConnection{
+			serverName: "srv",
+			Status:     StatusConnected,
+		},
+		err: fmt.Errorf("calling %q: %w", mcpMethodReadResource, inner),
+	}
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"srv": conn,
+		},
+	}
+
+	_, err := proxy.forwardReadResource(context.Background(), session, "srv", "file:///test")
+
+	assert.Assert(t, err == inner)
+}

--- a/internal/proxy/forwarded_method_error_test.go
+++ b/internal/proxy/forwarded_method_error_test.go
@@ -32,7 +32,7 @@ func TestNormalizeForwardedMethodError(t *testing.T) {
 
 		got := normalizeForwardedMethodError(mcpMethodCallTool, err)
 
-		assert.Assert(t, got == inner)
+		assert.Assert(t, errors.Is(got, inner))
 	})
 
 	t.Run("unwraps matching non tool method", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestNormalizeForwardedMethodError(t *testing.T) {
 
 		got := normalizeForwardedMethodError(mcpMethodReadResource, err)
 
-		assert.Assert(t, got == inner)
+		assert.Assert(t, errors.Is(got, inner))
 	})
 
 	t.Run("leaves mismatched method untouched", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestNormalizeForwardedMethodError(t *testing.T) {
 
 		got := normalizeForwardedMethodError(mcpMethodCallTool, err)
 
-		assert.Assert(t, got == err)
+		assert.Assert(t, errors.Is(got, err))
 	})
 
 	t.Run("falls back to trimming one matching prefix when unwrapping is unavailable", func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestToolCallContextSendRequestNormalizesDownstreamMethodWrapper(t *testing.
 
 	err := toolCtx.SendRequest(context.Background())
 
-	assert.Assert(t, err == inner)
+	assert.Assert(t, errors.Is(err, inner))
 }
 
 func TestForwardReadResourceNormalizesDownstreamMethodWrapper(t *testing.T) {
@@ -117,5 +117,5 @@ func TestForwardReadResourceNormalizesDownstreamMethodWrapper(t *testing.T) {
 
 	_, err := proxy.forwardReadResource(context.Background(), session, "srv", "file:///test")
 
-	assert.Assert(t, err == inner)
+	assert.Assert(t, errors.Is(err, inner))
 }

--- a/internal/proxy/interfaces.go
+++ b/internal/proxy/interfaces.go
@@ -36,6 +36,7 @@ type DownstreamConnectionInterface interface {
 	Complete(ctx context.Context, req *mcp.CompleteRequest) (*mcp.CompleteResult, error)
 	Subscribe(ctx context.Context, uri string) error
 	Unsubscribe(ctx context.Context, uri string) error
+	SetLoggingLevel(ctx context.Context, params *mcp.SetLoggingLevelParams) error
 	Close() error
 	GetConfig() *config.MCPServerConfig
 	GetStatus() ConnectionStatus

--- a/internal/proxy/proxy_downstream_pool.go
+++ b/internal/proxy/proxy_downstream_pool.go
@@ -152,6 +152,8 @@ func (p *CentianEndpoint) connectDownstreamPool(
 	connectOptions *DownstreamConnectOptions,
 ) {
 	serverName := conn.GetServerName()
+	connectOptions = cloneDownstreamConnectOptions(connectOptions)
+	connectOptions.LoggingHandler = p.newPoolLoggingHandler(downstreamSessionKey, serverName, conn)
 	if err := conn.Connect(context.Background(), connectOptions); err != nil {
 		p.mu.Lock()
 		if pool, ok := p.downstreamPools[downstreamSessionKey]; ok {
@@ -163,6 +165,8 @@ func (p *CentianEndpoint) connectDownstreamPool(
 		common.LogWarn("ProxyEndpoint[%s]: failed to connect pooled downstream %s: %v", p.name, serverName, err)
 		return
 	}
+
+	p.syncPoolLoggingLevel(downstreamSessionKey)
 
 	p.mu.Lock()
 	var sessions []*UpstreamSession

--- a/internal/proxy/proxy_http.go
+++ b/internal/proxy/proxy_http.go
@@ -24,6 +24,7 @@ import (
 type observedMCPRequest struct {
 	sessionID string
 	methods   map[string]struct{}
+	logLevel  mcp.LoggingLevel
 }
 
 func (o observedMCPRequest) hasMethod(method string) bool {
@@ -134,6 +135,9 @@ func (p *CentianEndpoint) observeMCPRequests(next http.Handler) http.Handler {
 			p.markUpstreamSessionRootsDirty(sessionID)
 			p.syncUpstreamSessionState(r.Context(), sessionID)
 		}
+		if observation.logLevel != "" {
+			p.syncUpstreamLoggingLevel(sessionID, observation.logLevel)
+		}
 		if delayedWriter != nil {
 			writeDelayedResponse(w, delayedWriter)
 		}
@@ -154,6 +158,7 @@ func inspectMCPRequest(r *http.Request) observedMCPRequest {
 	return observedMCPRequest{
 		sessionID: r.Header.Get("Mcp-Session-Id"),
 		methods:   methods,
+		logLevel:  extractLoggingLevel(body),
 	}
 }
 
@@ -181,6 +186,43 @@ func extractMCPMethods(body []byte) map[string]struct{} {
 		methods[single.Method] = struct{}{}
 	}
 	return methods
+}
+
+func extractLoggingLevel(body []byte) mcp.LoggingLevel {
+	type rpcEnvelope struct {
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	type setLevelParams struct {
+		Level mcp.LoggingLevel `json:"level"`
+	}
+
+	extract := func(items []rpcEnvelope) mcp.LoggingLevel {
+		var level mcp.LoggingLevel
+		for _, item := range items {
+			if item.Method != "logging/setLevel" {
+				continue
+			}
+			var params setLevelParams
+			if err := json.Unmarshal(item.Params, &params); err == nil && params.Level != "" {
+				level = params.Level
+			}
+		}
+		return level
+	}
+
+	var batch []rpcEnvelope
+	if err := json.Unmarshal(body, &batch); err == nil {
+		if level := extract(batch); level != "" {
+			return level
+		}
+	}
+
+	var single rpcEnvelope
+	if err := json.Unmarshal(body, &single); err == nil {
+		return extract([]rpcEnvelope{single})
+	}
+	return ""
 }
 
 func cloneRequestBody(r *http.Request) []byte {

--- a/internal/proxy/proxy_logging.go
+++ b/internal/proxy/proxy_logging.go
@@ -7,6 +7,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+const logLevelInfo mcp.LoggingLevel = "info"
+
 // This file forwards downstream logging notifications to the live upstream
 // sessions attached to the same pooled downstream session.
 
@@ -177,7 +179,7 @@ func loggingLevelRank(level mcp.LoggingLevel) int {
 	switch level {
 	case "debug":
 		return 0
-	case "info":
+	case logLevelInfo:
 		return 1
 	case "notice":
 		return 2

--- a/internal/proxy/proxy_logging.go
+++ b/internal/proxy/proxy_logging.go
@@ -1,0 +1,197 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/T4cceptor/centian/internal/common"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// This file forwards downstream logging notifications to the live upstream
+// sessions attached to the same pooled downstream session.
+
+func (p *CentianEndpoint) newPoolLoggingHandler(
+	downstreamSessionKey string,
+	serverName string,
+	conn DownstreamConnectionInterface,
+) DownstreamLoggingHandler {
+	return func(ctx context.Context, req *mcp.LoggingMessageRequest) {
+		if req == nil || req.Params == nil {
+			return
+		}
+		p.forwardDownstreamLog(ctx, downstreamSessionKey, serverName, conn, req.Params)
+	}
+}
+
+func (p *CentianEndpoint) forwardDownstreamLog(
+	ctx context.Context,
+	downstreamSessionKey string,
+	serverName string,
+	conn DownstreamConnectionInterface,
+	params *mcp.LoggingMessageParams,
+) {
+	if params == nil || downstreamSessionKey == "" {
+		return
+	}
+
+	sessions := p.snapshotPoolUpstreamSessions(downstreamSessionKey, conn)
+	for _, session := range sessions {
+		serverSession := p.currentUpstreamServerSession(session)
+		if serverSession == nil {
+			continue
+		}
+		if err := serverSession.Log(ctx, params); err != nil {
+			common.LogWarn(
+				"ProxyEndpoint[%s]: failed to forward downstream log from %s to upstream session %s: %v",
+				p.name,
+				sanitizeLogValue(serverName),
+				sanitizeLogValue(session.id),
+				err,
+			)
+		}
+	}
+}
+
+func (p *CentianEndpoint) snapshotPoolUpstreamSessions(
+	downstreamSessionKey string,
+	conn DownstreamConnectionInterface,
+) []*UpstreamSession {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	pool := p.downstreamPools[downstreamSessionKey]
+	if pool != nil && (conn == nil || poolContainsConnection(pool, conn)) {
+		return clonePoolUpstreamSessions(pool)
+	}
+
+	if conn == nil {
+		return nil
+	}
+	for _, pool = range p.downstreamPools {
+		if poolContainsConnection(pool, conn) {
+			return clonePoolUpstreamSessions(pool)
+		}
+	}
+	return nil
+}
+
+func clonePoolUpstreamSessions(pool *DownstreamSessionPool) []*UpstreamSession {
+	if pool == nil {
+		return nil
+	}
+
+	sessions := make([]*UpstreamSession, 0, len(pool.upstreamSessions))
+	for _, session := range pool.upstreamSessions {
+		if session != nil {
+			sessions = append(sessions, session)
+		}
+	}
+	return sessions
+}
+
+func poolContainsConnection(pool *DownstreamSessionPool, conn DownstreamConnectionInterface) bool {
+	if pool == nil || conn == nil {
+		return false
+	}
+	current, ok := pool.downstreamConns[conn.GetServerName()]
+	return ok && current == conn
+}
+
+func (p *CentianEndpoint) syncUpstreamLoggingLevel(sessionID string, level mcp.LoggingLevel) {
+	if sessionID == "" || level == "" {
+		return
+	}
+
+	p.mu.Lock()
+	session := p.upstreamSessions[sessionID]
+	if session != nil {
+		session.logLevel = level
+	}
+	p.mu.Unlock()
+
+	if session == nil || session.downstreamSessionKey == "" {
+		return
+	}
+	p.syncPoolLoggingLevel(session.downstreamSessionKey)
+}
+
+func (p *CentianEndpoint) syncPoolLoggingLevel(downstreamSessionKey string) {
+	level, conns := p.poolLoggingState(downstreamSessionKey)
+	if level == "" {
+		return
+	}
+
+	for _, conn := range conns {
+		if err := conn.SetLoggingLevel(context.Background(), &mcp.SetLoggingLevelParams{Level: level}); err != nil {
+			common.LogWarn(
+				"ProxyEndpoint[%s]: failed to sync downstream logging level for %s: %v",
+				p.name,
+				sanitizeLogValue(conn.GetServerName()),
+				err,
+			)
+		}
+	}
+}
+
+func (p *CentianEndpoint) poolLoggingState(downstreamSessionKey string) (mcp.LoggingLevel, []DownstreamConnectionInterface) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	pool := p.downstreamPools[downstreamSessionKey]
+	if pool == nil {
+		return "", nil
+	}
+
+	level := mostVerbosePoolLogLevel(pool)
+	if level == "" {
+		return "", nil
+	}
+
+	conns := make([]DownstreamConnectionInterface, 0, len(pool.downstreamConns))
+	for _, conn := range pool.downstreamConns {
+		if conn != nil && conn.IsConnected() {
+			conns = append(conns, conn)
+		}
+	}
+	return level, conns
+}
+
+func mostVerbosePoolLogLevel(pool *DownstreamSessionPool) mcp.LoggingLevel {
+	if pool == nil {
+		return ""
+	}
+
+	var level mcp.LoggingLevel
+	for _, session := range pool.upstreamSessions {
+		if session == nil || session.logLevel == "" {
+			continue
+		}
+		if level == "" || loggingLevelRank(session.logLevel) < loggingLevelRank(level) {
+			level = session.logLevel
+		}
+	}
+	return level
+}
+
+func loggingLevelRank(level mcp.LoggingLevel) int {
+	switch level {
+	case "debug":
+		return 0
+	case "info":
+		return 1
+	case "notice":
+		return 2
+	case "warning":
+		return 3
+	case "error":
+		return 4
+	case "critical":
+		return 5
+	case "alert":
+		return 6
+	case "emergency":
+		return 7
+	default:
+		return 100
+	}
+}

--- a/internal/proxy/proxy_logging_test.go
+++ b/internal/proxy/proxy_logging_test.go
@@ -1,0 +1,282 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/T4cceptor/centian/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gotest.tools/assert"
+)
+
+type loggingNotificationRecorder struct {
+	mu       sync.Mutex
+	messages []*mcp.LoggingMessageParams
+}
+
+func (r *loggingNotificationRecorder) record(params *mcp.LoggingMessageParams) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages = append(r.messages, params)
+}
+
+func (r *loggingNotificationRecorder) snapshot() []*mcp.LoggingMessageParams {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*mcp.LoggingMessageParams(nil), r.messages...)
+}
+
+func newLoggingTestProxy() *CentianEndpoint {
+	return &CentianEndpoint{
+		name:             "gateway",
+		endpoint:         "/mcp/gateway",
+		server:           &CentianServer{Config: &config.GlobalConfig{Version: "1.0.0"}},
+		upstreamSessions: make(map[string]*UpstreamSession),
+		downstreamPools:  make(map[string]*DownstreamSessionPool),
+	}
+}
+
+func newLoggingTestSession(proxy *CentianEndpoint, sessionID string) *UpstreamSession {
+	session := &UpstreamSession{
+		id:                  sessionID,
+		downstreamConns:     make(map[string]DownstreamConnectionInterface),
+		registeredTools:     make(map[string]struct{}),
+		registeredResources: make(map[string]struct{}),
+		registeredPrompts:   make(map[string]struct{}),
+	}
+	session.upstreamServer = proxy.newUpstreamServer(session)
+	proxy.upstreamSessions[sessionID] = session
+	return session
+}
+
+func connectLoggingClient(
+	t *testing.T,
+	session *UpstreamSession,
+	middleware ...mcp.Middleware,
+) (*loggingNotificationRecorder, func()) {
+	t.Helper()
+
+	for _, mw := range middleware {
+		session.upstreamServer.AddSendingMiddleware(mw)
+	}
+
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := session.upstreamServer.Connect(ctx, serverTransport, nil)
+	assert.NilError(t, err)
+
+	recorder := &loggingNotificationRecorder{}
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "1.0.0"}, &mcp.ClientOptions{
+		LoggingMessageHandler: func(_ context.Context, req *mcp.LoggingMessageRequest) {
+			recorder.record(req.Params)
+		},
+	})
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	assert.NilError(t, err)
+	assert.NilError(t, clientSession.SetLoggingLevel(ctx, &mcp.SetLoggingLevelParams{Level: "info"}))
+	// In-memory SDK sessions do not expose transport session IDs, so use the
+	// existing empty-ID fallback when resolving the live session in tests.
+	session.id = ""
+
+	return recorder, func() {
+		_ = clientSession.Close()
+		_ = serverSession.Close()
+	}
+}
+
+func waitForLogCount(t *testing.T, recorder *loggingNotificationRecorder, want int) []*mcp.LoggingMessageParams {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := recorder.snapshot()
+		if len(snapshot) == want {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	snapshot := recorder.snapshot()
+	t.Fatalf("expected %d log messages, got %d", want, len(snapshot))
+	return nil
+}
+
+func failLoggingNotificationMiddleware(err error) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if method == "notifications/message" {
+				return nil, err
+			}
+			return next(ctx, method, req)
+		}
+	}
+}
+
+func TestForwardDownstreamLog_SingleSession(t *testing.T) {
+	proxy := newLoggingTestProxy()
+	session := newLoggingTestSession(proxy, "session-1")
+	recorder, cleanup := connectLoggingClient(t, session)
+	defer cleanup()
+
+	proxy.downstreamPools["pool-1"] = &DownstreamSessionPool{
+		downstreamSessionKey: "pool-1",
+		upstreamSessions:     map[string]*UpstreamSession{"session-1": session},
+	}
+
+	proxy.forwardDownstreamLog(context.Background(), "pool-1", "server-1", nil, &mcp.LoggingMessageParams{
+		Level: "info",
+		Data:  "hello",
+	})
+
+	messages := waitForLogCount(t, recorder, 1)
+	assert.Equal(t, messages[0].Data.(string), "hello")
+}
+
+func TestForwardDownstreamLog_BroadcastsToSharedPool(t *testing.T) {
+	proxy := newLoggingTestProxy()
+	sessionA := newLoggingTestSession(proxy, "session-a")
+	sessionB := newLoggingTestSession(proxy, "session-b")
+	recorderA, cleanupA := connectLoggingClient(t, sessionA)
+	defer cleanupA()
+	recorderB, cleanupB := connectLoggingClient(t, sessionB)
+	defer cleanupB()
+
+	proxy.downstreamPools["pool-1"] = &DownstreamSessionPool{
+		downstreamSessionKey: "pool-1",
+		upstreamSessions: map[string]*UpstreamSession{
+			"session-a": sessionA,
+			"session-b": sessionB,
+		},
+	}
+
+	proxy.forwardDownstreamLog(context.Background(), "pool-1", "server-1", nil, &mcp.LoggingMessageParams{
+		Level: "info",
+		Data:  "broadcast",
+	})
+
+	assert.Equal(t, waitForLogCount(t, recorderA, 1)[0].Data.(string), "broadcast")
+	assert.Equal(t, waitForLogCount(t, recorderB, 1)[0].Data.(string), "broadcast")
+}
+
+func TestForwardDownstreamLog_SkipsStaleSessions(t *testing.T) {
+	proxy := newLoggingTestProxy()
+	liveSession := newLoggingTestSession(proxy, "session-live")
+	staleSession := newLoggingTestSession(proxy, "session-stale")
+	recorder, cleanup := connectLoggingClient(t, liveSession)
+	defer cleanup()
+
+	proxy.downstreamPools["pool-1"] = &DownstreamSessionPool{
+		downstreamSessionKey: "pool-1",
+		upstreamSessions: map[string]*UpstreamSession{
+			"session-live":  liveSession,
+			"session-stale": staleSession,
+		},
+	}
+
+	proxy.forwardDownstreamLog(context.Background(), "pool-1", "server-1", nil, &mcp.LoggingMessageParams{
+		Level: "info",
+		Data:  "live-only",
+	})
+
+	messages := waitForLogCount(t, recorder, 1)
+	assert.Equal(t, messages[0].Data.(string), "live-only")
+	assert.Assert(t, proxy.currentUpstreamServerSession(staleSession) == nil)
+}
+
+func TestForwardDownstreamLog_ContinuesAfterRecipientError(t *testing.T) {
+	proxy := newLoggingTestProxy()
+	failingSession := newLoggingTestSession(proxy, "session-bad")
+	liveSession := newLoggingTestSession(proxy, "session-good")
+	_, cleanupBad := connectLoggingClient(t, failingSession, failLoggingNotificationMiddleware(errors.New("send failed")))
+	defer cleanupBad()
+	recorder, cleanupGood := connectLoggingClient(t, liveSession)
+	defer cleanupGood()
+
+	proxy.downstreamPools["pool-1"] = &DownstreamSessionPool{
+		downstreamSessionKey: "pool-1",
+		upstreamSessions: map[string]*UpstreamSession{
+			"session-bad":  failingSession,
+			"session-good": liveSession,
+		},
+	}
+
+	proxy.forwardDownstreamLog(context.Background(), "pool-1", "server-1", nil, &mcp.LoggingMessageParams{
+		Level: "info",
+		Data:  "still-delivered",
+	})
+
+	messages := waitForLogCount(t, recorder, 1)
+	assert.Equal(t, messages[0].Data.(string), "still-delivered")
+}
+
+func TestSyncUpstreamLoggingLevel_UsesMostVerbosePoolLevel(t *testing.T) {
+	proxy := newLoggingTestProxy()
+	conn := &MockDownstreamConnection{serverName: "server-1", Status: StatusConnected}
+	sessionInfo := newLoggingTestSession(proxy, "session-info")
+	sessionError := newLoggingTestSession(proxy, "session-error")
+	sessionInfo.downstreamSessionKey = "pool-1"
+	sessionError.downstreamSessionKey = "pool-1"
+	sessionError.logLevel = "error"
+
+	proxy.downstreamPools["pool-1"] = &DownstreamSessionPool{
+		downstreamSessionKey: "pool-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-1": conn,
+		},
+		upstreamSessions: map[string]*UpstreamSession{
+			"session-info":  sessionInfo,
+			"session-error": sessionError,
+		},
+	}
+
+	proxy.syncUpstreamLoggingLevel("session-info", "info")
+
+	conn.mu.RLock()
+	defer conn.mu.RUnlock()
+	assert.DeepEqual(t, conn.CapturedLogLevels, []mcp.LoggingLevel{"info"})
+}
+
+func TestProxyHTTP_SetLoggingLevelPropagatesToDownstreamPool(t *testing.T) {
+	mockConn := &MockDownstreamConnection{
+		serverName: "server-1",
+		Status:     StatusConnected,
+		tools: []*mcp.Tool{
+			{Name: "ping", Description: "ping", InputSchema: map[string]any{"type": "object"}},
+		},
+	}
+	proxy := &CentianEndpoint{
+		name:             "server-1",
+		endpoint:         "/mcp/server-1",
+		config:           &config.GatewayConfig{MCPServers: map[string]*config.MCPServerConfig{"server-1": {Command: "node"}}},
+		server:           &CentianServer{Config: &config.GlobalConfig{Version: "1.0.0"}},
+		upstreamSessions: make(map[string]*UpstreamSession),
+		downstreamPools:  make(map[string]*DownstreamSessionPool),
+		connectionFactory: func(string, *config.MCPServerConfig) DownstreamConnectionInterface {
+			return mockConn
+		},
+	}
+
+	mux := http.NewServeMux()
+	RegisterEndpoint(proxy, mux, nil)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
+		Endpoint: server.URL + "/mcp/server-1",
+	}, nil)
+	assert.NilError(t, err)
+	defer func() { _ = session.Close() }()
+
+	assert.NilError(t, session.SetLoggingLevel(context.Background(), &mcp.SetLoggingLevelParams{Level: "info"}))
+	waitForCondition(t, time.Second, func() bool {
+		mockConn.mu.RLock()
+		defer mockConn.mu.RUnlock()
+		return len(mockConn.CapturedLogLevels) == 1 && mockConn.CapturedLogLevels[0] == "info"
+	})
+}

--- a/internal/proxy/proxy_logging_test.go
+++ b/internal/proxy/proxy_logging_test.go
@@ -89,20 +89,20 @@ func connectLoggingClient(
 	}
 }
 
-func waitForLogCount(t *testing.T, recorder *loggingNotificationRecorder, want int) []*mcp.LoggingMessageParams {
+func waitForSingleLog(t *testing.T, recorder *loggingNotificationRecorder) []*mcp.LoggingMessageParams {
 	t.Helper()
 
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		snapshot := recorder.snapshot()
-		if len(snapshot) == want {
+		if len(snapshot) == 1 {
 			return snapshot
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
 	snapshot := recorder.snapshot()
-	t.Fatalf("expected %d log messages, got %d", want, len(snapshot))
+	t.Fatalf("expected 1 log message, got %d", len(snapshot))
 	return nil
 }
 
@@ -133,7 +133,7 @@ func TestForwardDownstreamLog_SingleSession(t *testing.T) {
 		Data:  "hello",
 	})
 
-	messages := waitForLogCount(t, recorder, 1)
+	messages := waitForSingleLog(t, recorder)
 	assert.Equal(t, messages[0].Data.(string), "hello")
 }
 
@@ -159,8 +159,8 @@ func TestForwardDownstreamLog_BroadcastsToSharedPool(t *testing.T) {
 		Data:  "broadcast",
 	})
 
-	assert.Equal(t, waitForLogCount(t, recorderA, 1)[0].Data.(string), "broadcast")
-	assert.Equal(t, waitForLogCount(t, recorderB, 1)[0].Data.(string), "broadcast")
+	assert.Equal(t, waitForSingleLog(t, recorderA)[0].Data.(string), "broadcast")
+	assert.Equal(t, waitForSingleLog(t, recorderB)[0].Data.(string), "broadcast")
 }
 
 func TestForwardDownstreamLog_SkipsStaleSessions(t *testing.T) {
@@ -183,7 +183,7 @@ func TestForwardDownstreamLog_SkipsStaleSessions(t *testing.T) {
 		Data:  "live-only",
 	})
 
-	messages := waitForLogCount(t, recorder, 1)
+	messages := waitForSingleLog(t, recorder)
 	assert.Equal(t, messages[0].Data.(string), "live-only")
 	assert.Assert(t, proxy.currentUpstreamServerSession(staleSession) == nil)
 }
@@ -210,7 +210,7 @@ func TestForwardDownstreamLog_ContinuesAfterRecipientError(t *testing.T) {
 		Data:  "still-delivered",
 	})
 
-	messages := waitForLogCount(t, recorder, 1)
+	messages := waitForSingleLog(t, recorder)
 	assert.Equal(t, messages[0].Data.(string), "still-delivered")
 }
 

--- a/internal/proxy/proxy_prompts.go
+++ b/internal/proxy/proxy_prompts.go
@@ -120,5 +120,9 @@ func (p *CentianEndpoint) forwardGetPrompt(ctx context.Context, session *Upstrea
 	if err != nil {
 		return nil, fmt.Errorf("prompt %q: %w", downstreamName, err)
 	}
-	return conn.GetPrompt(ctx, downstreamName, req.Params.Arguments)
+	result, err := conn.GetPrompt(ctx, downstreamName, req.Params.Arguments)
+	if err != nil {
+		return nil, normalizeForwardedMethodError(mcpMethodGetPrompt, err)
+	}
+	return result, nil
 }

--- a/internal/proxy/proxy_resources.go
+++ b/internal/proxy/proxy_resources.go
@@ -111,7 +111,11 @@ func (p *CentianEndpoint) forwardReadResource(ctx context.Context, session *Upst
 	if err != nil {
 		return nil, fmt.Errorf("resource %q: %w", uri, err)
 	}
-	return conn.ReadResource(ctx, uri)
+	result, err := conn.ReadResource(ctx, uri)
+	if err != nil {
+		return nil, normalizeForwardedMethodError(mcpMethodReadResource, err)
+	}
+	return result, nil
 }
 
 // forwardSubscribe forwards a resource subscription request to the downstream that owns the URI.
@@ -121,7 +125,7 @@ func (p *CentianEndpoint) forwardSubscribe(ctx context.Context, session *Upstrea
 	if conn == nil {
 		return fmt.Errorf("no downstream connection found for resource URI %q", uri)
 	}
-	return conn.Subscribe(ctx, uri)
+	return normalizeForwardedMethodError(mcpMethodSubscribe, conn.Subscribe(ctx, uri))
 }
 
 // forwardUnsubscribe forwards a resource unsubscription request to the downstream that owns the URI.
@@ -131,7 +135,7 @@ func (p *CentianEndpoint) forwardUnsubscribe(ctx context.Context, session *Upstr
 	if conn == nil {
 		return fmt.Errorf("no downstream connection found for resource URI %q", uri)
 	}
-	return conn.Unsubscribe(ctx, uri)
+	return normalizeForwardedMethodError(mcpMethodUnsubscribe, conn.Unsubscribe(ctx, uri))
 }
 
 // forwardCompletion forwards a completion request to the first connected downstream.
@@ -139,7 +143,11 @@ func (p *CentianEndpoint) forwardUnsubscribe(ctx context.Context, session *Upstr
 func (p *CentianEndpoint) forwardCompletion(ctx context.Context, session *UpstreamSession, req *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
 	for _, conn := range session.downstreamConns {
 		if conn.IsConnected() {
-			return conn.Complete(ctx, req)
+			result, err := conn.Complete(ctx, req)
+			if err != nil {
+				return nil, normalizeForwardedMethodError(mcpMethodComplete, err)
+			}
+			return result, nil
 		}
 	}
 	return nil, fmt.Errorf("no downstream connection available for completion request")

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -50,6 +50,7 @@ type UpstreamSession struct {
 	protocolVersion         string
 	clientCapabilities      *mcp.ClientCapabilities
 	roots                   []*mcp.Root
+	logLevel                mcp.LoggingLevel
 	capabilitiesFingerprint string
 	rootsFingerprint        string
 	rootsDirty              bool

--- a/internal/proxy/tool_call_context.go
+++ b/internal/proxy/tool_call_context.go
@@ -160,7 +160,7 @@ func (c *ToolCallContext) SendRequest(ctx context.Context) error {
 	// Note: per-request headers require CallTool signature change (Phase 3)
 	result, err := conn.CallTool(ctx, c.GetToolName(), args)
 	if err != nil {
-		return err
+		return normalizeForwardedMethodError(mcpMethodCallTool, err)
 	}
 	c.SetResult(result)
 	return nil

--- a/tests/integrationtests/everything/harness_test.go
+++ b/tests/integrationtests/everything/harness_test.go
@@ -25,6 +25,7 @@ const (
 	everythingServerCmdEnv      = "CENTIAN_EVERYTHING_SERVER_CMD"
 	everythingServerArgsEnv     = "CENTIAN_EVERYTHING_SERVER_ARGS"
 	defaultSessionTimeout       = 30 * time.Second
+	defaultDirectTerminateWait  = 250 * time.Millisecond
 	defaultToolsWaitTimeout     = 20 * time.Second
 	defaultEverythingServerCmd  = "npx"
 	defaultEverythingServerArgs = "-y @modelcontextprotocol/server-everything"
@@ -113,7 +114,10 @@ func (h *everythingHarness) connectDirect(t *testing.T) *instrumentedSession {
 	return connectInstrumentedSession(
 		t,
 		"direct",
-		&mcp.CommandTransport{Command: command},
+		&mcp.CommandTransport{
+			Command:           command,
+			TerminateDuration: defaultDirectTerminateWait,
+		},
 	)
 }
 
@@ -156,6 +160,9 @@ func connectInstrumentedSession(
 	}
 	t.Cleanup(func() {
 		if closeErr := session.Close(); closeErr != nil {
+			if mode == "direct" && isExpectedDirectCloseError(closeErr) {
+				return
+			}
 			t.Fatalf("failed to close %s session: %v", mode, closeErr)
 		}
 	})
@@ -166,6 +173,11 @@ func connectInstrumentedSession(
 		session:  session,
 		recorder: recorder,
 	}
+}
+
+func isExpectedDirectCloseError(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr)
 }
 
 func newInstrumentedClient(recorder *notificationRecorder) *mcp.Client {

--- a/tests/integrationtests/everything/harness_unit_test.go
+++ b/tests/integrationtests/everything/harness_unit_test.go
@@ -1,0 +1,15 @@
+package everything
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestIsExpectedDirectCloseError(t *testing.T) {
+	assert.Assert(t, isExpectedDirectCloseError(&exec.ExitError{}))
+	assert.Assert(t, !isExpectedDirectCloseError(errors.New("plain error")))
+	assert.Assert(t, !isExpectedDirectCloseError(nil))
+}

--- a/tests/integrationtests/everything/probe_test.go
+++ b/tests/integrationtests/everything/probe_test.go
@@ -176,13 +176,13 @@ func evaluateLoggingProbe(ctx context.Context, t *testing.T, pair *connectionPai
 	directSnapshot := pair.Direct.recorder.snapshot()
 	proxiedSnapshot := pair.Proxied.recorder.snapshot()
 
-	if directSnapshot.LogCount == proxiedSnapshot.LogCount && jsonEqual(t, directResult, proxiedResult) {
+	if directSnapshot.LogCount > 0 && proxiedSnapshot.LogCount > 0 && jsonEqual(t, directResult, proxiedResult) {
 		return phase3Outcome{
 			Name:           toolName,
 			Classification: classificationMatch,
-			Summary:        fmt.Sprintf("both paths produced %d log notifications", directSnapshot.LogCount),
-			DirectDetails:  prettyJSON(t, directSnapshot),
-			ProxiedDetails: prettyJSON(t, proxiedSnapshot),
+			Summary:        fmt.Sprintf("both paths produced log notifications (direct=%d proxied=%d)", directSnapshot.LogCount, proxiedSnapshot.LogCount),
+			DirectDetails:  renderLoggingOutcome(t, directResult, directSnapshot),
+			ProxiedDetails: renderLoggingOutcome(t, proxiedResult, proxiedSnapshot),
 		}
 	}
 
@@ -191,8 +191,8 @@ func evaluateLoggingProbe(ctx context.Context, t *testing.T, pair *connectionPai
 			Name:           toolName,
 			Classification: classificationProxyDivergence,
 			Summary:        "direct path received log notifications but proxied path did not",
-			DirectDetails:  prettyJSON(t, directSnapshot),
-			ProxiedDetails: prettyJSON(t, proxiedSnapshot),
+			DirectDetails:  renderLoggingOutcome(t, directResult, directSnapshot),
+			ProxiedDetails: renderLoggingOutcome(t, proxiedResult, proxiedSnapshot),
 		}
 	}
 
@@ -200,8 +200,8 @@ func evaluateLoggingProbe(ctx context.Context, t *testing.T, pair *connectionPai
 		Name:           toolName,
 		Classification: classificationProxyDivergence,
 		Summary:        "logging probe produced different direct/proxied outcomes",
-		DirectDetails:  fmt.Sprintf("result:\n%s\nnotifications:\n%s", prettyJSON(t, directResult), prettyJSON(t, directSnapshot)),
-		ProxiedDetails: fmt.Sprintf("result:\n%s\nnotifications:\n%s", prettyJSON(t, proxiedResult), prettyJSON(t, proxiedSnapshot)),
+		DirectDetails:  renderLoggingOutcome(t, directResult, directSnapshot),
+		ProxiedDetails: renderLoggingOutcome(t, proxiedResult, proxiedSnapshot),
 	}
 }
 
@@ -340,6 +340,12 @@ func renderOperationOutcome(t *testing.T, result any, err error) string {
 		return err.Error()
 	}
 	return prettyJSON(t, result)
+}
+
+func renderLoggingOutcome(t *testing.T, result *mcp.CallToolResult, snapshot notificationSnapshot) string {
+	t.Helper()
+
+	return fmt.Sprintf("result:\n%s\nLogCount: %d", prettyJSON(t, result), snapshot.LogCount)
 }
 
 func sameErrorMessage(left, right error) bool {

--- a/tests/integrationtests/realworld/filesystem_test.go
+++ b/tests/integrationtests/realworld/filesystem_test.go
@@ -32,6 +32,7 @@ var filesystemManifest = &serverManifest{
 		"read_text_file",
 		"search_files",
 		"write_file",
+		"read_file",
 	},
 	BuildFixture: buildFilesystemFixture,
 	Normalize:    normalizeFilesystemResult,


### PR DESCRIPTION
## Summary

This PR improves Centian’s downstream capability forwarding and proxy fidelity versus the direct path. It adds full pooled-session logging support, propagates upstream `logging/setLevel` to downstream sessions, and normalizes duplicated SDK RPC error wrappers before forwarding errors upstream.

See #66

## Added functionality

- Forward downstream `notifications/message` log events from pooled downstream sessions to all live upstream sessions attached to the same pool.
- Wire downstream logging callbacks through connection setup via `mcp.ClientOptions.LoggingMessageHandler`.
- Track upstream-selected logging levels per session and sync the effective level to connected downstream pooled sessions.
- Add downstream `SetLoggingLevel` support to the proxy connection layer.

## Changed functionality

- Proxy error forwarding now strips one redundant inner SDK wrapper like `calling "<method>": ...` before returning errors upstream.
- This normalization is applied generically to forwarded downstream request paths:
  - `tools/call`
  - `resources/read`
  - `prompts/get`
  - `completion/complete`
  - `resources/subscribe`
  - `resources/unsubscribe`
- The phase-3 logging probe now validates actual log delivery instead of requiring exact notification-count parity or comparing unrelated notification noise.

## Added/Changed tests

- Added unit tests for downstream logging handler wiring and downstream log forwarding.
- Added proxy-level tests for pooled log fan-out, stale-session skipping, and best-effort delivery when one recipient fails.
- Added unit tests for forwarded RPC error normalization.
- Added a harness unit test for expected direct-session close errors.
- Updated the `everything` integration probe expectations for logging behavior.
- Updated the realworld filesystem manifest test to include `read_file` - see #76

## Bugfixes of existing functionality

- Fixed missing forwarding of downstream log notifications for pooled sessions, including out-of-band logs.
- Fixed missing propagation of upstream `logging/setLevel` to downstream sessions.
- Fixed proxied sampling and elicitation failures caused by duplicated SDK error-wrapper noise.
- Fixed `everything` integration cleanup failures caused by expected direct `CommandTransport` subprocess termination on close.