### PR TITLE
Implemented _meta forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.0.5 - 2026-03-16
+
+### Major
+- Expanded MCP parity across the proxy by forwarding downstream logging, propagating client capabilities and roots support, and adding downstream resource and resource-template capabilities.
+- Added comprehensive `server-everything` integration coverage for tool parity, protocol capability probes, and metadata-sensitive flows.
+- Added real-world integration coverage for external MCP servers, including filesystem and memory scenarios.
+
+### Minor
+- Added an auth context handler so processors can receive sanitized request authentication context without coupling to transport internals.
+- Improved proxy test coverage around capability propagation, logging, resources, real-world parity, and metadata-preserving tool forwarding.
+- Updated the `everything` integration documentation to reflect the current conformance-oriented test surface.
+
+### Bugfixes
+- Fixed aggregated tool-name normalization so processors and downstream calls keep the correct current and original tool names.
+- Fixed logger synchronization issues that could surface under concurrent proxy activity.
+- Fixed tool-call forwarding to preserve upstream `_meta` on proxied requests instead of rebuilding calls from only tool name and arguments.
+- Fixed stdio downstream environment handling so configured env vars merge with the inherited OS environment instead of replacing it entirely.
+
 ## v0.0.4 - 2026-03-12
 
 ### Major

--- a/internal/proxy/call_context.go
+++ b/internal/proxy/call_context.go
@@ -99,8 +99,35 @@ func deepCloneRequest(req *mcp.CallToolRequest) *mcp.CallToolRequest {
 
 	return &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{
+			Meta:      deepCloneMeta(req.Params.Meta),
 			Name:      req.Params.Name,
 			Arguments: argsCopy,
 		},
 	}
+}
+
+func deepCloneMeta(meta mcp.Meta) mcp.Meta {
+	if meta == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		cloned := make(mcp.Meta, len(meta))
+		for key, value := range meta {
+			cloned[key] = value
+		}
+		return cloned
+	}
+
+	var cloned mcp.Meta
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		fallback := make(mcp.Meta, len(meta))
+		for key, value := range meta {
+			fallback[key] = value
+		}
+		return fallback
+	}
+
+	return cloned
 }

--- a/internal/proxy/downstream_connection.go
+++ b/internal/proxy/downstream_connection.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
+	"slices"
 	"sync"
 	"time"
 
@@ -284,13 +286,42 @@ func (dc *DownstreamConnection) createTransport(forwardedHeaders map[string]stri
 	if isStdioTransport {
 		//nolint:gosec // command comes from trusted user config
 		cmd := exec.Command(dc.config.Command, dc.config.Args...)
-		for key, value := range dc.config.Env {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+		if len(dc.config.Env) > 0 {
+			cmd.Env = mergeEnvironment(os.Environ(), dc.config.Env)
 		}
 		return &mcp.CommandTransport{Command: cmd}, nil
 	}
 
 	return nil, fmt.Errorf("no URL or Command configured for server %s", dc.serverName)
+}
+
+func mergeEnvironment(base []string, overrides map[string]string) []string {
+	values := make(map[string]string, len(base)+len(overrides))
+	for _, entry := range base {
+		key, value, ok := splitEnvironmentEntry(entry)
+		if ok {
+			values[key] = value
+		}
+	}
+	for key, value := range overrides {
+		values[key] = value
+	}
+
+	merged := make([]string, 0, len(values))
+	for key, value := range values {
+		merged = append(merged, fmt.Sprintf("%s=%s", key, value))
+	}
+	slices.Sort(merged)
+	return merged
+}
+
+func splitEnvironmentEntry(entry string) (string, string, bool) {
+	for i := 0; i < len(entry); i++ {
+		if entry[i] == '=' {
+			return entry[:i], entry[i+1:], true
+		}
+	}
+	return "", "", false
 }
 
 func (dc *DownstreamConnection) discoverTools(ctx context.Context) error {

--- a/internal/proxy/downstream_connection.go
+++ b/internal/proxy/downstream_connection.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os/exec"
@@ -454,18 +455,26 @@ func (dc *DownstreamConnection) SetLoggingLevel(ctx context.Context, params *mcp
 }
 
 // CallTool forwards a tool call to the downstream server.
-func (dc *DownstreamConnection) CallTool(ctx context.Context, toolName string, args map[string]any) (*mcp.CallToolResult, error) {
+func (dc *DownstreamConnection) CallTool(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dc.mu.RLock()
 	defer dc.mu.RUnlock()
 
 	if !dc.status.IsConnected() || dc.session == nil {
 		return nil, fmt.Errorf("not connected to %s", dc.serverName)
 	}
+	if req == nil || req.Params == nil {
+		return nil, fmt.Errorf("call tool request params are required")
+	}
 
-	return dc.session.CallTool(ctx, &mcp.CallToolParams{
-		Name:      toolName,
-		Arguments: args,
-	})
+	params := &mcp.CallToolParams{
+		Meta: deepCloneMeta(req.Params.Meta),
+		Name: req.Params.Name,
+	}
+	if req.Params.Arguments != nil {
+		params.Arguments = json.RawMessage(append([]byte(nil), req.Params.Arguments...))
+	}
+
+	return dc.session.CallTool(ctx, params)
 }
 
 // Close terminates the downstream connection.

--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 
 	"github.com/T4cceptor/centian/internal/config"
@@ -24,6 +25,8 @@ type MockDownstreamConnection struct {
 	// Captured call data.
 	CapturedToolName     string
 	CapturedArgs         map[string]any
+	CapturedMeta         mcp.Meta
+	CapturedRequest      *mcp.CallToolRequest
 	CapturedConnects     []DownstreamConnectOptions
 	CapturedConnectAuths []map[string]string
 	CapturedLogLevels    []mcp.LoggingLevel
@@ -80,11 +83,27 @@ func (m *MockDownstreamConnection) GetError() error {
 	return m.ErrorToReturn
 }
 
-func (m *MockDownstreamConnection) CallTool(_ context.Context, toolName string, args map[string]any) (*mcp.CallToolResult, error) {
+func (m *MockDownstreamConnection) CallTool(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.CapturedToolName = toolName
-	m.CapturedArgs = args
+
+	m.CapturedRequest = deepCloneRequest(req)
+	if req != nil && req.Params != nil {
+		m.CapturedToolName = req.Params.Name
+		m.CapturedMeta = deepCloneMeta(req.Params.Meta)
+
+		var args map[string]any
+		if err := json.Unmarshal(req.Params.Arguments, &args); err == nil {
+			m.CapturedArgs = args
+		} else {
+			m.CapturedArgs = nil
+		}
+	} else {
+		m.CapturedToolName = ""
+		m.CapturedMeta = nil
+		m.CapturedArgs = nil
+	}
+
 	return m.ResultToReturn, m.ErrorToReturn
 }
 

--- a/internal/proxy/downstream_connection_test.go
+++ b/internal/proxy/downstream_connection_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -263,7 +264,12 @@ func TestDownstreamConnection_ForwardsLoggingNotifications(t *testing.T) {
 	dc.status = StatusConnected
 
 	assert.NilError(t, dc.SetLoggingLevel(ctx, &mcp.SetLoggingLevelParams{Level: "info"}))
-	_, err = dc.CallTool(ctx, "log", map[string]any{})
+	_, err = dc.CallTool(ctx, &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "log",
+			Arguments: json.RawMessage(`{}`),
+		},
+	})
 	assert.NilError(t, err)
 
 	select {
@@ -277,7 +283,12 @@ func TestDownstreamConnection_ForwardsLoggingNotifications(t *testing.T) {
 func TestDownstreamConnectionCallTool_NotConnected(t *testing.T) {
 	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
 
-	result, err := dc.CallTool(context.Background(), "ping", map[string]any{"k": "v"})
+	result, err := dc.CallTool(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "ping",
+			Arguments: json.RawMessage(`{"k":"v"}`),
+		},
+	})
 
 	assert.Assert(t, result == nil)
 	assert.ErrorContains(t, err, "not connected to server")
@@ -318,11 +329,64 @@ func TestDownstreamConnectionCallTool(t *testing.T) {
 	dc.session = clientSession
 	dc.status = StatusConnected
 
-	result, err := dc.CallTool(context.Background(), "ping", map[string]any{"message": "pong"})
+	result, err := dc.CallTool(context.Background(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "ping",
+			Arguments: json.RawMessage(`{"message":"pong"}`),
+		},
+	})
 
 	assert.NilError(t, err)
 	assert.Assert(t, result != nil)
 	assert.Equal(t, result.Content[0].(*mcp.TextContent).Text, "pong")
+}
+
+func TestDownstreamConnectionCallTool_PreservesMeta(t *testing.T) {
+	var capturedMeta mcp.Meta
+
+	clientSession, cleanup := connectTestClientSession(t, func(server *mcp.Server) {
+		mcp.AddTool(server, &mcp.Tool{Name: "ping", Description: "ping"}, func(_ context.Context, req *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
+			if req != nil && req.Params != nil {
+				capturedMeta = deepCloneMeta(req.Params.Meta)
+			}
+			return &mcp.CallToolResult{
+				StructuredContent: map[string]any{
+					"meta": req.Params.Meta,
+				},
+			}, nil, nil
+		})
+	})
+	defer cleanup()
+
+	dc := NewDownstreamConnection("server", &config.MCPServerConfig{})
+	dc.session = clientSession
+	dc.status = StatusConnected
+
+	req := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Meta: mcp.Meta{
+				"progressToken": "progress-1",
+				"custom":        "value",
+			},
+			Name:      "ping",
+			Arguments: json.RawMessage(`{"message":"pong"}`),
+		},
+	}
+
+	result, err := dc.CallTool(context.Background(), req)
+
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.DeepEqual(t, capturedMeta, req.Params.Meta)
+
+	structured, ok := result.StructuredContent.(map[string]any)
+	assert.Assert(t, ok)
+	meta, ok := structured["meta"].(map[string]any)
+	assert.Assert(t, ok)
+	assert.DeepEqual(t, meta, map[string]any{
+		"progressToken": "progress-1",
+		"custom":        "value",
+	})
 }
 
 func containsEnv(env []string, entry string) bool {

--- a/internal/proxy/downstream_connection_test.go
+++ b/internal/proxy/downstream_connection_test.go
@@ -90,6 +90,72 @@ func TestCreateTransport_Stdio(t *testing.T) {
 	assert.Assert(t, containsEnv(cmdTransport.Command.Env, "A=B"))
 }
 
+func TestCreateTransport_StdioMergesConfiguredEnvWithOS(t *testing.T) {
+	// Given: inherited OS env and configured downstream env.
+	t.Setenv("CENTIAN_TEST_INHERITED_ENV", "inherited")
+
+	cfg := &config.MCPServerConfig{
+		Command: "echo",
+		Args:    []string{"hello"},
+		Env: map[string]string{
+			"A": "B",
+		},
+	}
+	dc := NewDownstreamConnection("server", cfg)
+
+	// When: creating the stdio transport.
+	transport, err := dc.createTransport(nil)
+
+	// Then: configured env is present and inherited env is preserved.
+	assert.NilError(t, err)
+	cmdTransport, ok := transport.(*mcp.CommandTransport)
+	assert.Assert(t, ok)
+	assert.Assert(t, containsEnv(cmdTransport.Command.Env, "A=B"))
+	assert.Assert(t, containsEnv(cmdTransport.Command.Env, "CENTIAN_TEST_INHERITED_ENV=inherited"))
+}
+
+func TestCreateTransport_StdioConfiguredEnvOverridesOS(t *testing.T) {
+	// Given: an OS env var with the same key as configured downstream env.
+	t.Setenv("CENTIAN_TEST_OVERRIDE_ENV", "os-value")
+
+	cfg := &config.MCPServerConfig{
+		Command: "echo",
+		Args:    []string{"hello"},
+		Env: map[string]string{
+			"CENTIAN_TEST_OVERRIDE_ENV": "config-value",
+		},
+	}
+	dc := NewDownstreamConnection("server", cfg)
+
+	// When: creating the stdio transport.
+	transport, err := dc.createTransport(nil)
+
+	// Then: configured env wins over the inherited value.
+	assert.NilError(t, err)
+	cmdTransport, ok := transport.(*mcp.CommandTransport)
+	assert.Assert(t, ok)
+	assert.Assert(t, containsEnv(cmdTransport.Command.Env, "CENTIAN_TEST_OVERRIDE_ENV=config-value"))
+	assert.Assert(t, !containsEnv(cmdTransport.Command.Env, "CENTIAN_TEST_OVERRIDE_ENV=os-value"))
+}
+
+func TestCreateTransport_StdioWithoutConfiguredEnvInheritsOS(t *testing.T) {
+	// Given: a stdio command with no configured env overrides.
+	cfg := &config.MCPServerConfig{
+		Command: "echo",
+		Args:    []string{"hello"},
+	}
+	dc := NewDownstreamConnection("server", cfg)
+
+	// When: creating the stdio transport.
+	transport, err := dc.createTransport(nil)
+
+	// Then: Go inheritance behavior is preserved by leaving cmd.Env unset.
+	assert.NilError(t, err)
+	cmdTransport, ok := transport.(*mcp.CommandTransport)
+	assert.Assert(t, ok)
+	assert.Assert(t, cmdTransport.Command.Env == nil)
+}
+
 func TestCreateTransport_InvalidConfigs(t *testing.T) {
 	// Given: a config with both URL and Command
 	cfg := &config.MCPServerConfig{URL: "https://example.com", Command: "echo"}

--- a/internal/proxy/interfaces.go
+++ b/internal/proxy/interfaces.go
@@ -19,7 +19,7 @@ type ProcessingControllerInterface interface {
 //
 // The actual connection lives in DownstreamConnection.
 type DownstreamConnectionInterface interface {
-	CallTool(ctx context.Context, toolName string, args map[string]any) (*mcp.CallToolResult, error)
+	CallTool(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error)
 	GetServerName() string
 	IsConnected() bool
 	IsConnecting() bool

--- a/internal/proxy/tool_call_context.go
+++ b/internal/proxy/tool_call_context.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/T4cceptor/centian/internal/common"
@@ -150,15 +149,13 @@ func (c *ToolCallContext) SendRequest(ctx context.Context) error {
 			serverName, c.originalServerName)
 	}
 
-	// Parse arguments from current request
-	var args map[string]any
-	if err := json.Unmarshal(c.request.Params.Arguments, &args); err != nil {
-		return fmt.Errorf("failed to parse arguments: %w", err)
+	if c.request == nil || c.request.Params == nil {
+		return fmt.Errorf("tool call request params are required")
 	}
 
-	// Make the call with current request data
-	// Note: per-request headers require CallTool signature change (Phase 3)
-	result, err := conn.CallTool(ctx, c.GetToolName(), args)
+	// Forward the current request object so downstream receives the full tool
+	// call shape, including request metadata.
+	result, err := conn.CallTool(ctx, c.GetRequest())
 	if err != nil {
 		return normalizeForwardedMethodError(mcpMethodCallTool, err)
 	}

--- a/internal/proxy/tool_call_context_test.go
+++ b/internal/proxy/tool_call_context_test.go
@@ -72,6 +72,7 @@ func TestBuildRoutingContext(t *testing.T) {
 func TestNewToolCallContext(t *testing.T) {
 	request := &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{
+			Meta:      mcp.Meta{"progressToken": "original-progress", "custom": "original"},
 			Name:      "demo_tool",
 			Arguments: json.RawMessage(`{"k":"v"}`),
 		},
@@ -162,7 +163,9 @@ func TestNewToolCallContext(t *testing.T) {
 		// And: original request was deep-cloned.
 		assert.Assert(t, callCtx.GetOriginalRequest() != callCtx.GetRequest())
 		callCtx.GetRequest().Params.Arguments = json.RawMessage(`{"k":"changed"}`)
+		callCtx.GetRequest().Params.Meta["custom"] = "changed"
 		assert.Equal(t, string(callCtx.GetOriginalRequest().Params.Arguments), `{"k":"v"}`)
+		assert.Equal(t, callCtx.GetOriginalRequest().Params.Meta["custom"], "original")
 	})
 
 	t.Run("normalizes aggregated tool names into current request state", func(t *testing.T) {
@@ -244,8 +247,37 @@ func TestNewToolCallContext(t *testing.T) {
 	})
 }
 
+func TestDeepCloneRequestPreservesMeta(t *testing.T) {
+	req := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Meta: mcp.Meta{
+				"progressToken": "progress-1",
+				"custom":        "value",
+				"nested": map[string]any{
+					"flag": true,
+				},
+			},
+			Name:      "demo_tool",
+			Arguments: json.RawMessage(`{"k":"v"}`),
+		},
+	}
+
+	cloned := deepCloneRequest(req)
+
+	assert.Assert(t, cloned != nil)
+	assert.DeepEqual(t, cloned.Params.Meta, req.Params.Meta)
+	assert.Assert(t, cloned.Params.Meta != nil)
+
+	req.Params.Meta["custom"] = "changed"
+	req.Params.Meta["nested"].(map[string]any)["flag"] = false
+
+	assert.Equal(t, cloned.Params.Meta["custom"], "value")
+	assert.Equal(t, cloned.Params.Meta["progressToken"], "progress-1")
+	assert.Equal(t, cloned.Params.Meta["nested"].(map[string]any)["flag"], true)
+}
+
 func TestToolCallContextSendRequest(t *testing.T) {
-	makeContext := func(conn DownstreamConnectionInterface, args json.RawMessage) *ToolCallContext {
+	makeContext := func(conn DownstreamConnectionInterface, meta mcp.Meta, args json.RawMessage) *ToolCallContext {
 		return &ToolCallContext{
 			proxy:              &CentianEndpoint{},
 			originalServerName: "orig-srv",
@@ -257,6 +289,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 			routingContext: &common.RoutingContext{ServerName: "srv"},
 			request: &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{
+					Meta:      meta,
 					Name:      "tool_name",
 					Arguments: args,
 				},
@@ -287,17 +320,28 @@ func TestToolCallContextSendRequest(t *testing.T) {
 		toolCtx := makeContext(&MockDownstreamConnection{
 			cfg:    &config.MCPServerConfig{Command: "python3"},
 			Status: StatusFailed,
-		}, json.RawMessage(`{}`))
+		}, nil, json.RawMessage(`{}`))
 
 		err := toolCtx.SendRequest(context.Background())
 		assert.Assert(t, err != nil)
 	})
 
-	t.Run("fails on invalid request arguments", func(t *testing.T) {
-		toolCtx := makeContext(&MockDownstreamConnection{
-			cfg:    &config.MCPServerConfig{Command: "python3"},
-			Status: StatusConnected,
-		}, json.RawMessage(`{invalid}`))
+	t.Run("fails when request params are missing", func(t *testing.T) {
+		toolCtx := &ToolCallContext{
+			proxy:              &CentianEndpoint{},
+			originalServerName: "orig-srv",
+			upstreamSession: &UpstreamSession{
+				downstreamConns: map[string]DownstreamConnectionInterface{
+					"srv": &MockDownstreamConnection{
+						cfg:    &config.MCPServerConfig{Command: "python3"},
+						Status: StatusConnected,
+					},
+				},
+			},
+			routingContext: &common.RoutingContext{ServerName: "srv"},
+			request:        &mcp.CallToolRequest{},
+			event:          common.NewMCPRequestEvent("stdio"),
+		}
 
 		err := toolCtx.SendRequest(context.Background())
 		assert.Assert(t, err != nil)
@@ -308,7 +352,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 			cfg:           &config.MCPServerConfig{Command: "python3"},
 			Status:        StatusConnected,
 			ErrorToReturn: errors.New("downstream failed"),
-		}, json.RawMessage(`{"a":1}`))
+		}, nil, json.RawMessage(`{"a":1}`))
 
 		err := toolCtx.SendRequest(context.Background())
 		assert.Assert(t, err != nil)
@@ -322,7 +366,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
 			},
 		}
-		toolCtx := makeContext(conn, json.RawMessage(`{"a":1}`))
+		toolCtx := makeContext(conn, nil, json.RawMessage(`{"a":1}`))
 
 		err := toolCtx.SendRequest(context.Background())
 		assert.NilError(t, err)
@@ -331,6 +375,27 @@ func TestToolCallContextSendRequest(t *testing.T) {
 		assert.Assert(t, toolCtx.HasResult())
 		assert.Assert(t, toolCtx.GetResult() != nil)
 		assert.Assert(t, toolCtx.GetOriginalResult() == toolCtx.GetResult())
+	})
+
+	t.Run("forwards request meta unchanged", func(t *testing.T) {
+		conn := &MockDownstreamConnection{
+			cfg:    &config.MCPServerConfig{Command: "python3"},
+			Status: StatusConnected,
+			ResultToReturn: &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+			},
+		}
+		meta := mcp.Meta{
+			"progressToken": "progress-123",
+			"custom":        "value",
+		}
+		toolCtx := makeContext(conn, meta, json.RawMessage(`{"a":1}`))
+
+		err := toolCtx.SendRequest(context.Background())
+		assert.NilError(t, err)
+		assert.Assert(t, conn.CapturedRequest != nil)
+		assert.DeepEqual(t, conn.CapturedMeta, meta)
+		assert.DeepEqual(t, conn.CapturedRequest.Params.Meta, meta)
 	})
 }
 

--- a/tests/integrationtests/everything/README.md
+++ b/tests/integrationtests/everything/README.md
@@ -5,7 +5,7 @@ This package contains integration tests for comparing a direct connection to
 Centian.
 
 The main goal is to show where Centian matches MCP behavior and where it
-currently diverges.
+must continue to match MCP behavior.
 
 ## What Is Implemented
 
@@ -14,7 +14,8 @@ The current test package covers three layers:
 1. Baseline connection and tool discovery
 2. Tool and metadata parity checks for deterministic tool calls
 3. Capability probes for logging, resources, roots, sampling, elicitation, and
-   other protocol surfaces that are expected to be weaker in Centian today
+   other protocol surfaces that have historically diverged and now act as
+   regression checks
 
 ## How The Harness Works
 
@@ -114,11 +115,17 @@ These probes currently focus on:
 - `trigger-elicitation-request`
 - `simulate-research-query`
 - `resources/list`
+- `resources/read`
+- `resources/subscribe`
+- `resources/templates/list`
+
+The progress probe also exercises tool-call `_meta` forwarding by attaching a
+progress token to both the direct and proxied paths.
 
 ## Interpreting Failures
 
 Not every failure means the test harness is wrong. The suite is intentionally
-designed to expose current Centian gaps.
+designed to make protocol mismatches obvious and actionable.
 
 Examples of meaningful failures:
 
@@ -129,18 +136,16 @@ Examples of meaningful failures:
   hides
 
 If a failure includes `proxy_divergence` or `unsupported_in_centian`, it should
-generally be treated as a product gap to evaluate, not as a flaky test by
-default.
+generally be treated as a product regression or an uncovered capability gap,
+not as a flaky test by default.
 
 ## Current Supporting Material
 
-- Plan: `tests/integrationtests/everything/PLAN.md`
-- Issue drafts: `tests/integrationtests/everything/ISSUE_DRAFTS.md`
 - Example captured output: `tests/integrationtests/everything/tmp/`
 
 ## Notes
 
 - These tests are intentionally separate from the general integration suite
   because they rely on a real downstream MCP server implementation.
-- The package currently focuses on assessment and gap discovery, not on
-  providing a permanently green conformance suite yet.
+- The package is used both for parity verification and for investigating new
+  MCP capability regressions when they appear.

--- a/tests/integrationtests/realworld/fetch_test.go
+++ b/tests/integrationtests/realworld/fetch_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -28,6 +29,15 @@ func TestFetchToolCatalogParity(t *testing.T) {
 }
 
 func TestFetchMarkdownParity(t *testing.T) {
+	// CI can fail this direct-path fetch parity check on a cold environment:
+	// the first `uvx mcp-server-fetch` startup sometimes emits non-JSON stdout,
+	// which makes the direct MCP client fail with
+	// `invalid character 'a' looking for beginning of value`, while the later
+	// proxied startup succeeds after the runtime/cache is warm.
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping flaky CI-only direct fetch markdown parity case; cold uvx startup can emit non-MCP stdout")
+	}
+
 	runServerComparison(t, fetchManifest, "markdown_html", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
 		assertToolCallParity(
 			ctx,

--- a/tests/integrationtests/realworld/fetch_test.go
+++ b/tests/integrationtests/realworld/fetch_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 )
@@ -17,9 +16,11 @@ var fetchManifest = &serverManifest{
 	CommandEnvVar:  "CENTIAN_FETCH_SERVER_CMD",
 	ArgsEnvVar:     "CENTIAN_FETCH_SERVER_ARGS",
 	DefaultCommand: "uvx",
-	DefaultArgs:    []string{"mcp-server-fetch"},
-	ExpectedTools:  []string{"fetch"},
-	BuildFixture:   buildFetchFixture,
+	// Keep uvx quiet so first-run package resolution does not emit non-MCP
+	// stdout that can corrupt stdio protocol startup in CI.
+	DefaultArgs:   []string{"--quiet", "--no-progress", "mcp-server-fetch"},
+	ExpectedTools: []string{"fetch"},
+	BuildFixture:  buildFetchFixture,
 }
 
 func TestFetchToolCatalogParity(t *testing.T) {
@@ -29,15 +30,6 @@ func TestFetchToolCatalogParity(t *testing.T) {
 }
 
 func TestFetchMarkdownParity(t *testing.T) {
-	// CI can fail this direct-path fetch parity check on a cold environment:
-	// the first `uvx mcp-server-fetch` startup sometimes emits non-JSON stdout,
-	// which makes the direct MCP client fail with
-	// `invalid character 'a' looking for beginning of value`, while the later
-	// proxied startup succeeds after the runtime/cache is warm.
-	if os.Getenv("CI") != "" {
-		t.Skip("skipping flaky CI-only direct fetch markdown parity case; cold uvx startup can emit non-MCP stdout")
-	}
-
 	runServerComparison(t, fetchManifest, "markdown_html", func(ctx context.Context, t *testing.T, pair *connectionPair, fixture *fixtureBundle) {
 		assertToolCallParity(
 			ctx,


### PR DESCRIPTION
## Summary

Fixes `#68` by preserving upstream `tools/call` request `_meta` when Centian forwards tool calls downstream.

Before this change, Centian rebuilt downstream tool calls from `toolName + arguments`, which dropped request metadata such as `progressToken` and any custom `_meta` fields. This change switches the internal forwarding path to carry the full `CallToolRequest` through the proxy and copy `_meta` into the downstream SDK call.

## What Changed

- Changed the internal proxy tool-call boundary from:
  - `CallTool(ctx, toolName, args)`
  - to `CallTool(ctx, req *mcp.CallToolRequest)`
- Updated `ToolCallContext.SendRequest` to forward the current request object instead of reparsing and rebuilding arguments.
- Updated `DownstreamConnection.CallTool` to forward:
  - tool name
  - full request `_meta`
  - raw arguments payload
- Updated request cloning so `GetOriginalRequest()` preserves `_meta` and does not share metadata map state with the mutable request.
- Updated proxy test doubles to capture the full forwarded request and metadata.

## Tests

Added:
- Unit test proving `ToolCallContext.SendRequest` forwards `_meta` unchanged.
- Unit test proving deep-cloned original requests preserve `_meta` without shared state.
- Focused integration test proving the downstream MCP tool handler receives the original `_meta`, including `progressToken` and a custom field.

## Related

- Closes #68