### PR TITLE
Implemented resource capabilities

### DIFF
--- a/internal/proxy/downstream_client_state.go
+++ b/internal/proxy/downstream_client_state.go
@@ -22,6 +22,12 @@ type DownstreamElicitationHandler func(context.Context, *mcp.ElicitRequest) (*mc
 // DownstreamLoggingHandler forwards logging notifications from a downstream session.
 type DownstreamLoggingHandler func(context.Context, *mcp.LoggingMessageRequest)
 
+// DownstreamResourceListChangedHandler forwards resource list change notifications from a downstream session.
+type DownstreamResourceListChangedHandler func(context.Context, *mcp.ResourceListChangedRequest)
+
+// DownstreamResourceUpdatedHandler forwards resource update notifications from a downstream session.
+type DownstreamResourceUpdatedHandler func(context.Context, *mcp.ResourceUpdatedNotificationRequest)
+
 // DownstreamClientState describes the effective upstream client state mirrored downstream.
 type DownstreamClientState struct {
 	ProtocolVersion         string
@@ -33,11 +39,13 @@ type DownstreamClientState struct {
 
 // DownstreamConnectOptions configures downstream client setup.
 type DownstreamConnectOptions struct {
-	ForwardedHeaders   map[string]string
-	ClientState        DownstreamClientState
-	SamplingHandler    DownstreamSamplingHandler
-	ElicitationHandler DownstreamElicitationHandler
-	LoggingHandler     DownstreamLoggingHandler
+	ForwardedHeaders           map[string]string
+	ClientState                DownstreamClientState
+	SamplingHandler            DownstreamSamplingHandler
+	ElicitationHandler         DownstreamElicitationHandler
+	LoggingHandler             DownstreamLoggingHandler
+	ResourceListChangedHandler DownstreamResourceListChangedHandler
+	ResourceUpdatedHandler     DownstreamResourceUpdatedHandler
 }
 
 type clientCapabilitiesWire struct {
@@ -62,9 +70,11 @@ func cloneDownstreamConnectOptions(options *DownstreamConnectOptions) *Downstrea
 			CapabilitiesFingerprint: options.ClientState.CapabilitiesFingerprint,
 			RootsFingerprint:        options.ClientState.RootsFingerprint,
 		},
-		SamplingHandler:    options.SamplingHandler,
-		ElicitationHandler: options.ElicitationHandler,
-		LoggingHandler:     options.LoggingHandler,
+		SamplingHandler:            options.SamplingHandler,
+		ElicitationHandler:         options.ElicitationHandler,
+		LoggingHandler:             options.LoggingHandler,
+		ResourceListChangedHandler: options.ResourceListChangedHandler,
+		ResourceUpdatedHandler:     options.ResourceUpdatedHandler,
 	}
 }
 

--- a/internal/proxy/downstream_connection.go
+++ b/internal/proxy/downstream_connection.go
@@ -54,14 +54,15 @@ func (s ConnectionStatus) IsDisconnected() bool {
 
 // DownstreamConnection represents a connection to a downstream MCP server.
 type DownstreamConnection struct {
-	serverName string
-	config     *config.MCPServerConfig
-	client     *mcp.Client
-	session    *mcp.ClientSession
-	tools      []*mcp.Tool
-	resources  []*mcp.Resource
-	prompts    []*mcp.Prompt
-	mu         sync.RWMutex
+	serverName        string
+	config            *config.MCPServerConfig
+	client            *mcp.Client
+	session           *mcp.ClientSession
+	tools             []*mcp.Tool
+	resources         []*mcp.Resource
+	resourceTemplates []*mcp.ResourceTemplate
+	prompts           []*mcp.Prompt
+	mu                sync.RWMutex
 
 	clientState DownstreamClientState
 
@@ -139,6 +140,12 @@ func (dc *DownstreamConnection) buildClientOptions(options *DownstreamConnectOpt
 	}
 	if options.LoggingHandler != nil {
 		clientOptions.LoggingMessageHandler = options.LoggingHandler
+	}
+	if options.ResourceListChangedHandler != nil {
+		clientOptions.ResourceListChangedHandler = options.ResourceListChangedHandler
+	}
+	if options.ResourceUpdatedHandler != nil {
+		clientOptions.ResourceUpdatedHandler = options.ResourceUpdatedHandler
 	}
 	return clientOptions
 }
@@ -308,6 +315,15 @@ func (dc *DownstreamConnection) discoverResources(ctx context.Context) error {
 	return nil
 }
 
+func (dc *DownstreamConnection) discoverResourceTemplates(ctx context.Context) error {
+	result, err := dc.session.ListResourceTemplates(ctx, nil)
+	if err != nil {
+		return err
+	}
+	dc.resourceTemplates = result.ResourceTemplates
+	return nil
+}
+
 func (dc *DownstreamConnection) discoverPrompts(ctx context.Context) error {
 	result, err := dc.session.ListPrompts(ctx, nil)
 	if err != nil {
@@ -328,6 +344,17 @@ func (dc *DownstreamConnection) DiscoverResources(ctx context.Context) error {
 	return dc.discoverResources(ctx)
 }
 
+// DiscoverResourceTemplates fetches and caches the resource template list from the downstream server.
+// Safe to call after Connect returns; acquires the write lock for the duration of the RPC.
+func (dc *DownstreamConnection) DiscoverResourceTemplates(ctx context.Context) error {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	if dc.session == nil {
+		return nil
+	}
+	return dc.discoverResourceTemplates(ctx)
+}
+
 // DiscoverPrompts fetches and caches the prompt list from the downstream server.
 // Safe to call after Connect returns; acquires the write lock for the duration of the RPC.
 func (dc *DownstreamConnection) DiscoverPrompts(ctx context.Context) error {
@@ -344,6 +371,13 @@ func (dc *DownstreamConnection) Resources() []*mcp.Resource {
 	dc.mu.RLock()
 	defer dc.mu.RUnlock()
 	return dc.resources
+}
+
+// ResourceTemplates returns the cached resource templates discovered on connect (nil if not connected or unsupported).
+func (dc *DownstreamConnection) ResourceTemplates() []*mcp.ResourceTemplate {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+	return dc.resourceTemplates
 }
 
 // Prompts returns the cached prompts discovered on connect (nil if not connected or unsupported).

--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -10,15 +10,16 @@ import (
 
 // MockDownstreamConnection is a shared test double for DownstreamConnectionInterface.
 type MockDownstreamConnection struct {
-	mu           sync.RWMutex
-	serverName   string
-	tools        []*mcp.Tool
-	resources    []*mcp.Resource
-	prompts      []*mcp.Prompt
-	cfg          *config.MCPServerConfig
-	ConnectCalls int
-	CloseCalls   int
-	ConnectFunc  func(context.Context, *DownstreamConnectOptions) error
+	mu                sync.RWMutex
+	serverName        string
+	tools             []*mcp.Tool
+	resources         []*mcp.Resource
+	resourceTemplates []*mcp.ResourceTemplate
+	prompts           []*mcp.Prompt
+	cfg               *config.MCPServerConfig
+	ConnectCalls      int
+	CloseCalls        int
+	ConnectFunc       func(context.Context, *DownstreamConnectOptions) error
 
 	// Captured call data.
 	CapturedToolName     string
@@ -28,9 +29,15 @@ type MockDownstreamConnection struct {
 	CapturedLogLevels    []mcp.LoggingLevel
 
 	// Configurable downstream behavior.
-	ResultToReturn *mcp.CallToolResult
-	ErrorToReturn  error
-	Status         ConnectionStatus
+	ResultToReturn                 *mcp.CallToolResult
+	ErrorToReturn                  error
+	ReadResourceResultToReturn     *mcp.ReadResourceResult
+	ReadResourceErrorToReturn      error
+	SubscribeErrorToReturn         error
+	UnsubscribeErrorToReturn       error
+	DiscoverResourcesErrorToReturn error
+	DiscoverTemplatesErrorToReturn error
+	Status                         ConnectionStatus
 }
 
 func (m *MockDownstreamConnection) GetServerName() string {
@@ -143,8 +150,18 @@ func (m *MockDownstreamConnection) Prompts() []*mcp.Prompt {
 	return m.prompts
 }
 
+func (m *MockDownstreamConnection) ResourceTemplates() []*mcp.ResourceTemplate {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.resourceTemplates
+}
+
 func (m *MockDownstreamConnection) DiscoverResources(_ context.Context) error {
-	return nil
+	return m.DiscoverResourcesErrorToReturn
+}
+
+func (m *MockDownstreamConnection) DiscoverResourceTemplates(_ context.Context) error {
+	return m.DiscoverTemplatesErrorToReturn
 }
 
 func (m *MockDownstreamConnection) DiscoverPrompts(_ context.Context) error {
@@ -152,6 +169,9 @@ func (m *MockDownstreamConnection) DiscoverPrompts(_ context.Context) error {
 }
 
 func (m *MockDownstreamConnection) ReadResource(_ context.Context, _ string) (*mcp.ReadResourceResult, error) {
+	if m.ReadResourceResultToReturn != nil || m.ReadResourceErrorToReturn != nil {
+		return m.ReadResourceResultToReturn, m.ReadResourceErrorToReturn
+	}
 	return &mcp.ReadResourceResult{}, nil
 }
 
@@ -164,11 +184,11 @@ func (m *MockDownstreamConnection) Complete(_ context.Context, _ *mcp.CompleteRe
 }
 
 func (m *MockDownstreamConnection) Subscribe(_ context.Context, _ string) error {
-	return nil
+	return m.SubscribeErrorToReturn
 }
 
 func (m *MockDownstreamConnection) Unsubscribe(_ context.Context, _ string) error {
-	return nil
+	return m.UnsubscribeErrorToReturn
 }
 
 func (m *MockDownstreamConnection) SetLoggingLevel(_ context.Context, params *mcp.SetLoggingLevelParams) error {
@@ -199,10 +219,12 @@ func cloneConnectOptions(options *DownstreamConnectOptions) DownstreamConnectOpt
 		return DownstreamConnectOptions{}
 	}
 	cloned := DownstreamConnectOptions{
-		ForwardedHeaders:   cloneAuthHeaders(options.ForwardedHeaders),
-		SamplingHandler:    options.SamplingHandler,
-		ElicitationHandler: options.ElicitationHandler,
-		LoggingHandler:     options.LoggingHandler,
+		ForwardedHeaders:           cloneAuthHeaders(options.ForwardedHeaders),
+		SamplingHandler:            options.SamplingHandler,
+		ElicitationHandler:         options.ElicitationHandler,
+		LoggingHandler:             options.LoggingHandler,
+		ResourceListChangedHandler: options.ResourceListChangedHandler,
+		ResourceUpdatedHandler:     options.ResourceUpdatedHandler,
 	}
 	cloned.ClientState = DownstreamClientState{
 		ProtocolVersion:         options.ClientState.ProtocolVersion,

--- a/internal/proxy/downstream_connection_test.go
+++ b/internal/proxy/downstream_connection_test.go
@@ -206,6 +206,32 @@ func TestBuildClientOptions_IncludesLoggingHandler(t *testing.T) {
 	assert.Assert(t, called)
 }
 
+func TestBuildClientOptions_IncludesResourceHandlers(t *testing.T) {
+	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
+	listChangedCalled := false
+	resourceUpdatedCalled := false
+
+	options := dc.buildClientOptions(&DownstreamConnectOptions{
+		ResourceListChangedHandler: func(_ context.Context, req *mcp.ResourceListChangedRequest) {
+			listChangedCalled = req != nil
+		},
+		ResourceUpdatedHandler: func(_ context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			resourceUpdatedCalled = req != nil && req.Params != nil && req.Params.URI == "file:///resource"
+		},
+	})
+
+	assert.Assert(t, options.ResourceListChangedHandler != nil)
+	assert.Assert(t, options.ResourceUpdatedHandler != nil)
+	options.ResourceListChangedHandler(context.Background(), &mcp.ResourceListChangedRequest{
+		Params: &mcp.ResourceListChangedParams{},
+	})
+	options.ResourceUpdatedHandler(context.Background(), &mcp.ResourceUpdatedNotificationRequest{
+		Params: &mcp.ResourceUpdatedNotificationParams{URI: "file:///resource"},
+	})
+	assert.Assert(t, listChangedCalled)
+	assert.Assert(t, resourceUpdatedCalled)
+}
+
 func TestDownstreamConnection_ForwardsLoggingNotifications(t *testing.T) {
 	ctx := context.Background()
 	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "1.0.0"}, nil)
@@ -255,6 +281,27 @@ func TestDownstreamConnectionCallTool_NotConnected(t *testing.T) {
 
 	assert.Assert(t, result == nil)
 	assert.ErrorContains(t, err, "not connected to server")
+}
+
+func TestDownstreamConnectionDiscoverResourceTemplates(t *testing.T) {
+	clientSession, cleanup := connectTestClientSession(t, func(server *mcp.Server) {
+		server.AddResourceTemplate(&mcp.ResourceTemplate{
+			URITemplate: "file:///items/{id}",
+			Name:        "item-template",
+		}, func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{}, nil
+		})
+	})
+	defer cleanup()
+
+	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
+	dc.session = clientSession
+
+	err := dc.DiscoverResourceTemplates(context.Background())
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(dc.ResourceTemplates()), 1)
+	assert.Equal(t, dc.ResourceTemplates()[0].URITemplate, "file:///items/{id}")
 }
 
 func TestDownstreamConnectionCallTool(t *testing.T) {

--- a/internal/proxy/interfaces.go
+++ b/internal/proxy/interfaces.go
@@ -28,8 +28,10 @@ type DownstreamConnectionInterface interface {
 	IsPending() bool
 	Tools() []*mcp.Tool
 	Resources() []*mcp.Resource
+	ResourceTemplates() []*mcp.ResourceTemplate
 	Prompts() []*mcp.Prompt
 	DiscoverResources(ctx context.Context) error
+	DiscoverResourceTemplates(ctx context.Context) error
 	DiscoverPrompts(ctx context.Context) error
 	ReadResource(ctx context.Context, uri string) (*mcp.ReadResourceResult, error)
 	GetPrompt(ctx context.Context, name string, args map[string]string) (*mcp.GetPromptResult, error)

--- a/internal/proxy/proxy_downstream_pool.go
+++ b/internal/proxy/proxy_downstream_pool.go
@@ -154,6 +154,8 @@ func (p *CentianEndpoint) connectDownstreamPool(
 	serverName := conn.GetServerName()
 	connectOptions = cloneDownstreamConnectOptions(connectOptions)
 	connectOptions.LoggingHandler = p.newPoolLoggingHandler(downstreamSessionKey, serverName, conn)
+	connectOptions.ResourceListChangedHandler = p.newPoolResourceListChangedHandler(downstreamSessionKey, serverName, conn)
+	connectOptions.ResourceUpdatedHandler = p.newPoolResourceUpdatedHandler(downstreamSessionKey, serverName, conn)
 	if err := conn.Connect(context.Background(), connectOptions); err != nil {
 		p.mu.Lock()
 		if pool, ok := p.downstreamPools[downstreamSessionKey]; ok {
@@ -184,6 +186,9 @@ func (p *CentianEndpoint) connectDownstreamPool(
 	if err := conn.DiscoverResources(context.Background()); err != nil {
 		common.LogWarn("ProxyEndpoint[%s]: resource discovery failed for %s: %v", p.name, sanitizeLogValue(serverName), err)
 	}
+	if err := conn.DiscoverResourceTemplates(context.Background()); err != nil {
+		common.LogWarn("ProxyEndpoint[%s]: resource template discovery failed for %s: %v", p.name, sanitizeLogValue(serverName), err)
+	}
 	if err := conn.DiscoverPrompts(context.Background()); err != nil {
 		common.LogWarn("ProxyEndpoint[%s]: prompt discovery failed for %s: %v", p.name, sanitizeLogValue(serverName), err)
 	}
@@ -192,10 +197,11 @@ func (p *CentianEndpoint) connectDownstreamPool(
 	for _, session := range sessions {
 		p.syncAvailableTools(session)
 		p.syncAvailableResources(session)
+		p.syncAvailableResourceTemplates(session)
 		p.syncAvailablePrompts(session)
 	}
 	p.toolRegMu.Unlock()
 
-	common.LogInfo("ProxyEndpoint[%s]: connected pooled downstream %s with %d tools, %d resources, %d prompts",
-		p.name, sanitizeLogValue(serverName), len(conn.Tools()), len(conn.Resources()), len(conn.Prompts()))
+	common.LogInfo("ProxyEndpoint[%s]: connected pooled downstream %s with %d tools, %d resources, %d resource templates, %d prompts",
+		p.name, sanitizeLogValue(serverName), len(conn.Tools()), len(conn.Resources()), len(conn.ResourceTemplates()), len(conn.Prompts()))
 }

--- a/internal/proxy/proxy_logging_test.go
+++ b/internal/proxy/proxy_logging_test.go
@@ -43,11 +43,12 @@ func newLoggingTestProxy() *CentianEndpoint {
 
 func newLoggingTestSession(proxy *CentianEndpoint, sessionID string) *UpstreamSession {
 	session := &UpstreamSession{
-		id:                  sessionID,
-		downstreamConns:     make(map[string]DownstreamConnectionInterface),
-		registeredTools:     make(map[string]struct{}),
-		registeredResources: make(map[string]struct{}),
-		registeredPrompts:   make(map[string]struct{}),
+		id:                          sessionID,
+		downstreamConns:             make(map[string]DownstreamConnectionInterface),
+		registeredTools:             make(map[string]struct{}),
+		registeredResources:         make(map[string]struct{}),
+		registeredResourceTemplates: make(map[string]struct{}),
+		registeredPrompts:           make(map[string]struct{}),
 	}
 	session.upstreamServer = proxy.newUpstreamServer(session)
 	proxy.upstreamSessions[sessionID] = session

--- a/internal/proxy/proxy_resource_notifications.go
+++ b/internal/proxy/proxy_resource_notifications.go
@@ -1,0 +1,99 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/T4cceptor/centian/internal/common"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// This file forwards downstream resource notifications to the live upstream
+// sessions attached to the same pooled downstream session.
+
+func (p *CentianEndpoint) newPoolResourceListChangedHandler(
+	downstreamSessionKey string,
+	serverName string,
+	conn DownstreamConnectionInterface,
+) DownstreamResourceListChangedHandler {
+	return func(ctx context.Context, req *mcp.ResourceListChangedRequest) {
+		p.refreshDownstreamResources(ctx, downstreamSessionKey, serverName, conn, req)
+	}
+}
+
+func (p *CentianEndpoint) newPoolResourceUpdatedHandler(
+	downstreamSessionKey string,
+	serverName string,
+	conn DownstreamConnectionInterface,
+) DownstreamResourceUpdatedHandler {
+	return func(ctx context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+		if req == nil || req.Params == nil {
+			return
+		}
+		p.forwardDownstreamResourceUpdated(ctx, downstreamSessionKey, serverName, conn, req.Params)
+	}
+}
+
+func (p *CentianEndpoint) refreshDownstreamResources(
+	ctx context.Context,
+	downstreamSessionKey string,
+	serverName string,
+	conn DownstreamConnectionInterface,
+	req *mcp.ResourceListChangedRequest,
+) {
+	if req == nil || downstreamSessionKey == "" || conn == nil {
+		return
+	}
+
+	if err := conn.DiscoverResources(ctx); err != nil {
+		common.LogWarn(
+			"ProxyEndpoint[%s]: failed to refresh downstream resources for %s: %v",
+			p.name,
+			sanitizeLogValue(serverName),
+			err,
+		)
+	}
+	if err := conn.DiscoverResourceTemplates(ctx); err != nil {
+		common.LogWarn(
+			"ProxyEndpoint[%s]: failed to refresh downstream resource templates for %s: %v",
+			p.name,
+			sanitizeLogValue(serverName),
+			err,
+		)
+	}
+
+	sessions := p.snapshotPoolUpstreamSessions(downstreamSessionKey, conn)
+	p.toolRegMu.Lock()
+	defer p.toolRegMu.Unlock()
+	for _, session := range sessions {
+		p.syncAvailableResources(session)
+		p.syncAvailableResourceTemplates(session)
+	}
+}
+
+func (p *CentianEndpoint) forwardDownstreamResourceUpdated(
+	ctx context.Context,
+	downstreamSessionKey string,
+	serverName string,
+	conn DownstreamConnectionInterface,
+	params *mcp.ResourceUpdatedNotificationParams,
+) {
+	if params == nil || downstreamSessionKey == "" {
+		return
+	}
+
+	sessions := p.snapshotPoolUpstreamSessions(downstreamSessionKey, conn)
+	for _, session := range sessions {
+		if p.currentUpstreamServerSession(session) == nil {
+			continue
+		}
+		if err := session.upstreamServer.ResourceUpdated(ctx, params); err != nil {
+			common.LogWarn(
+				"ProxyEndpoint[%s]: failed to forward downstream resource update from %s to upstream session %s: %v",
+				p.name,
+				sanitizeLogValue(serverName),
+				sanitizeLogValue(session.id),
+				err,
+			)
+		}
+	}
+}

--- a/internal/proxy/proxy_resource_notifications_test.go
+++ b/internal/proxy/proxy_resource_notifications_test.go
@@ -72,19 +72,18 @@ func subscribeResource(t *testing.T, clientSession *mcp.ClientSession, uri strin
 	assert.NilError(t, clientSession.Subscribe(context.Background(), &mcp.SubscribeParams{URI: uri}))
 }
 
-func waitForSingleResourceUpdate(t *testing.T, recorder *resourceUpdateRecorder) []*mcp.ResourceUpdatedNotificationParams {
+func waitForSingleResourceUpdate(t *testing.T, recorder *resourceUpdateRecorder) {
 	t.Helper()
 
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		snapshot := recorder.snapshot()
 		if len(snapshot) == 1 {
-			return snapshot
+			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
 	snapshot := recorder.snapshot()
 	t.Fatalf("expected 1 resource update, got %d", len(snapshot))
-	return nil
 }

--- a/internal/proxy/proxy_resource_notifications_test.go
+++ b/internal/proxy/proxy_resource_notifications_test.go
@@ -1,0 +1,90 @@
+package proxy
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"gotest.tools/assert"
+)
+
+type resourceUpdateRecorder struct {
+	mu      sync.Mutex
+	updates []*mcp.ResourceUpdatedNotificationParams
+}
+
+func (r *resourceUpdateRecorder) record(params *mcp.ResourceUpdatedNotificationParams) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.updates = append(r.updates, params)
+}
+
+func (r *resourceUpdateRecorder) snapshot() []*mcp.ResourceUpdatedNotificationParams {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*mcp.ResourceUpdatedNotificationParams(nil), r.updates...)
+}
+
+func connectResourceClient(t *testing.T, session *UpstreamSession) (*resourceUpdateRecorder, *mcp.ClientSession, func()) {
+	t.Helper()
+
+	session.upstreamServer = mcp.NewServer(&mcp.Implementation{Name: "server", Version: "1.0.0"}, &mcp.ServerOptions{
+		HasResources: true,
+		SubscribeHandler: func(context.Context, *mcp.SubscribeRequest) error {
+			return nil
+		},
+		UnsubscribeHandler: func(context.Context, *mcp.UnsubscribeRequest) error {
+			return nil
+		},
+		GetSessionID: func() string {
+			return session.id
+		},
+	})
+	session.upstreamServer.AddResource(&mcp.Resource{URI: "file:///resource", Name: "resource"}, func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{}, nil
+	})
+
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := session.upstreamServer.Connect(ctx, serverTransport, nil)
+	assert.NilError(t, err)
+
+	recorder := &resourceUpdateRecorder{}
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "1.0.0"}, &mcp.ClientOptions{
+		ResourceUpdatedHandler: func(_ context.Context, req *mcp.ResourceUpdatedNotificationRequest) {
+			recorder.record(req.Params)
+		},
+	})
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	assert.NilError(t, err)
+	session.id = ""
+
+	return recorder, clientSession, func() {
+		_ = clientSession.Close()
+		_ = serverSession.Close()
+	}
+}
+
+func subscribeResource(t *testing.T, clientSession *mcp.ClientSession, uri string) {
+	t.Helper()
+	assert.NilError(t, clientSession.Subscribe(context.Background(), &mcp.SubscribeParams{URI: uri}))
+}
+
+func waitForSingleResourceUpdate(t *testing.T, recorder *resourceUpdateRecorder) []*mcp.ResourceUpdatedNotificationParams {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		snapshot := recorder.snapshot()
+		if len(snapshot) == 1 {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	snapshot := recorder.snapshot()
+	t.Fatalf("expected 1 resource update, got %d", len(snapshot))
+	return nil
+}

--- a/internal/proxy/proxy_resources.go
+++ b/internal/proxy/proxy_resources.go
@@ -81,7 +81,7 @@ func (p *CentianEndpoint) registerResource(session *UpstreamSession, serverName 
 	session.registeredResources[resource.URI] = struct{}{}
 
 	uri := resource.URI
-	session.upstreamServer.AddResource(resource, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	session.upstreamServer.AddResource(copyResourceForRegistration(resource), func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		return p.forwardReadResource(ctx, session, serverName, uri)
 	})
 }
@@ -102,6 +102,89 @@ func (p *CentianEndpoint) registerAvailableResources(session *UpstreamSession) {
 
 	p.toolRegMu.Lock()
 	p.syncAvailableResources(session)
+	p.toolRegMu.Unlock()
+}
+
+// syncAvailableResourceTemplates reconciles the upstream server's registered resource templates
+// against the set currently available from connected downstream servers.
+func (p *CentianEndpoint) syncAvailableResourceTemplates(session *UpstreamSession) {
+	if session == nil || session.upstreamServer == nil {
+		return
+	}
+	if session.registeredResourceTemplates == nil {
+		session.registeredResourceTemplates = make(map[string]struct{})
+	}
+
+	type resourceTemplateEntry struct {
+		resourceTemplate *mcp.ResourceTemplate
+		serverName       string
+	}
+	desiredTemplates := make(map[string]resourceTemplateEntry) // keyed by URI template
+	for serverName, conn := range session.downstreamConns {
+		if !conn.IsConnected() {
+			continue
+		}
+		for _, resourceTemplate := range conn.ResourceTemplates() {
+			if resourceTemplate == nil {
+				continue
+			}
+			desiredTemplates[resourceTemplate.URITemplate] = resourceTemplateEntry{
+				resourceTemplate: resourceTemplate,
+				serverName:       serverName,
+			}
+		}
+	}
+
+	staleTemplates := make([]string, 0)
+	for uriTemplate := range session.registeredResourceTemplates {
+		if _, ok := desiredTemplates[uriTemplate]; !ok {
+			staleTemplates = append(staleTemplates, uriTemplate)
+		}
+	}
+	if len(staleTemplates) > 0 {
+		session.upstreamServer.RemoveResourceTemplates(staleTemplates...)
+		for _, uriTemplate := range staleTemplates {
+			delete(session.registeredResourceTemplates, uriTemplate)
+		}
+	}
+
+	for uriTemplate, entry := range desiredTemplates {
+		if _, ok := session.registeredResourceTemplates[uriTemplate]; ok {
+			continue
+		}
+		p.registerResourceTemplate(session, entry.serverName, entry.resourceTemplate)
+	}
+}
+
+func (p *CentianEndpoint) registerResourceTemplate(session *UpstreamSession, serverName string, resourceTemplate *mcp.ResourceTemplate) {
+	if session.registeredResourceTemplates == nil {
+		session.registeredResourceTemplates = make(map[string]struct{})
+	}
+	if _, exists := session.registeredResourceTemplates[resourceTemplate.URITemplate]; exists {
+		return
+	}
+	session.registeredResourceTemplates[resourceTemplate.URITemplate] = struct{}{}
+
+	session.upstreamServer.AddResourceTemplate(copyResourceTemplateForRegistration(resourceTemplate), func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return p.forwardReadResource(ctx, session, serverName, req.Params.URI)
+	})
+}
+
+func (p *CentianEndpoint) registerAvailableResourceTemplates(session *UpstreamSession) {
+	if session == nil {
+		return
+	}
+
+	p.mu.RLock()
+	pool := p.downstreamPools[session.downstreamSessionKey]
+	p.mu.RUnlock()
+
+	if pool == nil {
+		return
+	}
+
+	p.toolRegMu.Lock()
+	p.syncAvailableResourceTemplates(session)
 	p.toolRegMu.Unlock()
 }
 

--- a/internal/proxy/proxy_resources_test.go
+++ b/internal/proxy/proxy_resources_test.go
@@ -1,7 +1,10 @@
 package proxy
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/assert"
@@ -121,4 +124,230 @@ func TestSyncAvailableResources_DuplicateURILastServerWins(t *testing.T) {
 		"duplicate URI should be collapsed to a single registration")
 	_, registered := session.registeredResources[sharedURI]
 	assert.Assert(t, registered, "the shared URI must appear in registeredResources")
+}
+
+func TestForwardReadResource_ReturnsErrorWhenNoDownstreamOwnsURI(t *testing.T) {
+	proxy := &CentianEndpoint{name: "test"}
+	conn := &MockDownstreamConnection{
+		serverName: "server-a",
+		Status:     StatusConnected,
+		resources: []*mcp.Resource{
+			{URI: "file:///other"},
+		},
+	}
+	session := &UpstreamSession{
+		id: "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": conn,
+		},
+	}
+
+	result, err := proxy.forwardReadResource(context.Background(), session, "server-b", "file:///missing")
+
+	assert.Assert(t, result == nil)
+	assert.ErrorContains(t, err, `resource "file:///missing": no connection to server "server-b" found`)
+}
+
+func TestForwardReadResource_NormalizesDownstreamMethodError(t *testing.T) {
+	conn := &MockDownstreamConnection{
+		serverName:                "server-a",
+		Status:                    StatusConnected,
+		ReadResourceErrorToReturn: errors.New(`calling "resources/read": method not found`),
+	}
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id: "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": conn,
+		},
+	}
+
+	result, err := proxy.forwardReadResource(context.Background(), session, "server-a", "file:///resource")
+
+	assert.Assert(t, result == nil)
+	assert.Equal(t, err.Error(), "method not found")
+}
+
+func TestForwardSubscribe_ReturnsErrorWhenNoDownstreamOwnsURI(t *testing.T) {
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id:              "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{},
+	}
+
+	err := proxy.forwardSubscribe(context.Background(), session, &mcp.SubscribeRequest{
+		Params: &mcp.SubscribeParams{URI: "file:///missing"},
+	})
+
+	assert.ErrorContains(t, err, `no downstream connection found for resource URI "file:///missing"`)
+}
+
+func TestForwardUnsubscribe_ReturnsErrorWhenNoDownstreamOwnsURI(t *testing.T) {
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id:              "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{},
+	}
+
+	err := proxy.forwardUnsubscribe(context.Background(), session, &mcp.UnsubscribeRequest{
+		Params: &mcp.UnsubscribeParams{URI: "file:///missing"},
+	})
+
+	assert.ErrorContains(t, err, `no downstream connection found for resource URI "file:///missing"`)
+}
+
+func TestForwardSubscribe_NormalizesDownstreamMethodError(t *testing.T) {
+	conn := &MockDownstreamConnection{
+		serverName:             "server-a",
+		Status:                 StatusConnected,
+		resources:              []*mcp.Resource{{URI: "file:///resource"}},
+		SubscribeErrorToReturn: errors.New(`calling "resources/subscribe": method not found`),
+	}
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id: "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": conn,
+		},
+	}
+
+	err := proxy.forwardSubscribe(context.Background(), session, &mcp.SubscribeRequest{
+		Params: &mcp.SubscribeParams{URI: "file:///resource"},
+	})
+
+	assert.Equal(t, err.Error(), "method not found")
+}
+
+func TestForwardUnsubscribe_NormalizesDownstreamMethodError(t *testing.T) {
+	conn := &MockDownstreamConnection{
+		serverName:               "server-a",
+		Status:                   StatusConnected,
+		resources:                []*mcp.Resource{{URI: "file:///resource"}},
+		UnsubscribeErrorToReturn: errors.New(`calling "resources/unsubscribe": method not found`),
+	}
+	proxy := &CentianEndpoint{name: "test"}
+	session := &UpstreamSession{
+		id: "session-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": conn,
+		},
+	}
+
+	err := proxy.forwardUnsubscribe(context.Background(), session, &mcp.UnsubscribeRequest{
+		Params: &mcp.UnsubscribeParams{URI: "file:///resource"},
+	})
+
+	assert.Equal(t, err.Error(), "method not found")
+}
+
+func TestSyncAvailableResourceTemplates_RegistersTemplates(t *testing.T) {
+	const templateURI = "file:///items/{id}"
+
+	conn := &MockDownstreamConnection{
+		serverName:        "server-a",
+		Status:            StatusConnected,
+		resourceTemplates: []*mcp.ResourceTemplate{{URITemplate: templateURI, Name: "item-template"}},
+	}
+	proxy := &CentianEndpoint{name: "test"}
+	upstreamServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, &mcp.ServerOptions{
+		HasResources: true,
+	})
+	session := &UpstreamSession{
+		id:                          "session-1",
+		upstreamServer:              upstreamServer,
+		registeredResources:         make(map[string]struct{}),
+		registeredResourceTemplates: make(map[string]struct{}),
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": conn,
+		},
+	}
+
+	proxy.syncAvailableResourceTemplates(session)
+
+	_, registered := session.registeredResourceTemplates[templateURI]
+	assert.Assert(t, registered)
+}
+
+func TestRefreshDownstreamResources_SyncsTemplatesAndResources(t *testing.T) {
+	proxy := newLoggingTestProxy()
+	session := newLoggingTestSession(proxy, "session-1")
+	session.downstreamSessionKey = "pool-1"
+	conn := &MockDownstreamConnection{
+		serverName:        "server-a",
+		Status:            StatusConnected,
+		resources:         []*mcp.Resource{{URI: "file:///resource"}},
+		resourceTemplates: []*mcp.ResourceTemplate{{URITemplate: "file:///resource/{id}", Name: "template"}},
+	}
+	session.downstreamConns = map[string]DownstreamConnectionInterface{"server-a": conn}
+	proxy.downstreamPools["pool-1"] = &DownstreamSessionPool{
+		downstreamSessionKey: "pool-1",
+		downstreamConns: map[string]DownstreamConnectionInterface{
+			"server-a": conn,
+		},
+		upstreamSessions: map[string]*UpstreamSession{"session-1": session},
+	}
+
+	proxy.refreshDownstreamResources(context.Background(), "pool-1", "server-a", conn, &mcp.ResourceListChangedRequest{
+		Params: &mcp.ResourceListChangedParams{},
+	})
+
+	_, resourceRegistered := session.registeredResources["file:///resource"]
+	_, templateRegistered := session.registeredResourceTemplates["file:///resource/{id}"]
+	assert.Assert(t, resourceRegistered)
+	assert.Assert(t, templateRegistered)
+}
+
+func TestForwardDownstreamResourceUpdated_BroadcastsToSubscribedSessions(t *testing.T) {
+	proxy := newLoggingTestProxy()
+	sessionA := newLoggingTestSession(proxy, "session-a")
+	sessionB := newLoggingTestSession(proxy, "session-b")
+	recorderA, clientSessionA, cleanupA := connectResourceClient(t, sessionA)
+	defer cleanupA()
+	recorderB, clientSessionB, cleanupB := connectResourceClient(t, sessionB)
+	defer cleanupB()
+
+	proxy.downstreamPools["pool-1"] = &DownstreamSessionPool{
+		downstreamSessionKey: "pool-1",
+		upstreamSessions: map[string]*UpstreamSession{
+			"session-a": sessionA,
+			"session-b": sessionB,
+		},
+	}
+
+	subscribeResource(t, clientSessionA, "file:///resource")
+	subscribeResource(t, clientSessionB, "file:///resource")
+
+	proxy.forwardDownstreamResourceUpdated(context.Background(), "pool-1", "server-a", nil, &mcp.ResourceUpdatedNotificationParams{
+		URI: "file:///resource",
+	})
+
+	waitForSingleResourceUpdate(t, recorderA)
+	waitForSingleResourceUpdate(t, recorderB)
+}
+
+func TestForwardDownstreamResourceUpdated_StopsAfterUnsubscribe(t *testing.T) {
+	proxy := newLoggingTestProxy()
+	session := newLoggingTestSession(proxy, "session-1")
+	recorder, clientSession, cleanup := connectResourceClient(t, session)
+	defer cleanup()
+
+	proxy.downstreamPools["pool-1"] = &DownstreamSessionPool{
+		downstreamSessionKey: "pool-1",
+		upstreamSessions:     map[string]*UpstreamSession{"session-1": session},
+	}
+
+	subscribeResource(t, clientSession, "file:///resource")
+	proxy.forwardDownstreamResourceUpdated(context.Background(), "pool-1", "server-a", nil, &mcp.ResourceUpdatedNotificationParams{
+		URI: "file:///resource",
+	})
+	waitForSingleResourceUpdate(t, recorder)
+
+	assert.NilError(t, clientSession.Unsubscribe(context.Background(), &mcp.UnsubscribeParams{URI: "file:///resource"}))
+	time.Sleep(50 * time.Millisecond)
+	proxy.forwardDownstreamResourceUpdated(context.Background(), "pool-1", "server-a", nil, &mcp.ResourceUpdatedNotificationParams{
+		URI: "file:///resource",
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, len(recorder.snapshot()), 1)
 }

--- a/internal/proxy/proxy_sessions.go
+++ b/internal/proxy/proxy_sessions.go
@@ -85,15 +85,16 @@ func (p *CentianEndpoint) createUpstreamSession(id string, r *http.Request, iden
 		clientHeaders = r.Header.Clone()
 	}
 	return &UpstreamSession{
-		id:                  id,
-		downstreamConns:     make(map[string]DownstreamConnectionInterface),
-		registeredTools:     make(map[string]struct{}),
-		registeredResources: make(map[string]struct{}),
-		registeredPrompts:   make(map[string]struct{}),
-		clientHeaders:       clientHeaders,
-		identityKey:         identityKey,
-		authData:            authData.Clone(),
-		rootsDirty:          true,
+		id:                          id,
+		downstreamConns:             make(map[string]DownstreamConnectionInterface),
+		registeredTools:             make(map[string]struct{}),
+		registeredResources:         make(map[string]struct{}),
+		registeredResourceTemplates: make(map[string]struct{}),
+		registeredPrompts:           make(map[string]struct{}),
+		clientHeaders:               clientHeaders,
+		identityKey:                 identityKey,
+		authData:                    authData.Clone(),
+		rootsDirty:                  true,
 	}
 }
 
@@ -384,6 +385,7 @@ func (p *CentianEndpoint) finalizeDownstreamPoolUpdate(ctx context.Context, sess
 	}
 	p.registerAvailableTools(session)
 	p.registerAvailableResources(session)
+	p.registerAvailableResourceTemplates(session)
 	p.registerAvailablePrompts(session)
 }
 

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -36,11 +36,12 @@ type CentianServer struct {
 type UpstreamSession struct {
 	id string
 
-	upstreamServer      *mcp.Server
-	downstreamConns     map[string]DownstreamConnectionInterface
-	registeredTools     map[string]struct{}
-	registeredResources map[string]struct{} // keyed by resource URI
-	registeredPrompts   map[string]struct{} // keyed by prompt name
+	upstreamServer              *mcp.Server
+	downstreamConns             map[string]DownstreamConnectionInterface
+	registeredTools             map[string]struct{}
+	registeredResources         map[string]struct{} // keyed by resource URI
+	registeredResourceTemplates map[string]struct{} // keyed by resource URI template
+	registeredPrompts           map[string]struct{} // keyed by prompt name
 
 	clientHeaders        http.Header
 	identityKey          string
@@ -207,5 +208,31 @@ func copyToolForRegistration(tool *mcp.Tool) *mcp.Tool {
 		OutputSchema: tool.OutputSchema,
 		Title:        tool.Title,
 		Icons:        tool.Icons,
+	}
+}
+
+func copyResourceForRegistration(resource *mcp.Resource) *mcp.Resource {
+	return &mcp.Resource{
+		Annotations: resource.Annotations,
+		Description: resource.Description,
+		MIMEType:    resource.MIMEType,
+		Name:        resource.Name,
+		Title:       resource.Title,
+		URI:         resource.URI,
+		Meta:        resource.Meta,
+		Icons:       resource.Icons,
+	}
+}
+
+func copyResourceTemplateForRegistration(resourceTemplate *mcp.ResourceTemplate) *mcp.ResourceTemplate {
+	return &mcp.ResourceTemplate{
+		Annotations: resourceTemplate.Annotations,
+		Description: resourceTemplate.Description,
+		MIMEType:    resourceTemplate.MIMEType,
+		Name:        resourceTemplate.Name,
+		Title:       resourceTemplate.Title,
+		URITemplate: resourceTemplate.URITemplate,
+		Meta:        resourceTemplate.Meta,
+		Icons:       resourceTemplate.Icons,
 	}
 }

--- a/tests/integrationtests/everything/harness_test.go
+++ b/tests/integrationtests/everything/harness_test.go
@@ -53,6 +53,7 @@ type notificationSnapshot struct {
 	LogCount               int
 	ProgressCount          int
 	ResourceUpdateCount    int
+	ResourceUpdateURIs     []string
 	ToolListChangedCount   int
 	ResourceListChanged    int
 	PromptListChangedCount int
@@ -287,10 +288,19 @@ func (r *notificationRecorder) snapshot() notificationSnapshot {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	resourceUpdateURIs := make([]string, 0, len(r.resourceUpdates))
+	for _, update := range r.resourceUpdates {
+		if update == nil {
+			continue
+		}
+		resourceUpdateURIs = append(resourceUpdateURIs, update.URI)
+	}
+
 	return notificationSnapshot{
 		LogCount:               len(r.logMessages),
 		ProgressCount:          len(r.progressMessages),
 		ResourceUpdateCount:    len(r.resourceUpdates),
+		ResourceUpdateURIs:     resourceUpdateURIs,
 		ToolListChangedCount:   r.toolListChanged,
 		ResourceListChanged:    r.resourceListChanged,
 		PromptListChangedCount: r.promptListChanged,

--- a/tests/integrationtests/everything/probe_test.go
+++ b/tests/integrationtests/everything/probe_test.go
@@ -203,8 +203,8 @@ func evaluateLoggingProbe(ctx context.Context, t *testing.T, pair *connectionPai
 			Name:           toolName,
 			Classification: classificationMatch,
 			Summary:        fmt.Sprintf("both paths produced log notifications (direct=%d proxied=%d)", directSnapshot.LogCount, proxiedSnapshot.LogCount),
-			DirectDetails:  renderLoggingOutcome(t, directResult, directSnapshot),
-			ProxiedDetails: renderLoggingOutcome(t, proxiedResult, proxiedSnapshot),
+			DirectDetails:  renderLoggingOutcome(t, directResult, &directSnapshot),
+			ProxiedDetails: renderLoggingOutcome(t, proxiedResult, &proxiedSnapshot),
 		}
 	}
 
@@ -213,8 +213,8 @@ func evaluateLoggingProbe(ctx context.Context, t *testing.T, pair *connectionPai
 			Name:           toolName,
 			Classification: classificationProxyDivergence,
 			Summary:        "direct path received log notifications but proxied path did not",
-			DirectDetails:  renderLoggingOutcome(t, directResult, directSnapshot),
-			ProxiedDetails: renderLoggingOutcome(t, proxiedResult, proxiedSnapshot),
+			DirectDetails:  renderLoggingOutcome(t, directResult, &directSnapshot),
+			ProxiedDetails: renderLoggingOutcome(t, proxiedResult, &proxiedSnapshot),
 		}
 	}
 
@@ -222,8 +222,8 @@ func evaluateLoggingProbe(ctx context.Context, t *testing.T, pair *connectionPai
 		Name:           toolName,
 		Classification: classificationProxyDivergence,
 		Summary:        "logging probe produced different direct/proxied outcomes",
-		DirectDetails:  renderLoggingOutcome(t, directResult, directSnapshot),
-		ProxiedDetails: renderLoggingOutcome(t, proxiedResult, proxiedSnapshot),
+		DirectDetails:  renderLoggingOutcome(t, directResult, &directSnapshot),
+		ProxiedDetails: renderLoggingOutcome(t, proxiedResult, &proxiedSnapshot),
 	}
 }
 
@@ -655,7 +655,7 @@ func renderOperationOutcome(t *testing.T, result any, err error) string {
 	return prettyJSON(t, result)
 }
 
-func renderLoggingOutcome(t *testing.T, result *mcp.CallToolResult, snapshot notificationSnapshot) string {
+func renderLoggingOutcome(t *testing.T, result *mcp.CallToolResult, snapshot *notificationSnapshot) string {
 	t.Helper()
 
 	return fmt.Sprintf("result:\n%s\nLogCount: %d", prettyJSON(t, result), snapshot.LogCount)

--- a/tests/integrationtests/everything/probe_test.go
+++ b/tests/integrationtests/everything/probe_test.go
@@ -3,6 +3,7 @@ package everything
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -49,8 +50,29 @@ func TestEverythingResearchTaskProbePhase3(t *testing.T) {
 }
 
 func TestEverythingResourcesSurfacePhase3(t *testing.T) {
-	runCapabilityComparison(t, "resources_surface", func(ctx context.Context, t *testing.T, pair *connectionPair) {
-		outcome := evaluateResourcesProbe(ctx, t, pair)
+	runCapabilityComparison(t, "resources_list", func(ctx context.Context, t *testing.T, pair *connectionPair) {
+		outcome := evaluateResourcesListProbe(ctx, t, pair)
+		reportPhase3Outcome(t, &outcome)
+	})
+}
+
+func TestEverythingResourceReadPhase3(t *testing.T) {
+	runCapabilityComparison(t, "resources_read", func(ctx context.Context, t *testing.T, pair *connectionPair) {
+		outcome := evaluateResourceReadProbe(ctx, t, pair)
+		reportPhase3Outcome(t, &outcome)
+	})
+}
+
+func TestEverythingResourceSubscriptionsPhase3(t *testing.T) {
+	runCapabilityComparison(t, "resources_subscribe", func(ctx context.Context, t *testing.T, pair *connectionPair) {
+		outcome := evaluateResourceSubscriptionProbe(ctx, t, pair)
+		reportPhase3Outcome(t, &outcome)
+	})
+}
+
+func TestEverythingResourceTemplatesPhase3(t *testing.T) {
+	runCapabilityComparison(t, "resources_templates_list", func(ctx context.Context, t *testing.T, pair *connectionPair) {
+		outcome := evaluateResourceTemplatesProbe(ctx, t, pair)
 		reportPhase3Outcome(t, &outcome)
 	})
 }
@@ -280,7 +302,7 @@ func evaluateSimpleToolProbe(
 	}
 }
 
-func evaluateResourcesProbe(ctx context.Context, t *testing.T, pair *connectionPair) phase3Outcome {
+func evaluateResourcesListProbe(ctx context.Context, t *testing.T, pair *connectionPair) phase3Outcome {
 	t.Helper()
 
 	directResources, directErr := pair.Direct.session.ListResources(ctx, nil)
@@ -315,6 +337,297 @@ func evaluateResourcesProbe(ctx context.Context, t *testing.T, pair *connectionP
 	}
 }
 
+func evaluateResourceReadProbe(ctx context.Context, t *testing.T, pair *connectionPair) phase3Outcome {
+	t.Helper()
+
+	resourceURI, directResources, proxiedResources := selectProbeResourceURI(ctx, t, pair)
+	if resourceURI == "" {
+		return phase3Outcome{
+			Name:           "resources/read",
+			Classification: classificationMatch,
+			Summary:        "resource read probe skipped because neither side exposes resources",
+			DirectDetails:  renderOperationOutcome(t, directResources, nil),
+			ProxiedDetails: renderOperationOutcome(t, proxiedResources, nil),
+		}
+	}
+
+	directResult, directErr := pair.Direct.session.ReadResource(ctx, &mcp.ReadResourceParams{URI: resourceURI})
+	proxiedResult, proxiedErr := pair.Proxied.session.ReadResource(ctx, &mcp.ReadResourceParams{URI: resourceURI})
+
+	if sameErrorMessage(directErr, proxiedErr) && jsonEqual(t, directResult, proxiedResult) {
+		return phase3Outcome{
+			Name:           "resources/read",
+			Classification: classificationMatch,
+			Summary:        "direct and proxied resources/read behaved the same",
+			DirectDetails:  renderOperationOutcome(t, directResult, directErr),
+			ProxiedDetails: renderOperationOutcome(t, proxiedResult, proxiedErr),
+		}
+	}
+
+	if directErr == nil && proxiedErr != nil {
+		return phase3Outcome{
+			Name:           "resources/read",
+			Classification: classificationUnsupportedInCentian,
+			Summary:        "direct path supports resources/read but proxied path does not",
+			DirectDetails:  renderOperationOutcome(t, directResult, directErr),
+			ProxiedDetails: renderOperationOutcome(t, proxiedResult, proxiedErr),
+		}
+	}
+
+	return phase3Outcome{
+		Name:           "resources/read",
+		Classification: classificationProxyDivergence,
+		Summary:        "resources/read produced different direct/proxied outcomes",
+		DirectDetails:  renderOperationOutcome(t, directResult, directErr),
+		ProxiedDetails: renderOperationOutcome(t, proxiedResult, proxiedErr),
+	}
+}
+
+func evaluateResourceSubscriptionProbe(ctx context.Context, t *testing.T, pair *connectionPair) phase3Outcome {
+	t.Helper()
+
+	resourceURI, _, _ := selectProbeResourceURI(ctx, t, pair)
+	if resourceURI == "" {
+		return phase3Outcome{
+			Name:           "resources/subscribe",
+			Classification: classificationMatch,
+			Summary:        "resource subscription probe skipped because neither side exposes resources",
+			DirectDetails:  "no resources discovered",
+			ProxiedDetails: "no resources discovered",
+		}
+	}
+
+	directSubErr := pair.Direct.session.Subscribe(ctx, &mcp.SubscribeParams{URI: resourceURI})
+	proxiedSubErr := pair.Proxied.session.Subscribe(ctx, &mcp.SubscribeParams{URI: resourceURI})
+	if sameErrorMessage(directSubErr, proxiedSubErr) && directSubErr != nil {
+		return phase3Outcome{
+			Name:           "resources/subscribe",
+			Classification: classificationMatch,
+			Summary:        "resources/subscribe is unsupported on both paths",
+			DirectDetails:  directSubErr.Error(),
+			ProxiedDetails: proxiedSubErr.Error(),
+		}
+	}
+	if directSubErr == nil && proxiedSubErr != nil {
+		return phase3Outcome{
+			Name:           "resources/subscribe",
+			Classification: classificationUnsupportedInCentian,
+			Summary:        "direct path supports resources/subscribe but proxied path does not",
+			DirectDetails:  "subscribe succeeded on direct path",
+			ProxiedDetails: proxiedSubErr.Error(),
+		}
+	}
+	if directSubErr != nil || proxiedSubErr != nil {
+		return phase3Outcome{
+			Name:           "resources/subscribe",
+			Classification: classificationProxyDivergence,
+			Summary:        "resources/subscribe produced different direct/proxied outcomes",
+			DirectDetails:  renderError(directSubErr),
+			ProxiedDetails: renderError(proxiedSubErr),
+		}
+	}
+
+	directBefore := pair.Direct.recorder.snapshot()
+	proxiedBefore := pair.Proxied.recorder.snapshot()
+
+	directToggle := mustCallTool(t, ctx, pair.Direct.session, "toggle-subscriber-updates", map[string]any{})
+	proxiedToggle := mustCallTool(t, ctx, pair.Proxied.session, "toggle-subscriber-updates", map[string]any{})
+
+	directAfter := waitForRecorderState(t, pair.Direct.recorder, 3*time.Second, func(snapshot notificationSnapshot) bool {
+		return snapshot.ResourceUpdateCount > directBefore.ResourceUpdateCount
+	})
+	proxiedAfter := waitForRecorderState(t, pair.Proxied.recorder, 3*time.Second, func(snapshot notificationSnapshot) bool {
+		return snapshot.ResourceUpdateCount > proxiedBefore.ResourceUpdateCount
+	})
+
+	if directAfter.ResourceUpdateCount == directBefore.ResourceUpdateCount {
+		return phase3Outcome{
+			Name:           "notifications/resources/updated",
+			Classification: classificationProxyDivergence,
+			Summary:        "direct path did not emit resource update notifications after enabling subscriber updates",
+			DirectDetails:  prettyJSON(t, directAfter),
+			ProxiedDetails: prettyJSON(t, proxiedAfter),
+		}
+	}
+	if proxiedAfter.ResourceUpdateCount == proxiedBefore.ResourceUpdateCount {
+		return phase3Outcome{
+			Name:           "notifications/resources/updated",
+			Classification: classificationProxyDivergence,
+			Summary:        "direct path emitted resource update notifications but proxied path did not",
+			DirectDetails:  prettyJSON(t, directAfter),
+			ProxiedDetails: prettyJSON(t, proxiedAfter),
+		}
+	}
+
+	directNewURIs := directAfter.ResourceUpdateURIs[directBefore.ResourceUpdateCount:]
+	proxiedNewURIs := proxiedAfter.ResourceUpdateURIs[proxiedBefore.ResourceUpdateCount:]
+	if len(directNewURIs) == 0 || len(proxiedNewURIs) == 0 || directNewURIs[0] != proxiedNewURIs[0] {
+		return phase3Outcome{
+			Name:           "notifications/resources/updated",
+			Classification: classificationProxyDivergence,
+			Summary:        "resource update notifications carried different URIs on direct and proxied paths",
+			DirectDetails:  prettyJSON(t, directAfter),
+			ProxiedDetails: prettyJSON(t, proxiedAfter),
+		}
+	}
+
+	if directAfter.ResourceListChanged > directBefore.ResourceListChanged && proxiedAfter.ResourceListChanged == proxiedBefore.ResourceListChanged {
+		return phase3Outcome{
+			Name:           "notifications/resources/list_changed",
+			Classification: classificationProxyDivergence,
+			Summary:        "direct path emitted resources/list_changed but proxied path did not",
+			DirectDetails:  prettyJSON(t, directAfter),
+			ProxiedDetails: prettyJSON(t, proxiedAfter),
+		}
+	}
+
+	directUnsubErr := pair.Direct.session.Unsubscribe(ctx, &mcp.UnsubscribeParams{URI: resourceURI})
+	proxiedUnsubErr := pair.Proxied.session.Unsubscribe(ctx, &mcp.UnsubscribeParams{URI: resourceURI})
+	if directUnsubErr == nil && proxiedUnsubErr != nil {
+		return phase3Outcome{
+			Name:           "resources/unsubscribe",
+			Classification: classificationUnsupportedInCentian,
+			Summary:        "direct path supports resources/unsubscribe but proxied path does not",
+			DirectDetails:  "unsubscribe succeeded on direct path",
+			ProxiedDetails: proxiedUnsubErr.Error(),
+		}
+	}
+	if !sameErrorMessage(directUnsubErr, proxiedUnsubErr) {
+		return phase3Outcome{
+			Name:           "resources/unsubscribe",
+			Classification: classificationProxyDivergence,
+			Summary:        "resources/unsubscribe produced different direct/proxied outcomes",
+			DirectDetails:  renderError(directUnsubErr),
+			ProxiedDetails: renderError(proxiedUnsubErr),
+		}
+	}
+
+	time.Sleep(1200 * time.Millisecond)
+	directFinal := pair.Direct.recorder.snapshot()
+	proxiedFinal := pair.Proxied.recorder.snapshot()
+	directPostUnsubDelta := directFinal.ResourceUpdateCount - directAfter.ResourceUpdateCount
+	proxiedPostUnsubDelta := proxiedFinal.ResourceUpdateCount - proxiedAfter.ResourceUpdateCount
+	if directPostUnsubDelta != proxiedPostUnsubDelta {
+		return phase3Outcome{
+			Name:           "resources/unsubscribe",
+			Classification: classificationProxyDivergence,
+			Summary:        "direct and proxied paths diverged after unsubscribe while subscriber updates were still running",
+			DirectDetails:  prettyJSON(t, directFinal),
+			ProxiedDetails: prettyJSON(t, proxiedFinal),
+		}
+	}
+
+	return phase3Outcome{
+		Name:           "resources/subscribe",
+		Classification: classificationMatch,
+		Summary:        fmt.Sprintf("resource subscription parity held (updates direct=%d proxied=%d, post-unsubscribe delta=%d)", directAfter.ResourceUpdateCount-directBefore.ResourceUpdateCount, proxiedAfter.ResourceUpdateCount-proxiedBefore.ResourceUpdateCount, directPostUnsubDelta),
+		DirectDetails:  fmt.Sprintf("toggle result:\n%s\nnotifications:\n%s", prettyJSON(t, directToggle), prettyJSON(t, directFinal)),
+		ProxiedDetails: fmt.Sprintf("toggle result:\n%s\nnotifications:\n%s", prettyJSON(t, proxiedToggle), prettyJSON(t, proxiedFinal)),
+	}
+}
+
+func evaluateResourceTemplatesProbe(ctx context.Context, t *testing.T, pair *connectionPair) phase3Outcome {
+	t.Helper()
+
+	directTemplates, directErr := pair.Direct.session.ListResourceTemplates(ctx, nil)
+	proxiedTemplates, proxiedErr := pair.Proxied.session.ListResourceTemplates(ctx, nil)
+
+	normalizedDirectTemplates := normalizeTemplateListResult(directTemplates)
+	normalizedProxiedTemplates := normalizeTemplateListResult(proxiedTemplates)
+	if sameErrorMessage(directErr, proxiedErr) && jsonEqual(t, normalizedDirectTemplates, normalizedProxiedTemplates) {
+		return phase3Outcome{
+			Name:           "resources/templates/list",
+			Classification: classificationMatch,
+			Summary:        "direct and proxied resources/templates/list behaved the same",
+			DirectDetails:  renderOperationOutcome(t, normalizedDirectTemplates, directErr),
+			ProxiedDetails: renderOperationOutcome(t, normalizedProxiedTemplates, proxiedErr),
+		}
+	}
+
+	if directErr == nil && proxiedErr != nil {
+		return phase3Outcome{
+			Name:           "resources/templates/list",
+			Classification: classificationUnsupportedInCentian,
+			Summary:        "direct path supports resources/templates/list but proxied path does not",
+			DirectDetails:  renderOperationOutcome(t, directTemplates, directErr),
+			ProxiedDetails: renderOperationOutcome(t, proxiedTemplates, proxiedErr),
+		}
+	}
+
+	return phase3Outcome{
+		Name:           "resources/templates/list",
+		Classification: classificationProxyDivergence,
+		Summary:        "resources/templates/list produced different direct/proxied outcomes",
+		DirectDetails:  renderOperationOutcome(t, normalizedDirectTemplates, directErr),
+		ProxiedDetails: renderOperationOutcome(t, normalizedProxiedTemplates, proxiedErr),
+	}
+}
+
+func selectProbeResourceURI(ctx context.Context, t *testing.T, pair *connectionPair) (string, *mcp.ListResourcesResult, *mcp.ListResourcesResult) {
+	t.Helper()
+
+	directResources, directErr := pair.Direct.session.ListResources(ctx, nil)
+	if directErr != nil {
+		t.Fatalf("failed to list direct resources: %v", directErr)
+	}
+	proxiedResources, proxiedErr := pair.Proxied.session.ListResources(ctx, nil)
+	if proxiedErr != nil {
+		t.Fatalf("failed to list proxied resources: %v", proxiedErr)
+	}
+	if len(directResources.Resources) == 0 {
+		return "", directResources, proxiedResources
+	}
+	return directResources.Resources[0].URI, directResources, proxiedResources
+}
+
+func waitForRecorderState(
+	t *testing.T,
+	recorder *notificationRecorder,
+	timeout time.Duration,
+	ready func(notificationSnapshot) bool,
+) notificationSnapshot {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		snapshot := recorder.snapshot()
+		if ready(snapshot) {
+			return snapshot
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return recorder.snapshot()
+}
+
+func normalizeTemplateListResult(result *mcp.ListResourceTemplatesResult) *mcp.ListResourceTemplatesResult {
+	if result == nil {
+		return nil
+	}
+
+	cloned := &mcp.ListResourceTemplatesResult{
+		Meta:              result.Meta,
+		NextCursor:        result.NextCursor,
+		ResourceTemplates: append([]*mcp.ResourceTemplate(nil), result.ResourceTemplates...),
+	}
+	slices.SortFunc(cloned.ResourceTemplates, func(left, right *mcp.ResourceTemplate) int {
+		switch {
+		case left == nil && right == nil:
+			return 0
+		case left == nil:
+			return -1
+		case right == nil:
+			return 1
+		case left.URITemplate < right.URITemplate:
+			return -1
+		case left.URITemplate > right.URITemplate:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return cloned
+}
+
 func hasTool(tools []*mcp.Tool, name string) bool {
 	for _, tool := range tools {
 		if tool.Name == name {
@@ -346,6 +659,13 @@ func renderLoggingOutcome(t *testing.T, result *mcp.CallToolResult, snapshot not
 	t.Helper()
 
 	return fmt.Sprintf("result:\n%s\nLogCount: %d", prettyJSON(t, result), snapshot.LogCount)
+}
+
+func renderError(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
 }
 
 func sameErrorMessage(left, right error) bool {


### PR DESCRIPTION
## Goal

Close issue `#67` by making Centian preserve downstream MCP resource behavior instead of exposing incomplete or divergent resource surfaces through the proxy.

## Summary

This PR expands Centian’s MCP resource support from basic `resources/list` parity to full resource-surface parity for the `server-everything` integration path.

The proxy now:
- discovers and exposes downstream resource templates
- forwards downstream resource update notifications to upstream clients
- refreshes proxied resource and resource-template registrations when downstream resource lists change
- preserves downstream behavior for `resources/read`, `resources/subscribe`, `resources/unsubscribe`, and `resources/templates/list`

The integration suite was extended to validate those flows against a direct `server-everything` connection.

## Functionality Added

- Added downstream resource-template discovery and caching in the proxy connection layer.
- Added upstream registration/sync for `resources/templates/list`.
- Added forwarding for downstream `notifications/resources/updated`.
- Added handling for downstream `notifications/resources/list_changed` by rediscovering resources/templates and reconciling the upstream-facing server state.
- Added shared proxy support for resource-template registration alongside existing tools/resources/prompts registration.

## What Changed

- Extended `DownstreamConnectionInterface` and connection state to include resource templates and resource notification handlers.
- Updated pooled downstream connection setup to wire resource notification handlers in the same way logging notifications were already wired.
- Added resource-template registration lifecycle management to the proxy.
- Reused SDK-native subscription behavior when re-emitting resource updates upstream, rather than implementing separate subscription state inside Centian.
- Normalized resource-template integration assertions to compare content rather than unstable ordering.

## Tests Added / Changed

### Integration tests
Expanded `tests/integrationtests/everything` to cover:
- `resources/list`
- `resources/read`
- `resources/subscribe`
- `resources/unsubscribe`
- downstream `notifications/resources/updated`
- downstream `notifications/resources/list_changed`
- `resources/templates/list`

These tests compare direct vs proxied behavior using `@modelcontextprotocol/server-everything` as the source of truth.

### Proxy unit tests
Added or strengthened tests for:
- read/subscribe/unsubscribe behavior when no downstream owns a resource URI
- normalization of downstream resource-method errors
- resource-template registration/sync
- pooled resource-update fanout to multiple upstream sessions
- unsubscribe behavior preventing further forwarded updates
- downstream connection support for resource-template discovery and resource notification handlers

## Bugfixes

- Fixed the original `#67` gap beyond `resources/list` by ensuring Centian no longer exposes incomplete resource surfaces through the proxy.
- Fixed missing forwarding for downstream resource update notifications.
- Fixed missing support for downstream resource templates in the proxied surface.
- Fixed resource-template parity test instability caused by unordered template registration output.
