### PR TITLE
Formalize processor data contract v1.0 with golden fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ centian processor add --type webhook --url https://example.com/processors/audit 
 ```
 
 CLI and webhook processors use the same `DataContext` contract and can coexist in the same chain.
+That contract centers on `event`, `payload`, `routing`, and optional read-only `auth` context, as documented in [`docs/processor_development_guide.md`](/Users/brb/_devspace/centian-cli/docs/processor_development_guide.md).
 
 ## Logging
 

--- a/docs/processor_development_guide.md
+++ b/docs/processor_development_guide.md
@@ -188,8 +188,18 @@ Processors receive a JSON object with this structure. CLI processors read it fro
 {
   "version": "1.0",
   "event": {
+    "status": 0,
     "timestamp": "2025-12-14T10:30:00Z",
-    "direction": "request"
+    "transport": "http",
+    "request_id": "req-abc123",
+    "direction": "[CLIENT -> SERVER]",
+    "message_type": "request",
+    "success": true,
+    "modified": false,
+    "routing": {
+      "transport": "http",
+      "server_name": "memory"
+    }
   },
   "payload": {
     "request": {
@@ -230,19 +240,20 @@ Processors receive a JSON object with this structure. CLI processors read it fro
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `version` | string | Processor DTO version |
-| `event` | object | MCP event metadata when the `meta` part is enabled |
+| `version` | string | Data contract version (e.g. `"1.0"`). Follows major.minor: major is breaking, minor is additive |
+| `event` | object | MCP event metadata when the `meta` part is enabled. Key fields: `direction` (`"[CLIENT -> SERVER]"` or `"[SERVER -> CLIENT]"`), `message_type` (`"request"` or `"response"`), `transport`, `timestamp`, `success`, `routing` |
 | `payload.request` | object | Current `tools/call` request payload when the `payload` part is enabled |
-| `payload.original_request` | object | Original upstream request snapshot |
+| `payload.original_request` | object | Original upstream request snapshot (read-only) |
 | `payload.result` | object | Current downstream tool result if one exists |
-| `payload.original_result` | object | Original downstream result snapshot |
+| `payload.original_result` | object | Original downstream result snapshot (read-only) |
 | `routing` | object | Current and original server/tool routing data |
 | `auth` | object | Read-only auth context |
 
 Notes:
 
 - Only configured parts are present.
-- For `tools/call`, request parameters are serialized under `payload.request.Params`.
+- For `tools/call`, request parameters are serialized under `payload.request.Params` (note capital `P`).
+- The `event.direction` value is `"[CLIENT -> SERVER]"` for requests and `"[SERVER -> CLIENT]"` for responses.
 - Processors should return the full structures they want Centian to apply. Partial request patching is not supported by the default payload handler.
 
 ---
@@ -338,13 +349,8 @@ Simply return the input unchanged:
 
 ```python
 import sys, json
-event = json.load(sys.stdin)
-print(json.dumps({
-    "status": 200,
-    "payload": event["payload"],
-    "error": None,
-    "metadata": {"processor_name": "passthrough"}
-}))
+ctx = json.load(sys.stdin)
+print(json.dumps(ctx))
 ```
 
 **Use Case**: Testing, debugging, placeholder
@@ -353,31 +359,25 @@ print(json.dumps({
 
 ### 2. Validator
 
-Check conditions and reject if invalid:
+Check conditions and inject a blocking result:
 
 ```python
 import sys, json
 
-event = json.load(sys.stdin)
-payload = event["payload"]
+ctx = json.load(sys.stdin)
+payload = ctx.get("payload") or {}
+request = payload.get("request") or {}
+params = request.get("Params") or {}
+tool_name = params.get("name", "")
 
-# Check if method contains "delete"
-if "delete" in payload.get("method", "").lower():
-    result = {
-        "status": 403,
-        "payload": {},
-        "error": "Delete operations not allowed",
-        "metadata": {"processor_name": "delete_blocker"}
+if "delete" in tool_name.lower():
+    payload["result"] = {
+        "content": [{"type": "text", "text": "Delete operations not allowed"}],
+        "isError": True
     }
-else:
-    result = {
-        "status": 200,
-        "payload": payload,
-        "error": None,
-        "metadata": {"processor_name": "delete_blocker"}
-    }
+    ctx["payload"] = payload
 
-print(json.dumps(result))
+print(json.dumps(ctx))
 ```
 
 **Use Cases**: Security policies, input validation, rate limiting
@@ -391,24 +391,20 @@ Modify the payload before forwarding:
 ```python
 import sys, json
 
-event = json.load(sys.stdin)
-payload = event["payload"]
+ctx = json.load(sys.stdin)
+payload = ctx.get("payload") or {}
+request = payload.get("request") or {}
+params = request.get("Params") or {}
+arguments = params.get("arguments") or {}
 
-# Add a custom header
-if "params" in payload:
-    if "arguments" not in payload["params"]:
-        payload["params"]["arguments"] = {}
-    payload["params"]["arguments"]["x-processor"] = "transformer"
+if isinstance(arguments, dict):
+    arguments["x-processor"] = "transformer"
+    params["arguments"] = arguments
+    request["Params"] = params
+    payload["request"] = request
+    ctx["payload"] = payload
 
-print(json.dumps({
-    "status": 200,
-    "payload": payload,
-    "error": None,
-    "metadata": {
-        "processor_name": "transformer",
-        "modifications": ["added x-processor header"]
-    }
-}))
+print(json.dumps(ctx))
 ```
 
 **Use Cases**: Data sanitization, enrichment, normalization
@@ -423,19 +419,20 @@ Record data and pass through:
 import sys, json
 from datetime import datetime
 
-event = json.load(sys.stdin)
+ctx = json.load(sys.stdin)
 
-# Log to file (stderr ignored by Centian v1)
+payload = ctx.get("payload") or {}
+request = payload.get("request") or {}
+params = request.get("Params") or {}
+tool_name = params.get("name", "unknown")
+direction = (ctx.get("event") or {}).get("direction", "unknown")
+
+# Log to file (stderr is also available for debug output)
 with open("/tmp/centian-processor.log", "a") as f:
-    f.write(f"{datetime.now()}: {event['type']} - {event['payload'].get('method')}\n")
+    f.write(json.dumps({"timestamp": datetime.now().isoformat(), "direction": direction, "tool": tool_name}) + "\n")
 
 # Pass through unchanged
-print(json.dumps({
-    "status": 200,
-    "payload": event["payload"],
-    "error": None,
-    "metadata": {"processor_name": "logger"}
-}))
+print(json.dumps(ctx))
 ```
 
 **Use Cases**: Audit logging, analytics, monitoring
@@ -444,36 +441,32 @@ print(json.dumps({
 
 ### 5. Request Filter
 
-Only process specific request types:
+Only apply logic for specific event directions:
 
 ```python
 import sys, json
 
-event = json.load(sys.stdin)
-payload = event["payload"]
+ctx = json.load(sys.stdin)
+event = ctx.get("event") or {}
 
-# Only validate "tools/call" requests
-if event["type"] == "request" and payload.get("method") == "tools/call":
-    # Perform validation
-    if not payload.get("params", {}).get("name"):
-        print(json.dumps({
-            "status": 400,
-            "payload": {},
-            "error": "Tool name is required",
-            "metadata": {"processor_name": "tool_validator"}
-        }))
-        sys.exit(0)
+# Only act on requests (client → server direction)
+if event.get("direction") == "[CLIENT -> SERVER]":
+    payload = ctx.get("payload") or {}
+    request = payload.get("request") or {}
+    params = request.get("Params") or {}
+    tool_name = params.get("name", "")
 
-# Pass through
-print(json.dumps({
-    "status": 200,
-    "payload": payload,
-    "error": None,
-    "metadata": {"processor_name": "tool_validator"}
-}))
+    if not tool_name:
+        payload["result"] = {
+            "content": [{"type": "text", "text": "Tool name is required"}],
+            "isError": True
+        }
+        ctx["payload"] = payload
+
+print(json.dumps(ctx))
 ```
 
-**Use Cases**: Method-specific validation, server-specific logic
+**Use Cases**: Direction-specific validation, server-specific logic
 
 ---
 
@@ -521,22 +514,25 @@ FAILED=0
 test_case() {
     local name=$1
     local input=$2
-    local expected_status=$3
+    local expect_error=$3  # "true" or "false"
 
     result=$(echo "$input" | $PROCESSOR)
-    status=$(echo "$result" | jq -r '.status')
+    is_error=$(echo "$result" | jq -r '.payload.result.isError // false')
 
-    if [ "$status" = "$expected_status" ]; then
+    if [ "$is_error" = "$expect_error" ]; then
         echo "✅ $name"
     else
-        echo "❌ $name (expected $expected_status, got $status)"
+        echo "❌ $name (expected isError=$expect_error, got isError=$is_error)"
         FAILED=1
     fi
 }
 
-# Test cases
-test_case "Allow normal request" '{"type":"request","payload":{"method":"tools/call","params":{"name":"safe_tool"}}}' "200"
-test_case "Block dangerous tool" '{"type":"request","payload":{"method":"tools/call","params":{"name":"delete_user"}}}' "403"
+# Test cases: use the DataContext format (version + event + payload + routing)
+SAFE='{"version":"1.0","event":{"direction":"[CLIENT -> SERVER]","message_type":"request","success":true},"payload":{"request":{"Params":{"name":"safe_tool","arguments":{}}}}}'
+DANGEROUS='{"version":"1.0","event":{"direction":"[CLIENT -> SERVER]","message_type":"request","success":true},"payload":{"request":{"Params":{"name":"delete_user","arguments":{}}}}}'
+
+test_case "Allow normal request" "$SAFE" "false"
+test_case "Block dangerous tool" "$DANGEROUS" "true"
 
 if [ $FAILED -eq 0 ]; then
     echo "All tests passed!"
@@ -670,10 +666,13 @@ Processors execute in order:
 ### 1. Use stderr for Debug Logging
 
 ```python
-import sys
+import sys, json
 
-# This won't affect Centian (stderr ignored in v1)
-print(f"DEBUG: Processing {event['type']}", file=sys.stderr)
+ctx = json.load(sys.stdin)
+event = ctx.get("event") or {}
+
+# This won't affect Centian (stderr ignored by Centian v1)
+print(f"DEBUG: direction={event.get('direction')} message_type={event.get('message_type')}", file=sys.stderr)
 ```
 
 ### 2. Test in Isolation
@@ -770,12 +769,11 @@ def load_blocked_list():
 **3. Early Return**
 
 ```python
-# Skip processing if not relevant
-if event["type"] != "request":
-    return passthrough(event)
-
-if event["payload"].get("method") != "tools/call":
-    return passthrough(event)
+# Skip processing if not relevant (e.g. only act on client→server requests)
+event = ctx.get("event") or {}
+if event.get("direction") != "[CLIENT -> SERVER]":
+    print(json.dumps(ctx))
+    sys.exit(0)
 
 # Now do expensive work
 ```
@@ -798,26 +796,27 @@ import sys
 import json
 from datetime import datetime
 
-event = json.load(sys.stdin)
+ctx = json.load(sys.stdin)
+
+event = ctx.get("event") or {}
+routing = ctx.get("routing") or {}
+payload = ctx.get("payload") or {}
+request = payload.get("request") or {}
+params = request.get("Params") or {}
 
 # Log to file
 log_entry = {
     "timestamp": datetime.now().isoformat(),
-    "type": event["type"],
-    "server": event["connection"]["server_name"],
-    "method": event["payload"].get("method", "unknown")
+    "direction": event.get("direction", "unknown"),
+    "server": routing.get("server_name", "unknown"),
+    "tool": params.get("name", "unknown")
 }
 
 with open("/tmp/centian-requests.log", "a") as f:
     f.write(json.dumps(log_entry) + "\n")
 
 # Pass through unchanged
-print(json.dumps({
-    "status": 200,
-    "payload": event["payload"],
-    "error": None,
-    "metadata": {"processor_name": "request_logger"}
-}))
+print(json.dumps(ctx))
 ```
 
 ### Example 2: SQL Injection Filter (Python)
@@ -828,18 +827,18 @@ import sys
 import json
 import re
 
-event = json.load(sys.stdin)
-payload = event["payload"]
+ctx = json.load(sys.stdin)
 
-# Only check tool calls
-if payload.get("method") != "tools/call":
-    print(json.dumps({
-        "status": 200,
-        "payload": payload,
-        "error": None,
-        "metadata": {"processor_name": "sql_filter"}
-    }))
+event = ctx.get("event") or {}
+# Only check client→server requests
+if event.get("direction") != "[CLIENT -> SERVER]":
+    print(json.dumps(ctx))
     sys.exit(0)
+
+payload = ctx.get("payload") or {}
+request = payload.get("request") or {}
+params = request.get("Params") or {}
+arguments = params.get("arguments") or {}
 
 # Check for SQL injection patterns
 sql_patterns = [
@@ -849,28 +848,20 @@ sql_patterns = [
     r"UNION\s+SELECT"
 ]
 
-args_str = json.dumps(payload.get("params", {}).get("arguments", {}))
+args_str = json.dumps(arguments)
 
 for pattern in sql_patterns:
     if re.search(pattern, args_str, re.IGNORECASE):
-        print(json.dumps({
-            "status": 403,
-            "payload": {},
-            "error": "Potential SQL injection detected",
-            "metadata": {
-                "processor_name": "sql_filter",
-                "pattern_matched": pattern
-            }
-        }))
+        payload["result"] = {
+            "content": [{"type": "text", "text": "Potential SQL injection detected"}],
+            "isError": True
+        }
+        ctx["payload"] = payload
+        print(json.dumps(ctx))
         sys.exit(0)
 
 # Safe - pass through
-print(json.dumps({
-    "status": 200,
-    "payload": payload,
-    "error": None,
-    "metadata": {"processor_name": "sql_filter"}
-}))
+print(json.dumps(ctx))
 ```
 
 ### Example 3: Rate Limiter (JavaScript)
@@ -887,14 +878,17 @@ const WINDOW_MS = 60000; // 1 minute
 let input = '';
 process.stdin.on('data', chunk => input += chunk);
 process.stdin.on('end', () => {
-  const event = JSON.parse(input);
+  const ctx = JSON.parse(input);
+  const event = ctx.event || {};
+  const routing = ctx.routing || {};
 
-  // Only rate limit requests
-  if (event.type !== 'request') {
-    return success(event.payload);
+  // Only rate limit client→server requests
+  if (event.direction !== '[CLIENT -> SERVER]') {
+    console.log(JSON.stringify(ctx));
+    return;
   }
 
-  const serverId = event.connection.server_name;
+  const serverId = routing.server_name || 'unknown';
   const now = Date.now();
 
   // Load rate limit state
@@ -915,31 +909,19 @@ process.stdin.on('end', () => {
 
   // Check rate limit
   if (state[serverId].count >= MAX_REQUESTS) {
-    reject(429, 'Rate limit exceeded');
+    const payload = ctx.payload || {};
+    payload.result = {
+      content: [{ type: 'text', text: 'Rate limit exceeded' }],
+      isError: true
+    };
+    ctx.payload = payload;
   } else {
     state[serverId].count++;
     fs.writeFileSync(RATE_LIMIT_FILE, JSON.stringify(state));
-    success(event.payload);
   }
+
+  console.log(JSON.stringify(ctx));
 });
-
-function success(payload) {
-  console.log(JSON.stringify({
-    status: 200,
-    payload: payload,
-    error: null,
-    metadata: { processor_name: 'rate_limiter' }
-  }));
-}
-
-function reject(status, error) {
-  console.log(JSON.stringify({
-    status: status,
-    payload: {},
-    error: error,
-    metadata: { processor_name: 'rate_limiter' }
-  }));
-}
 ```
 
 ---

--- a/docs/processor_development_guide.md
+++ b/docs/processor_development_guide.md
@@ -195,11 +195,7 @@ Processors receive a JSON object with this structure. CLI processors read it fro
     "direction": "[CLIENT -> SERVER]",
     "message_type": "request",
     "success": true,
-    "modified": false,
-    "routing": {
-      "transport": "http",
-      "server_name": "memory"
-    }
+    "modified": false
   },
   "payload": {
     "request": {
@@ -241,7 +237,7 @@ Processors receive a JSON object with this structure. CLI processors read it fro
 | Field | Type | Description |
 |-------|------|-------------|
 | `version` | string | Data contract version (e.g. `"1.0"`). Follows major.minor: major is breaking, minor is additive |
-| `event` | object | MCP event metadata when the `meta` part is enabled. Key fields: `direction` (`"[CLIENT -> SERVER]"` or `"[SERVER -> CLIENT]"`), `message_type` (`"request"` or `"response"`), `transport`, `timestamp`, `success`, `routing` |
+| `event` | object | MCP event metadata when the `meta` part is enabled. Key fields: `direction` (`"[CLIENT -> SERVER]"` or `"[SERVER -> CLIENT]"`), `message_type` (`"request"` or `"response"`), `transport`, `timestamp`, `success` |
 | `payload.request` | object | Current `tools/call` request payload when the `payload` part is enabled |
 | `payload.original_request` | object | Original upstream request snapshot (read-only) |
 | `payload.result` | object | Current downstream tool result if one exists |

--- a/docs/processor_development_guide.md
+++ b/docs/processor_development_guide.md
@@ -523,7 +523,7 @@ test_case() {
     fi
 }
 
-# Test cases: use the DataContext format (version + event + payload + routing)
+# Test cases: use the DataContext format (version + event + payload + routing + auth)
 SAFE='{"version":"1.0","event":{"direction":"[CLIENT -> SERVER]","message_type":"request","success":true},"payload":{"request":{"Params":{"name":"safe_tool","arguments":{}}}}}'
 DANGEROUS='{"version":"1.0","event":{"direction":"[CLIENT -> SERVER]","message_type":"request","success":true},"payload":{"request":{"Params":{"name":"delete_user","arguments":{}}}}}'
 

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -27,7 +27,7 @@ func TestHandleLogsCommandOutputsEntries(t *testing.T) {
 	os.Setenv("CENTIAN_LOG_DIR", tempDir)
 
 	// Given: a log file with a log entry.
-	e := common.MCPEvent{
+	e := common.LogEntry{
 		BaseMcpEvent: common.BaseMcpEvent{
 			Timestamp:        time.Date(2025, 1, 5, 10, 0, 0, 0, time.UTC),
 			Transport:        "stdio",
@@ -44,7 +44,7 @@ func TestHandleLogsCommandOutputsEntries(t *testing.T) {
 		},
 	}
 
-	writeTestLogFile(t, filepath.Join(tempDir, "requests_2025-01-05.jsonl"), []common.MCPEvent{e})
+	writeTestLogFile(t, filepath.Join(tempDir, "requests_2025-01-05.jsonl"), []common.LogEntry{e})
 
 	outBuf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
@@ -126,7 +126,7 @@ func TestHandleLogsCommandNoDirectory(t *testing.T) {
 // writeTestLogFile creates a JSONL log file at the specified path with the given entries.
 // Each entry is encoded as a single JSON line, matching the format used by the logging system.
 // The function creates parent directories if needed and truncates any existing file.
-func writeTestLogFile(t *testing.T, path string, entries []common.MCPEvent) {
+func writeTestLogFile(t *testing.T, path string, entries []common.LogEntry) {
 	t.Helper()
 
 	// Create parent directories if they don't exist.

--- a/internal/common/mcp_event.go
+++ b/internal/common/mcp_event.go
@@ -5,19 +5,16 @@ import (
 	"time"
 )
 
-// MCPEvent is a unified event type for all MCP transports.
-// It provides a transport-agnostic structure that can represent events from
-// HTTP, stdio, SDK-based proxies, or any future transport mechanism.
-//
-// It is mainly used to hold event metadata for the CallContext interface.
-type MCPEvent struct {
+// MetaContext contains processor-facing event metadata.
+type MetaContext struct {
 	BaseMcpEvent
+}
 
-	// Routing context (always present)
-	Routing RoutingContext `json:"routing"`
-
-	// Tool call context (optional - only for tool call events)
-	ToolCall *ToolCallLog `json:"tool_call,omitempty"`
+// LogEntry is the enriched log payload written to the Centian JSONL log.
+type LogEntry struct {
+	BaseMcpEvent
+	Routing  RoutingContext `json:"routing"`
+	ToolCall *ToolCallLog   `json:"tool_call,omitempty"`
 }
 
 // RoutingContext captures where the request is going.
@@ -48,7 +45,7 @@ type RoutingContext struct {
 
 // ToolCallLog captures tool call specific details.
 //
-// Note: this is typically only filled for logging MCPEvents.
+// Note: this is only filled for logging.
 type ToolCallLog struct {
 	// Name is the tool name being called
 	Name string `json:"name"`
@@ -70,13 +67,13 @@ type ToolCallLog struct {
 // Constructors
 // ============================================================================
 
-// NewMCPEvent creates a new MCPEvent with required fields initialized.
-func NewMCPEvent(
+// NewMetaContext creates a new MetaContext with required fields initialized.
+func NewMetaContext(
 	transport string,
 	direction McpEventDirection,
 	messageType McpMessageType,
-) *MCPEvent {
-	return &MCPEvent{
+) *MetaContext {
+	return &MetaContext{
 		BaseMcpEvent: BaseMcpEvent{
 			Timestamp:        time.Now(),
 			Transport:        transport,
@@ -87,13 +84,12 @@ func NewMCPEvent(
 			ProcessingErrors: make(map[string]error),
 			Metadata:         make(map[string]string),
 		},
-		Routing: RoutingContext{},
 	}
 }
 
-// NewMCPRequestEvent creates an MCPEvent for a request (client → server).
-func NewMCPRequestEvent(transport string) *MCPEvent {
-	return NewMCPEvent(transport, DirectionClientToServer, MessageTypeRequest)
+// NewRequestMetaContext creates a MetaContext for a request (client → server).
+func NewRequestMetaContext(transport string) *MetaContext {
+	return NewMetaContext(transport, DirectionClientToServer, MessageTypeRequest)
 }
 
 // ============================================================================
@@ -101,25 +97,25 @@ func NewMCPRequestEvent(transport string) *MCPEvent {
 // ============================================================================
 
 // WithRequestID sets the request ID.
-func (e *MCPEvent) WithRequestID(id string) *MCPEvent {
+func (e *MetaContext) WithRequestID(id string) *MetaContext {
 	e.RequestID = id
 	return e
 }
 
 // WithSessionID sets the session ID.
-func (e *MCPEvent) WithSessionID(id string) *MCPEvent {
+func (e *MetaContext) WithSessionID(id string) *MetaContext {
 	e.SessionID = id
 	return e
 }
 
 // WithServerID sets the server ID.
-func (e *MCPEvent) WithServerID(id string) *MCPEvent {
+func (e *MetaContext) WithServerID(id string) *MetaContext {
 	e.ServerID = id
 	return e
 }
 
-// WithToolRequest attaches name, originalName and args on ToolCall of this MCPEvent.
-func (e *MCPEvent) WithToolRequest(name, originalName string, args json.RawMessage) *MCPEvent {
+// WithToolRequest attaches name, originalName and args on ToolCall of this LogEntry.
+func (e *LogEntry) WithToolRequest(name, originalName string, args json.RawMessage) *LogEntry {
 	if e.ToolCall == nil {
 		e.ToolCall = &ToolCallLog{}
 	}
@@ -129,8 +125,8 @@ func (e *MCPEvent) WithToolRequest(name, originalName string, args json.RawMessa
 	return e
 }
 
-// WithToolResult attaches provided result and isError status on ToolCall of this MCPEvent.
-func (e *MCPEvent) WithToolResult(result json.RawMessage, isError bool) *MCPEvent {
+// WithToolResult attaches provided result and isError status on ToolCall of this LogEntry.
+func (e *LogEntry) WithToolResult(result json.RawMessage, isError bool) *LogEntry {
 	if e.ToolCall == nil {
 		e.ToolCall = &ToolCallLog{}
 	}
@@ -144,11 +140,21 @@ func (e *MCPEvent) WithToolResult(result json.RawMessage, isError bool) *MCPEven
 // ============================================================================
 
 // GetBaseEvent returns the BaseMcpEvent.
-func (e *MCPEvent) GetBaseEvent() BaseMcpEvent {
+func (e *MetaContext) GetBaseEvent() BaseMcpEvent {
+	return e.BaseMcpEvent
+}
+
+// GetBaseEvent returns the BaseMcpEvent.
+func (e *LogEntry) GetBaseEvent() BaseMcpEvent {
 	return e.BaseMcpEvent
 }
 
 // SetStatus sets the status code for this event.
-func (e *MCPEvent) SetStatus(status int) {
+func (e *MetaContext) SetStatus(status int) {
+	e.Status = status
+}
+
+// SetStatus sets the status code for this log entry.
+func (e *LogEntry) SetStatus(status int) {
 	e.Status = status
 }

--- a/internal/common/mcp_event_test.go
+++ b/internal/common/mcp_event_test.go
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/assert"
 )
 
-func hasDefaultValues(event *MCPEvent) bool {
+func hasDefaultValues(event *MetaContext) bool {
 	if event.Timestamp.IsZero() {
 		return false
 	}
@@ -19,10 +19,10 @@ func hasDefaultValues(event *MCPEvent) bool {
 	return is_recent && is_success && has_processing_error_map && has_metadata_map
 }
 
-func TestNewMCPEvent(t *testing.T) {
-	// Given: NewMCPEvent method
-	// When: creating a new event using NewMCPEvent
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+func TestNewMetaContext(t *testing.T) {
+	// Given: NewMetaContext method
+	// When: creating a new event using NewMetaContext
+	event := NewMetaContext("test", DirectionSystem, MessageTypeSystem)
 
 	// Then: the created event is as expected
 	assert.Assert(t, event.Transport == "test")
@@ -31,10 +31,10 @@ func TestNewMCPEvent(t *testing.T) {
 	assert.Assert(t, hasDefaultValues(event))
 }
 
-func TestNewMCPRequestEvent(t *testing.T) {
-	// Given: NewMCPEvent method
-	// When: creating a new event using NewMCPEvent
-	event := NewMCPRequestEvent("test")
+func TestNewRequestMetaContext(t *testing.T) {
+	// Given: NewRequestMetaContext method
+	// When: creating a new event using NewRequestMetaContext
+	event := NewRequestMetaContext("test")
 
 	// Then: the created event is as expected
 	assert.Assert(t, event.Transport == "test")
@@ -44,50 +44,50 @@ func TestNewMCPRequestEvent(t *testing.T) {
 }
 
 func TestWithRequestID(t *testing.T) {
-	// Given: a MCPEvent and a requestID
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a MetaContext and a requestID
+	event := NewMetaContext("test", DirectionSystem, MessageTypeSystem)
 	event.RequestID = "old_id"
 	requestID := "test_req_id"
 
 	// When: calling WithRequestID
-	new_event := event.WithRequestID(requestID)
+	newEvent := event.WithRequestID(requestID)
 
 	// Then:
-	assert.Equal(t, new_event, event)                  // the returned event is the same
+	assert.Equal(t, newEvent, event)                   // the returned event is the same
 	assert.Assert(t, event.RequestID == "test_req_id") // the request ID was set
 }
 
 func TestWithSessionID(t *testing.T) {
-	// Given: a MCPEvent and a sessionID
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a MetaContext and a sessionID
+	event := NewMetaContext("test", DirectionSystem, MessageTypeSystem)
 	event.SessionID = "old_session_id"
 	sessionID := "test_session_id"
 
 	// When: calling WithSessionID
-	new_event := event.WithSessionID(sessionID)
+	newEvent := event.WithSessionID(sessionID)
 
 	// Then:
-	assert.Equal(t, new_event, event)                      // the returned event is the same
+	assert.Equal(t, newEvent, event)                       // the returned event is the same
 	assert.Assert(t, event.SessionID == "test_session_id") // the request ID was set
 }
 
 func TestWithServerID(t *testing.T) {
-	// Given: a MCPEvent and a serverID
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a MetaContext and a serverID
+	event := NewMetaContext("test", DirectionSystem, MessageTypeSystem)
 	event.ServerID = "old_server_id"
 	serverID := "test_server_id"
 
 	// When: calling WithServerID
-	new_event := event.WithServerID(serverID)
+	newEvent := event.WithServerID(serverID)
 
 	// Then:
-	assert.Equal(t, new_event, event)                    // the returned event is the same
+	assert.Equal(t, newEvent, event)                     // the returned event is the same
 	assert.Assert(t, event.ServerID == "test_server_id") // the server ID was set
 }
 
 func TestGetBaseEvent(t *testing.T) {
-	// Given: a MCPEvent with a request ID
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a MetaContext with a request ID
+	event := NewMetaContext("test", DirectionSystem, MessageTypeSystem)
 	event.RequestID = "req-123"
 
 	// When: calling GetBaseEvent
@@ -98,8 +98,8 @@ func TestGetBaseEvent(t *testing.T) {
 }
 
 func TestSetStatus(t *testing.T) {
-	// Given: a MCPEvent
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a MetaContext
+	event := NewMetaContext("test", DirectionSystem, MessageTypeSystem)
 
 	// When: setting a status code
 	event.SetStatus(204)
@@ -109,14 +109,14 @@ func TestSetStatus(t *testing.T) {
 }
 
 func TestWithToolRequest(t *testing.T) {
-	// Given: an event without ToolCall.
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a log entry without ToolCall.
+	event := &LogEntry{}
 	args := json.RawMessage(`{"a":1}`)
 
 	// When: attaching tool request data.
 	updated := event.WithToolRequest("tool-a", "original-tool-a", args)
 
-	// Then: event pointer is preserved and fields are set.
+	// Then: log entry pointer is preserved and fields are set.
 	assert.Assert(t, updated == event)
 	assert.Assert(t, event.ToolCall != nil)
 	assert.Equal(t, event.ToolCall.Name, "tool-a")
@@ -125,8 +125,8 @@ func TestWithToolRequest(t *testing.T) {
 }
 
 func TestWithToolRequest_PreservesExistingResultFields(t *testing.T) {
-	// Given: an event with existing result state.
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a log entry with existing result state.
+	event := &LogEntry{}
 	event.ToolCall = &ToolCallLog{
 		Result:  json.RawMessage(`{"ok":true}`),
 		IsError: true,
@@ -144,14 +144,14 @@ func TestWithToolRequest_PreservesExistingResultFields(t *testing.T) {
 }
 
 func TestWithToolResult(t *testing.T) {
-	// Given: an event without ToolCall.
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a log entry without ToolCall.
+	event := &LogEntry{}
 	result := json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)
 
 	// When: attaching tool result data.
 	updated := event.WithToolResult(result, true)
 
-	// Then: event pointer is preserved and fields are set.
+	// Then: log entry pointer is preserved and fields are set.
 	assert.Assert(t, updated == event)
 	assert.Assert(t, event.ToolCall != nil)
 	assert.Equal(t, string(event.ToolCall.Result), `{"content":[{"type":"text","text":"ok"}]}`)
@@ -159,8 +159,8 @@ func TestWithToolResult(t *testing.T) {
 }
 
 func TestWithToolResult_PreservesExistingRequestFields(t *testing.T) {
-	// Given: an event with existing request state.
-	event := NewMCPEvent("test", DirectionSystem, MessageTypeSystem)
+	// Given: a log entry with existing request state.
+	event := &LogEntry{}
 	event.ToolCall = &ToolCallLog{
 		Name:         "tool-c",
 		OriginalName: "orig-tool-c",

--- a/internal/common/mcp_models_test.go
+++ b/internal/common/mcp_models_test.go
@@ -174,7 +174,7 @@ func TestGetBaseEvent_Works(t *testing.T) {
 	baseMcpEvent := BaseMcpEvent{
 		Transport: "my-test-transport",
 	}
-	mcpEvents := []MCPEvent{{BaseMcpEvent: baseMcpEvent}}
+	mcpEvents := []MetaContext{{BaseMcpEvent: baseMcpEvent}}
 
 	for _, event := range mcpEvents {
 		// When: calling IsRequest and IsResponse.
@@ -187,7 +187,7 @@ func TestGetBaseEvent_Works(t *testing.T) {
 
 func TestSetStatus_Works(t *testing.T) {
 	// Given: some MCP Events.
-	mcpEvents := []MCPEvent{{}}
+	mcpEvents := []MetaContext{{}}
 
 	for _, event := range mcpEvents {
 		// When: calling IsRequest and IsResponse.

--- a/internal/logging/common_logger.go
+++ b/internal/logging/common_logger.go
@@ -95,6 +95,6 @@ func (l *Logger) GetLogPath() string {
 }
 
 // LogMcpEvent logs the provided stdio/http MCP event.
-func (l *Logger) LogMcpEvent(event *common.MCPEvent) error {
+func (l *Logger) LogMcpEvent(event *common.LogEntry) error {
 	return l.LogEntry(event)
 }

--- a/internal/logging/common_logger_test.go
+++ b/internal/logging/common_logger_test.go
@@ -56,7 +56,7 @@ func TestLogMcpEvent(t *testing.T) {
 	}
 
 	baseMcpEvent := getBaseMcpEvent()
-	mcpEvent := common.MCPEvent{
+	mcpEvent := common.LogEntry{
 		BaseMcpEvent: baseMcpEvent,
 		Routing: common.RoutingContext{
 			DownstreamCommand: command,
@@ -83,7 +83,7 @@ func TestLogMcpEvent(t *testing.T) {
 	}
 
 	// Parse the log line as JSON.
-	var logEntry common.MCPEvent
+	var logEntry common.LogEntry
 	err = json.Unmarshal(logContent, &logEntry)
 	if err != nil {
 		t.Fatalf("Failed to parse log entry: %v", err)

--- a/internal/logging/log_reader.go
+++ b/internal/logging/log_reader.go
@@ -38,7 +38,7 @@ var ErrNoLogEntries = errors.New("no log entries found")
 
 // AnnotatedLogEntry wraps a generic MCP event with contextual metadata used for display.
 type AnnotatedLogEntry struct {
-	Event      common.MCPEvent
+	Event      common.LogEntry
 	SourceFile string
 }
 
@@ -171,7 +171,7 @@ func FormatDisplayLine(entry *AnnotatedLogEntry) string {
 // readLogFile reads and parses a JSONL log file, returning all valid entries.
 // Returns empty slice (not error) if file doesn't exist. Skips malformed lines.
 // Supports log lines up to 10MB.
-func readLogFile(path string) ([]common.MCPEvent, error) {
+func readLogFile(path string) ([]common.LogEntry, error) {
 	cleanPath := filepath.Clean(path)
 	file, err := os.Open(cleanPath)
 	if err != nil {
@@ -182,7 +182,7 @@ func readLogFile(path string) ([]common.MCPEvent, error) {
 	}
 	defer func() { _ = file.Close() }()
 
-	var entries []common.MCPEvent
+	var entries []common.LogEntry
 
 	scanner := bufio.NewScanner(file)
 	buf := make([]byte, 0, 64*1024)
@@ -195,7 +195,7 @@ func readLogFile(path string) ([]common.MCPEvent, error) {
 		}
 
 		// Unmarshal to appropriate type based on transport.
-		var event common.MCPEvent
+		var event common.LogEntry
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			continue
 		}

--- a/internal/logging/log_reader_test.go
+++ b/internal/logging/log_reader_test.go
@@ -25,7 +25,7 @@ func TestLoadRecentLogEntriesOrdersByTimestamp(t *testing.T) {
 		os.Setenv("CENTIAN_LOG_DIR", original)
 	}()
 
-	event1 := common.MCPEvent{
+	event1 := common.LogEntry{
 		BaseMcpEvent: common.BaseMcpEvent{
 			Timestamp:        time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
 			Transport:        "stdio",
@@ -40,7 +40,7 @@ func TestLoadRecentLogEntriesOrdersByTimestamp(t *testing.T) {
 			Args:              []string{"pkg"},
 		},
 	}
-	event2 := common.MCPEvent{
+	event2 := common.LogEntry{
 		BaseMcpEvent: common.BaseMcpEvent{
 			Timestamp:        time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC),
 			Transport:        "stdio",
@@ -55,8 +55,8 @@ func TestLoadRecentLogEntriesOrdersByTimestamp(t *testing.T) {
 			Args:              []string{"pkg"},
 		},
 	}
-	writeLogFile(t, tempDir, "requests_2025-01-01.jsonl", []common.MCPEvent{event1})
-	writeLogFile(t, tempDir, "requests_2025-01-02.jsonl", []common.MCPEvent{event2})
+	writeLogFile(t, tempDir, "requests_2025-01-01.jsonl", []common.LogEntry{event1})
+	writeLogFile(t, tempDir, "requests_2025-01-02.jsonl", []common.LogEntry{event2})
 
 	// When: loading all recent log entries with no limit.
 	entries, err := LoadRecentLogEntries(0)
@@ -87,7 +87,7 @@ func TestLoadRecentLogEntriesLimit(t *testing.T) {
 		os.Setenv("CENTIAN_LOG_DIR", original)
 	}()
 
-	event1 := common.MCPEvent{
+	event1 := common.LogEntry{
 		BaseMcpEvent: common.BaseMcpEvent{
 			Timestamp:        time.Date(2025, 1, 3, 12, 0, 0, 0, time.UTC),
 			Transport:        "stdio",
@@ -101,7 +101,7 @@ func TestLoadRecentLogEntriesLimit(t *testing.T) {
 			DownstreamCommand: "test",
 		},
 	}
-	event2 := common.MCPEvent{
+	event2 := common.LogEntry{
 		BaseMcpEvent: common.BaseMcpEvent{
 			Timestamp:        time.Date(2025, 1, 4, 12, 0, 0, 0, time.UTC),
 			Transport:        "stdio",
@@ -115,7 +115,7 @@ func TestLoadRecentLogEntriesLimit(t *testing.T) {
 			DownstreamCommand: "npx",
 		},
 	}
-	writeLogFile(t, tempDir, "requests_2025-01-03.jsonl", []common.MCPEvent{
+	writeLogFile(t, tempDir, "requests_2025-01-03.jsonl", []common.LogEntry{
 		event1,
 		event2,
 	})
@@ -163,7 +163,7 @@ func TestLoadRecentLogEntriesMissingDir(t *testing.T) {
 
 func TestFormatDisplayLine(t *testing.T) {
 	// Given: an annotated log entry with session ID and command details.
-	event := common.MCPEvent{
+	event := common.LogEntry{
 		BaseMcpEvent: common.BaseMcpEvent{
 			Timestamp:        time.Date(2025, 1, 1, 15, 4, 5, 0, time.UTC),
 			Transport:        "stdio",
@@ -195,7 +195,7 @@ func TestFormatDisplayLine(t *testing.T) {
 	}
 }
 
-func writeLogFile(t *testing.T, dir, name string, entries []common.MCPEvent) {
+func writeLogFile(t *testing.T, dir, name string, entries []common.LogEntry) {
 	t.Helper()
 
 	path := filepath.Join(dir, name)

--- a/internal/processor/contract_test.go
+++ b/internal/processor/contract_test.go
@@ -1,0 +1,238 @@
+package processor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/T4cceptor/centian/internal/common"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// contractV1Dir is the path to the v1 golden fixtures, relative to this package.
+const contractV1Dir = "../../tests/contracts/v1"
+
+const contractViolationMsg = `
+CONTRACT VIOLATION (v1): The serialized DataContext no longer matches the golden fixture.
+This is a DATA CONTRACT change that affects all external processors (CLI and webhook).
+
+DO NOT update the golden fixture in tests/contracts/v1/ — that would silently break
+processors written against the v1 contract.
+
+If this is a BREAKING change (field removed, renamed, or semantically incompatible):
+  1. Create tests/contracts/v2/ with new golden fixtures
+  2. Bump CurrentDataContextVersion to "2.0"
+  3. Update scaffold templates and docs to reflect the new contract
+
+If this is an ADDITIVE change (new optional field that processors can safely ignore):
+  1. Update both v1 fixtures (existing processors remain compatible)
+  2. Bump CurrentDataContextVersion minor to "1.1"
+`
+
+// contractFixtureTime is a fixed, deterministic timestamp used for fixture generation.
+// Using a zero timestamp would serialize as "0001-01-01T00:00:00Z" which is unclear.
+var contractFixtureTime = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// buildContractInputDataContext returns a representative, fully-populated DataContext
+// used to generate and validate the processor input (proxy → processor) golden fixture.
+// All values are stable and deterministic.
+func buildContractInputDataContext() *DataContext {
+	rawArgs := json.RawMessage(`{"key":"value"}`)
+
+	event := &common.MCPEvent{
+		BaseMcpEvent: common.BaseMcpEvent{
+			Status:      0,
+			Timestamp:   contractFixtureTime,
+			Transport:   "http",
+			RequestID:   "req-contract-v1",
+			Direction:   common.DirectionClientToServer,
+			MessageType: common.MessageTypeRequest,
+			Success:     true,
+			Modified:    false,
+		},
+		Routing: common.RoutingContext{
+			Transport:  common.HTTPTransport,
+			ServerName: "test-server",
+		},
+	}
+
+	request := &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "test_tool",
+			Arguments: rawArgs,
+		},
+	}
+
+	return &DataContext{
+		Version: CurrentDataContextVersion,
+		Event:   event,
+		Payload: &PayloadPart{
+			Request:         request,
+			OriginalRequest: request,
+		},
+		Routing: &RoutingPart{
+			ServerName:         "test-server",
+			ToolName:           "test_tool",
+			OriginalServerName: "test-server",
+			OriginalToolname:   "test_tool",
+		},
+		Auth: &common.AuthContext{
+			Authenticated: true,
+			PrincipalID:   "test-user",
+			PrincipalType: "api_key",
+		},
+	}
+}
+
+// buildContractOutputJSON returns the JSON representation of a representative processor
+// output (processor → proxy direction). Uses a plain map to avoid MCP SDK type uncertainties.
+func buildContractOutputJSON() ([]byte, error) {
+	output := map[string]interface{}{
+		"version": CurrentDataContextVersion,
+		"payload": map[string]interface{}{
+			"result": map[string]interface{}{
+				"content": []interface{}{
+					map[string]interface{}{
+						"type": "text",
+						"text": "processed result",
+					},
+				},
+				"isError": false,
+			},
+		},
+	}
+	return json.Marshal(output)
+}
+
+// TestGenerateContractFixtures generates the golden fixture files from the current
+// DataContext serialisation. Run this explicitly when intentionally bumping the contract version.
+//
+//	go test ./internal/processor/ -run TestGenerateContractFixtures
+//
+// Commit the generated files under tests/contracts/v1/ to lock the contract.
+func TestGenerateContractFixtures(t *testing.T) {
+	if err := os.MkdirAll(contractV1Dir, 0o755); err != nil {
+		t.Fatalf("Failed to create fixture directory: %v", err)
+	}
+
+	// Generate processor_input.json (proxy → processor direction, via DTO)
+	inputCtx := buildContractInputDataContext()
+	inputBytes, err := marshalProcessorInput(inputCtx)
+	if err != nil {
+		t.Fatalf("Failed to marshal input DataContext: %v", err)
+	}
+	writeFixtureFile(t, filepath.Join(contractV1Dir, "processor_input.json"), inputBytes)
+
+	// Generate processor_output.json (processor → proxy direction)
+	outputBytes, err := buildContractOutputJSON()
+	if err != nil {
+		t.Fatalf("Failed to build output JSON: %v", err)
+	}
+	writeFixtureFile(t, filepath.Join(contractV1Dir, "processor_output.json"), outputBytes)
+
+	t.Log("Golden fixtures generated — commit tests/contracts/v1/ to lock the contract.")
+}
+
+func writeFixtureFile(t *testing.T, path string, raw []byte) {
+	t.Helper()
+	pretty, err := prettyFormatJSON(raw)
+	if err != nil {
+		t.Fatalf("Failed to format fixture JSON: %v", err)
+	}
+	if err := os.WriteFile(path, pretty, 0o644); err != nil {
+		t.Fatalf("Failed to write fixture %s: %v", path, err)
+	}
+	t.Logf("Wrote %s", path)
+}
+
+// TestProcessorInputContractV1 validates that the current DataContext serialisation
+// (proxy → processor direction) has not drifted from the v1 golden fixture.
+//
+// A failure here is a DATA CONTRACT VIOLATION — not a test configuration issue.
+// Read the error message for guidance on how to proceed.
+func TestProcessorInputContractV1(t *testing.T) {
+	// Given: a representative DataContext with all fields populated
+	inputCtx := buildContractInputDataContext()
+
+	// When: serialising as the proxy would before sending to a processor
+	serialized, err := marshalProcessorInput(inputCtx)
+	if err != nil {
+		t.Fatalf("Failed to serialize DataContext: %v", err)
+	}
+
+	// Then: the result must match the golden fixture exactly
+	fixturePath := filepath.Join(contractV1Dir, "processor_input.json")
+	golden, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf(
+			"Golden fixture not found at %s\nRun: go test ./internal/processor/ -run TestGenerateContractFixtures",
+			fixturePath,
+		)
+	}
+
+	if !jsonDeepEqual(t, serialized, golden) {
+		pretty, _ := prettyFormatJSON(serialized)
+		t.Fatalf("%s\nGolden (expected):\n%s\n\nActual (got):\n%s",
+			contractViolationMsg, string(golden), string(pretty))
+	}
+}
+
+// TestProcessorOutputContractV1 validates that the proxy can successfully parse the v1
+// golden output fixture (processor → proxy direction) without errors, and that the
+// unmarshalled DataContext exposes the expected top-level fields.
+//
+// A failure here means the proxy's DataContext no longer understands v1 processor output.
+func TestProcessorOutputContractV1(t *testing.T) {
+	// Given: the v1 golden output fixture
+	fixturePath := filepath.Join(contractV1Dir, "processor_output.json")
+	golden, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf(
+			"Golden fixture not found at %s\nRun: go test ./internal/processor/ -run TestGenerateContractFixtures",
+			fixturePath,
+		)
+	}
+
+	// When: parsing as the proxy would after receiving output from a processor
+	output, err := unmarshalProcessorOutput(golden)
+	if err != nil {
+		t.Fatalf("%s\nProxy failed to parse v1 output fixture: %v", contractViolationMsg, err)
+	}
+
+	// Then: key fields must be accessible
+	if output.Version != CurrentDataContextVersion {
+		t.Errorf("Expected version %q in parsed output, got %q", CurrentDataContextVersion, output.Version)
+	}
+	if output.Payload == nil {
+		t.Fatal("Expected non-nil payload in parsed output fixture")
+	}
+	if output.Payload.Result == nil {
+		t.Fatal("Expected non-nil result in parsed output payload")
+	}
+}
+
+// jsonDeepEqual compares two JSON byte slices for structural equality.
+// Field insertion order is irrelevant — only the logical structure matters.
+func jsonDeepEqual(t *testing.T, a, b []byte) bool {
+	t.Helper()
+	var aVal, bVal interface{}
+	if err := json.Unmarshal(a, &aVal); err != nil {
+		t.Fatalf("Failed to unmarshal actual JSON for comparison: %v", err)
+	}
+	if err := json.Unmarshal(b, &bVal); err != nil {
+		t.Fatalf("Failed to unmarshal golden JSON for comparison: %v", err)
+	}
+	return reflect.DeepEqual(aVal, bVal)
+}
+
+// prettyFormatJSON formats a JSON byte slice with consistent indentation.
+func prettyFormatJSON(raw []byte) ([]byte, error) {
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(v, "", "  ")
+}

--- a/internal/processor/contract_test.go
+++ b/internal/processor/contract_test.go
@@ -42,7 +42,7 @@ var contractFixtureTime = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 func buildContractInputDataContext() *DataContext {
 	rawArgs := json.RawMessage(`{"key":"value"}`)
 
-	event := &common.MCPEvent{
+	event := &common.MetaContext{
 		BaseMcpEvent: common.BaseMcpEvent{
 			Status:      0,
 			Timestamp:   contractFixtureTime,
@@ -52,10 +52,6 @@ func buildContractInputDataContext() *DataContext {
 			MessageType: common.MessageTypeRequest,
 			Success:     true,
 			Modified:    false,
-		},
-		Routing: common.RoutingContext{
-			Transport:  common.HTTPTransport,
-			ServerName: "test-server",
 		},
 	}
 

--- a/internal/processor/data_context_codec.go
+++ b/internal/processor/data_context_codec.go
@@ -11,7 +11,7 @@ import (
 
 type processorInputDTO struct {
 	Version string              `json:"version,omitempty"`
-	Event   *common.MCPEvent    `json:"event,omitempty"`
+	Event   *common.MetaContext `json:"event,omitempty"`
 	Payload *payloadPartDTO     `json:"payload,omitempty"`
 	Routing *RoutingPart        `json:"routing,omitempty"`
 	Auth    *common.AuthContext `json:"auth,omitempty"`

--- a/internal/processor/processor_context.go
+++ b/internal/processor/processor_context.go
@@ -16,7 +16,7 @@ type DataContext struct {
 	Version string `json:"version"` // "1.0" - for evolution
 
 	// Parts - only populated based on processor config
-	Event   *common.MCPEvent    `json:"event,omitempty"`   // Contains event metadata
+	Event   *common.MetaContext `json:"event,omitempty"`   // Contains event metadata
 	Payload *PayloadPart        `json:"payload,omitempty"` // Payload of the request and result
 	Routing *RoutingPart        `json:"routing,omitempty"`
 	Auth    *common.AuthContext `json:"auth,omitempty"` // Auth identity and principal context

--- a/internal/processor/processor_context.go
+++ b/internal/processor/processor_context.go
@@ -5,6 +5,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// CurrentDataContextVersion is the data contract version sent to processors.
+// Follows major.minor semantics: a major bump is breaking, a minor bump is additive
+// and backward-compatible (processors that ignore unknown fields remain functional).
+const CurrentDataContextVersion = "1.0"
+
 // DataContext is passed to processors as JSON.
 // Holds all relevant information of a CallContext for processors to access and modify.
 type DataContext struct {

--- a/internal/processor/scaffold.go
+++ b/internal/processor/scaffold.go
@@ -552,6 +552,11 @@ func writeTestInput(path string) error {
     "tool_name": "test_tool",
     "original_server_name": "test",
     "original_tool_name": "test_tool"
+  },
+  "auth": {
+    "authenticated": true,
+    "principal_id": "test-user",
+    "principal_type": "api_key"
   }
 }
 `
@@ -773,21 +778,65 @@ class RoutingPart:
 
 
 @dataclass
+class AuthContext:
+    authenticated: bool = False
+    principal_id: str = ""
+    principal_type: str = ""
+    gateway: str = ""
+    auth_header: str = ""
+    internal_session_id: str = ""
+    transport_session_id: str = ""
+    credential_fingerprint: str = ""
+    key_id: str = ""
+
+    @staticmethod
+    def from_dict(data: Optional[Dict[str, Any]]) -> "AuthContext":
+        source = data or {}
+        return AuthContext(
+            authenticated=bool(source.get("authenticated", False)),
+            principal_id=source.get("principal_id", ""),
+            principal_type=source.get("principal_type", ""),
+            gateway=source.get("gateway", ""),
+            auth_header=source.get("auth_header", ""),
+            internal_session_id=source.get("internal_session_id", ""),
+            transport_session_id=source.get("transport_session_id", ""),
+            credential_fingerprint=source.get("credential_fingerprint", ""),
+            key_id=source.get("key_id", ""),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return compact_dict({
+            "authenticated": True if self.authenticated else None,
+            "principal_id": self.principal_id or None,
+            "principal_type": self.principal_type or None,
+            "gateway": self.gateway or None,
+            "auth_header": self.auth_header or None,
+            "internal_session_id": self.internal_session_id or None,
+            "transport_session_id": self.transport_session_id or None,
+            "credential_fingerprint": self.credential_fingerprint or None,
+            "key_id": self.key_id or None,
+        })
+
+
+@dataclass
 class DataContext:
     version: str = ""
     event: Optional[Dict[str, Any]] = None
     payload: Optional[PayloadPart] = None
     routing: Optional[RoutingPart] = None
+    auth: Optional[AuthContext] = None
 
     @staticmethod
     def from_dict(data: Dict[str, Any]) -> "DataContext":
         payload_source = data.get("payload")
         routing_source = data.get("routing")
+        auth_source = data.get("auth")
         return DataContext(
             version=data.get("version", ""),
             event=data.get("event"),
             payload=PayloadPart.from_dict(payload_source) if isinstance(payload_source, dict) else None,
             routing=RoutingPart.from_dict(routing_source) if isinstance(routing_source, dict) else None,
+            auth=AuthContext.from_dict(auth_source) if isinstance(auth_source, dict) else None,
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -796,6 +845,7 @@ class DataContext:
             "event": self.event,
             "payload": self.payload.to_dict() if self.payload else None,
             "routing": self.routing.to_dict() if self.routing else None,
+            "auth": self.auth.to_dict() if self.auth else None,
         })
 
 
@@ -911,11 +961,24 @@ interface RoutingPart {
   original_tool_name?: string;
 }
 
+interface AuthContext {
+  authenticated?: boolean;
+  principal_id?: string;
+  principal_type?: string;
+  gateway?: string;
+  auth_header?: string;
+  internal_session_id?: string;
+  transport_session_id?: string;
+  credential_fingerprint?: string;
+  key_id?: string;
+}
+
 interface DataContext {
   version?: string;
   event?: Record<string, unknown>;
   payload?: PayloadPart;
   routing?: RoutingPart;
+  auth?: AuthContext;
 }
 
 function processContext(ctx: DataContext): DataContext {

--- a/internal/processor/scaffold.go
+++ b/internal/processor/scaffold.go
@@ -535,8 +535,7 @@ func writeTestInput(path string) error {
     "direction": "[CLIENT -> SERVER]",
     "message_type": "request",
     "success": true,
-    "modified": false,
-    "routing": {}
+    "modified": false
   },
   "payload": {
     "request": {

--- a/internal/processor/scaffold.go
+++ b/internal/processor/scaffold.go
@@ -319,11 +319,6 @@ func pythonLogic(procType scaffoldType) string {
     tool_name = (params.name or "") if params else ""
 
     if "delete" in tool_name.lower():
-        event = ctx.event or {}
-        event["status"] = 403
-        event["error"] = "Delete operations not allowed"
-        event["success"] = False
-        ctx.event = event
         payload.result = CallToolResult(
             content=[{"type": "text", "text": "Delete operations not allowed"}],
             is_error=True,
@@ -363,13 +358,14 @@ func pythonLogic(procType scaffoldType) string {
         f.write(json.dumps(log_entry) + "\n")`
 	case typeCustom:
 		return `    # TODO: Add your custom logic here
-    # Example:
+    # Example: set a result to block the request
     # if some_condition:
-    #     event = ctx.event or {}
-    #     event["status"] = 403
-    #     event["error"] = "Condition failed"
-    #     event["success"] = False
-    #     ctx.event = event`
+    #     payload = ctx.payload or PayloadPart()
+    #     payload.result = CallToolResult(
+    #         content=[{"type": "text", "text": "Blocked by custom policy"}],
+    #         is_error=True,
+    #     )
+    #     ctx.payload = payload`
 	default:
 		return ""
 	}
@@ -387,12 +383,6 @@ func javascriptLogic(procType scaffoldType) string {
   const toolName = (params.name || "");
 
   if (toolName.toLowerCase().includes("delete")) {
-    ctx.event = {
-      ...(ctx.event || {}),
-      status: 403,
-      error: "Delete operations not allowed",
-      success: false
-    };
     payload.result = {
       content: [{ type: "text", text: "Delete operations not allowed" }],
       isError: true
@@ -451,12 +441,6 @@ func typescriptLogic(procType scaffoldType) string {
   const toolName = (params.name || "");
 
   if (toolName.toLowerCase().includes("delete")) {
-    ctx.event = {
-      ...(ctx.event || {}),
-      status: 403,
-      error: "Delete operations not allowed",
-      success: false
-    };
     payload.result = {
       content: [{ type: "text", text: "Delete operations not allowed" }],
       isError: true
@@ -512,12 +496,7 @@ func bashLogic(procType scaffoldType) string {
 TOOL_NAME=$(echo "$CTX" | jq -r '.payload.request.Params.name // empty')
 if echo "$TOOL_NAME" | grep -iq "delete"; then
   CTX=$(echo "$CTX" | jq '
-    .event = ((.event // {}) + {
-      "status": 403,
-      "error": "Delete operations not allowed",
-      "success": false
-    })
-    | .payload = (.payload // {})
+    .payload = (.payload // {})
     | .payload.result = {
       "content": [{"type": "text", "text": "Delete operations not allowed"}],
       "isError": true
@@ -549,10 +528,15 @@ func writeTestInput(path string) error {
 	const testPayload = `{
   "version": "1.0",
   "event": {
-    "status": 200,
-    "success": true,
+    "status": 0,
+    "timestamp": "2026-01-01T00:00:00Z",
+    "transport": "http",
+    "request_id": "",
+    "direction": "[CLIENT -> SERVER]",
     "message_type": "request",
-    "direction": "CLIENT_TO_SERVER"
+    "success": true,
+    "modified": false,
+    "routing": {}
   },
   "payload": {
     "request": {

--- a/internal/processor/scaffold_test.go
+++ b/internal/processor/scaffold_test.go
@@ -402,6 +402,10 @@ func TestWriteTestInput(t *testing.T) {
 	params, ok := request["Params"].(map[string]any)
 	assert.Assert(t, ok)
 	assert.Equal(t, params["name"], "test_tool")
+
+	auth, ok := input["auth"].(map[string]any)
+	assert.Assert(t, ok)
+	assert.Equal(t, auth["principal_type"], "api_key")
 }
 func TestAddProcessorToConfig(t *testing.T) {
 	// Given: a temp config and processor details

--- a/internal/proxy/call_context.go
+++ b/internal/proxy/call_context.go
@@ -29,8 +29,9 @@ type CallContext interface {
 	GetOriginalResult() *mcp.CallToolResult // Returns the initial CallToolResult first set, can be nil if request was not sent yet OR resulted in error
 	SetResult(*mcp.CallToolResult)          // Sets the result for this call context
 
-	GetEventInfo() *common.MCPEvent // Returns the attached MCPEvent
-	SetEventInfo(*common.MCPEvent)  // Sets the provided MCPEvent
+	GetMetaContext() *common.MetaContext // Returns the attached processor metadata
+	SetMetaContext(*common.MetaContext)  // Sets the provided processor metadata
+	ToLogEntry() *common.LogEntry        // Returns the current call state as a log entry
 
 	// Original request (immutable deep clone - for auditing/comparison)
 	GetOriginalServerName() string            // Returns name of the original server

--- a/internal/proxy/forwarded_method_error_test.go
+++ b/internal/proxy/forwarded_method_error_test.go
@@ -91,7 +91,7 @@ func TestToolCallContextSendRequestNormalizesDownstreamMethodWrapper(t *testing.
 				Arguments: []byte(`{"a":1}`),
 			},
 		},
-		event: common.NewMCPRequestEvent("stdio"),
+		meta: common.NewRequestMetaContext("stdio"),
 	}
 
 	err := toolCtx.SendRequest(context.Background())

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -1,9 +1,7 @@
 package proxy
 
 import (
-	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/logging"
@@ -25,8 +23,6 @@ type CallContextHandler interface {
 // LogHandler defines how CallContext is serialized for logging.
 // Different implementations allow different log formats.
 type LogHandler interface {
-	// ToLogEntry creates a loggable representation of the current state
-	ToLogEntry(callCtx CallContext) *common.MCPEvent
 	Log(callCtx CallContext) error
 }
 
@@ -82,18 +78,18 @@ func (h *DefaultPayloadHandler) Apply(callCtx CallContext, result *processor.Dat
 // metadata information to/by a processor.
 type DefaultMetaHandler struct{}
 
-// AttachPart attaches MCPEvent information from CallContext on input ProcessorContext.
+// AttachPart attaches MetaContext information from CallContext on input ProcessorContext.
 func (h *DefaultMetaHandler) AttachPart(callCtx CallContext, input *processor.DataContext) {
-	input.Event = callCtx.GetEventInfo()
+	input.Event = callCtx.GetMetaContext()
 	// TODO: slight issue here: we are attaching a reference to the callCtx
-	// - this can result in processors changing the attached MCPEvent before calling Apply
-	// Better: clone MCPEvent
+	// - this can result in processors changing the attached MetaContext before calling Apply
+	// Better: clone MetaContext
 }
 
 // Apply uses provided result ProcessorContext to modify the CallContext.
 func (h *DefaultMetaHandler) Apply(callCtx CallContext, result *processor.DataContext) error {
 	if result.Event != nil {
-		callCtx.SetEventInfo(result.Event)
+		callCtx.SetMetaContext(result.Event)
 	}
 	return nil
 }
@@ -203,7 +199,7 @@ func (h *DefaultAuthHandler) Apply(_ CallContext, _ *processor.DataContext) erro
 }
 
 // =============================================================================
-// DefaultLogHandler - produces MCPEvent-compatible log entries
+// DefaultLogHandler writes the current call state to the request log.
 // =============================================================================
 
 // DefaultLogHandler provides simple, default functionality for logging CallContext data.
@@ -218,52 +214,7 @@ func NewDefaultLogHandler(logger *logging.Logger) *DefaultLogHandler {
 	}
 }
 
-// Log uses the attached logger and ToLogEntry to log the provided CallContext data.
+// Log uses the attached logger to log the provided CallContext data.
 func (h *DefaultLogHandler) Log(callCtx CallContext) error {
-	return h.logger.LogEntry(h.ToLogEntry(callCtx))
-}
-
-// ToLogEntry transforms the provided CallContext into an MCPEvent struct.
-func (h *DefaultLogHandler) ToLogEntry(callCtx CallContext) *common.MCPEvent {
-	direction := callCtx.GetDirection()
-	msgType := callCtx.GetMessageType()
-	event := &common.MCPEvent{
-		BaseMcpEvent: common.BaseMcpEvent{
-			Timestamp:   time.Now(),
-			Transport:   h.getTransport(callCtx),
-			RequestID:   callCtx.GetRequestID(),
-			SessionID:   callCtx.GetSessionID(),
-			Direction:   direction,
-			MessageType: msgType,
-			Status:      callCtx.GetStatus(),
-			Success:     callCtx.GetStatus() < 400,
-		},
-	}
-
-	// Add routing context
-	if rc := callCtx.GetRoutingContext(); rc != nil {
-		// TODO
-		event.Routing = *rc
-	}
-
-	// Add arguments for request
-	req := callCtx.GetRequest()
-	if req != nil && req.Params != nil {
-		event.WithToolRequest(callCtx.GetToolName(), callCtx.GetOriginalToolName(), req.Params.Arguments)
-	}
-
-	// Add result for response
-	if callCtx.HasResult() {
-		result := callCtx.GetResult()
-		resultJSON, _ := json.Marshal(result)
-		event.WithToolResult(resultJSON, result.IsError)
-	}
-	return event
-}
-
-func (h *DefaultLogHandler) getTransport(callCtx CallContext) string {
-	if rc := callCtx.GetRoutingContext(); rc != nil {
-		return string(rc.Transport)
-	}
-	return "unknown"
+	return h.logger.LogEntry(callCtx.ToLogEntry())
 }

--- a/internal/proxy/handlers_test.go
+++ b/internal/proxy/handlers_test.go
@@ -31,7 +31,7 @@ func newHandlerTestCallContext() *ToolCallContext {
 		request:            req,
 		result:             &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "result-current"}}},
 		originalResult:     &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "result-original"}}},
-		event:              common.NewMCPRequestEvent("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
+		meta:               common.NewRequestMetaContext("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
 		routingContext:     &common.RoutingContext{ServerName: "server-current"},
 		authData: &AuthData{
 			AuthHeaderName: "Authorization",
@@ -119,17 +119,17 @@ func TestDefaultMetaHandlerAttachPartAndApply(t *testing.T) {
 	handler := &DefaultMetaHandler{}
 
 	handler.AttachPart(callCtx, input)
-	assert.Assert(t, input.Event == callCtx.GetEventInfo())
+	assert.Assert(t, input.Event == callCtx.GetMetaContext())
 
-	originalEvent := callCtx.GetEventInfo()
+	originalEvent := callCtx.GetMetaContext()
 	err := handler.Apply(callCtx, &processor.DataContext{})
 	assert.NilError(t, err)
-	assert.Assert(t, callCtx.GetEventInfo() == originalEvent)
+	assert.Assert(t, callCtx.GetMetaContext() == originalEvent)
 
-	newEvent := common.NewMCPRequestEvent("http")
+	newEvent := common.NewRequestMetaContext("http")
 	err = handler.Apply(callCtx, &processor.DataContext{Event: newEvent})
 	assert.NilError(t, err)
-	assert.Assert(t, callCtx.GetEventInfo() == newEvent)
+	assert.Assert(t, callCtx.GetMetaContext() == newEvent)
 }
 
 func TestDefaultRoutingHandlerAttachPart(t *testing.T) {
@@ -222,9 +222,7 @@ func TestDefaultAuthHandlerAttachPartAndApply(t *testing.T) {
 	assert.Equal(t, callCtx.GetAuthData().KeyEntry.ID, "key_1")
 }
 
-func TestDefaultLogHandlerToLogEntry(t *testing.T) {
-	handler := &DefaultLogHandler{}
-
+func TestToolCallContextToLogEntry(t *testing.T) {
 	t.Run("request entry includes routing and tool call arguments", func(t *testing.T) {
 		callCtx := newHandlerTestCallContext()
 		callCtx.result = nil
@@ -233,7 +231,7 @@ func TestDefaultLogHandlerToLogEntry(t *testing.T) {
 		callCtx.SetMessageType(common.MessageTypeRequest)
 		callCtx.SetStatus(200)
 
-		entry := handler.ToLogEntry(callCtx)
+		entry := callCtx.ToLogEntry()
 		assert.Assert(t, entry != nil)
 		assert.Equal(t, entry.Transport, string(common.StdioTransport))
 		assert.Equal(t, entry.Direction, common.DirectionClientToServer)
@@ -259,7 +257,7 @@ func TestDefaultLogHandlerToLogEntry(t *testing.T) {
 		callCtx.SetMessageType(common.MessageTypeResponse)
 		callCtx.SetStatus(500)
 
-		entry := handler.ToLogEntry(callCtx)
+		entry := callCtx.ToLogEntry()
 		assert.Assert(t, entry != nil)
 		assert.Equal(t, entry.Direction, common.DirectionServerToClient)
 		assert.Equal(t, entry.MessageType, common.MessageTypeResponse)
@@ -269,17 +267,6 @@ func TestDefaultLogHandlerToLogEntry(t *testing.T) {
 		assert.Assert(t, entry.ToolCall.IsError)
 		assert.Assert(t, len(entry.ToolCall.Result) > 0)
 	})
-}
-
-func TestDefaultLogHandlerGetTransport(t *testing.T) {
-	handler := &DefaultLogHandler{}
-	callCtx := newHandlerTestCallContext()
-
-	callCtx.routingContext = nil
-	assert.Equal(t, handler.getTransport(callCtx), "unknown")
-
-	callCtx.routingContext = &common.RoutingContext{Transport: common.HTTPTransport}
-	assert.Equal(t, handler.getTransport(callCtx), string(common.HTTPTransport))
 }
 
 func TestDefaultLogHandlerLog(t *testing.T) {

--- a/internal/proxy/proxy_event_processor.go
+++ b/internal/proxy/proxy_event_processor.go
@@ -43,7 +43,7 @@ func NewProcessingController(processorConfigs []*config.ProcessorConfig) (*Proce
 
 // GetInput uses the provided ProcessorConfig and CallContext to create the input map for the processor.
 func GetInput(processorConfig *config.ProcessorConfig, callCtx CallContext) *processor.DataContext {
-	input := &processor.DataContext{}
+	input := &processor.DataContext{Version: processor.CurrentDataContextVersion}
 	for _, part := range processorConfig.GetParts() {
 		handler, ok := callCtx.GetHandler(part) // TODO: we could have a "GetParts"
 		if ok {

--- a/internal/proxy/proxy_event_processor_test.go
+++ b/internal/proxy/proxy_event_processor_test.go
@@ -21,7 +21,7 @@ type mockCallContext struct {
 	originalRequest    *mcp.CallToolRequest
 	result             *mcp.CallToolResult
 	originalResult     *mcp.CallToolResult
-	event              *common.MCPEvent
+	meta               *common.MetaContext
 	routing            *common.RoutingContext
 	authData           *AuthData
 	handlers           map[string]CallContextHandler
@@ -41,7 +41,7 @@ func newMockCallContext() *mockCallContext {
 	return &mockCallContext{
 		request:         req,
 		originalRequest: deepCloneRequest(req),
-		event:           common.NewMCPRequestEvent("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
+		meta:            common.NewRequestMetaContext("stdio").WithRequestID("req-1").WithSessionID("sess-1"),
 		routing:         &common.RoutingContext{ServerName: "server-a", Transport: common.StdioTransport},
 		authData: &AuthData{
 			AuthHeaderName: "Authorization",
@@ -67,9 +67,16 @@ func (m *mockCallContext) SetResult(result *mcp.CallToolResult) {
 	}
 	m.result = result
 }
-func (m *mockCallContext) GetEventInfo() *common.MCPEvent { return m.event }
-func (m *mockCallContext) SetEventInfo(event *common.MCPEvent) {
-	m.event = event
+func (m *mockCallContext) GetMetaContext() *common.MetaContext { return m.meta }
+func (m *mockCallContext) SetMetaContext(meta *common.MetaContext) {
+	m.meta = meta
+}
+func (m *mockCallContext) ToLogEntry() *common.LogEntry {
+	entry := &common.LogEntry{BaseMcpEvent: m.meta.BaseMcpEvent}
+	if m.routing != nil {
+		entry.Routing = *m.routing
+	}
+	return entry
 }
 func (m *mockCallContext) GetOriginalServerName() string { return m.originalServerName }
 func (m *mockCallContext) GetOriginalRequest() *mcp.CallToolRequest {
@@ -95,24 +102,24 @@ func (m *mockCallContext) GetToolName() string {
 	}
 	return m.request.Params.Name
 }
-func (m *mockCallContext) GetStatus() int       { return m.event.Status }
-func (m *mockCallContext) SetStatus(status int) { m.event.Status = status }
-func (m *mockCallContext) GetError() string     { return m.event.Error }
-func (m *mockCallContext) SetError(msg string)  { m.event.Error = msg }
-func (m *mockCallContext) GetRequestID() string { return m.event.RequestID }
-func (m *mockCallContext) GetSessionID() string { return m.event.SessionID }
+func (m *mockCallContext) GetStatus() int       { return m.meta.Status }
+func (m *mockCallContext) SetStatus(status int) { m.meta.Status = status }
+func (m *mockCallContext) GetError() string     { return m.meta.Error }
+func (m *mockCallContext) SetError(msg string)  { m.meta.Error = msg }
+func (m *mockCallContext) GetRequestID() string { return m.meta.RequestID }
+func (m *mockCallContext) GetSessionID() string { return m.meta.SessionID }
 func (m *mockCallContext) GetAuthData() *AuthData {
 	return m.authData
 }
 func (m *mockCallContext) GetDirection() common.McpEventDirection {
-	return m.event.Direction
+	return m.meta.Direction
 }
 func (m *mockCallContext) SetDirection(direction common.McpEventDirection) {
-	m.event.Direction = direction
+	m.meta.Direction = direction
 }
-func (m *mockCallContext) GetMessageType() common.McpMessageType { return m.event.MessageType }
+func (m *mockCallContext) GetMessageType() common.McpMessageType { return m.meta.MessageType }
 func (m *mockCallContext) SetMessageType(msgType common.McpMessageType) {
-	m.event.MessageType = msgType
+	m.meta.MessageType = msgType
 }
 func (m *mockCallContext) GetRoutingContext() *common.RoutingContext { return m.routing }
 func (m *mockCallContext) GetHandler(part string) (CallContextHandler, bool) {
@@ -156,7 +163,6 @@ type mockLogHandler struct {
 	logErr   error
 }
 
-func (m *mockLogHandler) ToLogEntry(callCtx CallContext) *common.MCPEvent { return nil }
 func (m *mockLogHandler) Log(callCtx CallContext) error {
 	m.logCalls++
 	return m.logErr
@@ -221,7 +227,7 @@ func TestGetInput_UsesConfiguredHandlers(t *testing.T) {
 	}
 	metaHandler := &mockHandler{
 		getFn: func(callCtx CallContext, input *processor.DataContext) {
-			input.Event = callCtx.GetEventInfo()
+			input.Event = callCtx.GetMetaContext()
 		},
 	}
 
@@ -304,7 +310,7 @@ func TestApplyResult_AppliesConfiguredHandlers(t *testing.T) {
 	}
 	result := &processor.DataContext{
 		Payload: &processor.PayloadPart{},
-		Event:   common.NewMCPRequestEvent("stdio"),
+		Event:   common.NewRequestMetaContext("stdio"),
 	}
 
 	err := ApplyResult(processorConfig, result, callCtx)

--- a/internal/proxy/tool_call_context.go
+++ b/internal/proxy/tool_call_context.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -27,7 +29,7 @@ type ToolCallContext struct {
 	originalResult *mcp.CallToolResult // unmodified result from downstream
 
 	// State
-	event *common.MCPEvent
+	meta *common.MetaContext
 
 	// Routing context (reuses common.RoutingContext)
 	routingContext *common.RoutingContext
@@ -62,7 +64,7 @@ func NewToolCallContext(
 		transport = conn.GetConfig().GetTransport()
 	}
 
-	event := common.NewMCPRequestEvent(string(transport)).
+	meta := common.NewRequestMetaContext(string(transport)).
 		WithRequestID(getNewUUIDV7()).
 		WithSessionID(upstreamSession.id).
 		WithServerID(proxy.server.ServerID) // nil check was done above
@@ -89,7 +91,7 @@ func NewToolCallContext(
 		originalRequest:    originalRequest, // Immutable clone of the upstream request
 		request:            req,             // Mutable, will be modified by handlers
 		routingContext:     routingCtx,
-		event:              event,
+		meta:               meta,
 		authData:           upstreamSession.authData.Clone(),
 	}
 
@@ -163,14 +165,50 @@ func (c *ToolCallContext) SendRequest(ctx context.Context) error {
 	return nil
 }
 
-// GetEventInfo returns the attached MCPEvent.
-func (c *ToolCallContext) GetEventInfo() *common.MCPEvent {
-	return c.event
+// GetMetaContext returns the attached processor metadata.
+func (c *ToolCallContext) GetMetaContext() *common.MetaContext {
+	return c.meta
 }
 
-// SetEventInfo sets the provided MCPEvent.
-func (c *ToolCallContext) SetEventInfo(event *common.MCPEvent) {
-	c.event = event
+// SetMetaContext sets the provided processor metadata.
+func (c *ToolCallContext) SetMetaContext(meta *common.MetaContext) {
+	c.meta = meta
+}
+
+// ToLogEntry returns the current call state as a structured log entry.
+func (c *ToolCallContext) ToLogEntry() *common.LogEntry {
+	if c.meta == nil {
+		c.meta = common.NewMetaContext(string(common.UnknownTransport), common.DirectionUnknown, common.MessageTypeUnknown)
+	}
+
+	entry := &common.LogEntry{
+		BaseMcpEvent: c.meta.BaseMcpEvent,
+	}
+	entry.Timestamp = time.Now()
+	entry.Success = c.GetStatus() < 400
+
+	if rc := c.GetRoutingContext(); rc != nil {
+		entry.Routing = *rc
+		if rc.Transport != "" {
+			entry.Transport = string(rc.Transport)
+		}
+	}
+	if entry.Transport == "" {
+		entry.Transport = string(common.UnknownTransport)
+	}
+
+	req := c.GetRequest()
+	if req != nil && req.Params != nil {
+		entry.WithToolRequest(c.GetToolName(), c.GetOriginalToolName(), req.Params.Arguments)
+	}
+
+	if c.HasResult() {
+		result := c.GetResult()
+		resultJSON, _ := json.Marshal(result)
+		entry.WithToolResult(resultJSON, result.IsError)
+	}
+
+	return entry
 }
 
 // Result methods
@@ -200,24 +238,24 @@ func (c *ToolCallContext) GetOriginalResult() *mcp.CallToolResult {
 
 // Direction methods
 
-// GetDirection returns MCPEvent.Direction.
+// GetDirection returns MetaContext.Direction.
 func (c *ToolCallContext) GetDirection() common.McpEventDirection {
-	return c.event.Direction
+	return c.meta.Direction
 }
 
-// SetDirection sets MCPEvent.Direction.
+// SetDirection sets MetaContext.Direction.
 func (c *ToolCallContext) SetDirection(d common.McpEventDirection) {
-	c.event.Direction = d
+	c.meta.Direction = d
 }
 
-// GetMessageType returns MCPEvent.MessageType.
+// GetMessageType returns MetaContext.MessageType.
 func (c *ToolCallContext) GetMessageType() common.McpMessageType {
-	return c.event.MessageType
+	return c.meta.MessageType
 }
 
-// SetMessageType sets MCPEvent.MessageType.
+// SetMessageType sets MetaContext.MessageType.
 func (c *ToolCallContext) SetMessageType(t common.McpMessageType) {
-	c.event.MessageType = t
+	c.meta.MessageType = t
 }
 
 // Original request accessors
@@ -275,31 +313,31 @@ func (c *ToolCallContext) GetToolName() string {
 
 // Status and error handling
 
-// GetStatus returns ToolCallContext.MCPEvent.Status.
+// GetStatus returns ToolCallContext.MetaContext.Status.
 func (c *ToolCallContext) GetStatus() int {
-	return c.event.Status
+	return c.meta.Status
 }
 
-// SetStatus sets ToolCallContext.MCPEvent.Status.
+// SetStatus sets ToolCallContext.MetaContext.Status.
 func (c *ToolCallContext) SetStatus(status int) {
-	c.event.Status = status
+	c.meta.Status = status
 }
 
-// GetError returns ToolCallContext.MCPEvent.Error.
+// GetError returns ToolCallContext.MetaContext.Error.
 func (c *ToolCallContext) GetError() string {
-	return c.event.Error
+	return c.meta.Error
 }
 
-// SetError sets the ToolCallContext.MCPEvent.Error.
+// SetError sets the ToolCallContext.MetaContext.Error.
 func (c *ToolCallContext) SetError(msg string) {
-	c.event.Error = msg
+	c.meta.Error = msg
 }
 
 // Session and request identification
 
 // GetRequestID returns the current request ID.
 func (c *ToolCallContext) GetRequestID() string {
-	return c.event.RequestID
+	return c.meta.RequestID
 }
 
 // GetSessionID returns the current session ID.

--- a/internal/proxy/tool_call_context_test.go
+++ b/internal/proxy/tool_call_context_test.go
@@ -15,10 +15,6 @@ import (
 
 type noopLogHandler struct{}
 
-func (l *noopLogHandler) ToLogEntry(_ CallContext) *common.MCPEvent {
-	return nil
-}
-
 func (l *noopLogHandler) Log(_ CallContext) error {
 	return nil
 }
@@ -294,7 +290,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 					Arguments: args,
 				},
 			},
-			event: common.NewMCPRequestEvent("stdio"),
+			meta: common.NewRequestMetaContext("stdio"),
 		}
 	}
 
@@ -309,7 +305,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 			request: &mcp.CallToolRequest{
 				Params: &mcp.CallToolParamsRaw{Name: "tool_name", Arguments: json.RawMessage(`{}`)},
 			},
-			event: common.NewMCPRequestEvent("stdio"),
+			meta: common.NewRequestMetaContext("stdio"),
 		}
 
 		err := toolCtx.SendRequest(context.Background())
@@ -340,7 +336,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 			},
 			routingContext: &common.RoutingContext{ServerName: "srv"},
 			request:        &mcp.CallToolRequest{},
-			event:          common.NewMCPRequestEvent("stdio"),
+			meta:           common.NewRequestMetaContext("stdio"),
 		}
 
 		err := toolCtx.SendRequest(context.Background())
@@ -400,7 +396,7 @@ func TestToolCallContextSendRequest(t *testing.T) {
 }
 
 func TestToolCallContextAccessors(t *testing.T) {
-	event := common.NewMCPRequestEvent("stdio")
+	meta := common.NewRequestMetaContext("stdio")
 	toolCtx := &ToolCallContext{
 		proxy: &CentianEndpoint{
 			name:              "gw",
@@ -421,7 +417,7 @@ func TestToolCallContextAccessors(t *testing.T) {
 			Params: &mcp.CallToolParamsRaw{Name: "orig_tool"},
 		},
 		originalServerName: "orig-srv",
-		event:              event,
+		meta:               meta,
 	}
 
 	// Given: no routing context yet.
@@ -464,14 +460,14 @@ func TestToolCallContextAccessors(t *testing.T) {
 	assert.Equal(t, toolCtx.GetMessageType(), common.MessageTypeResponse)
 
 	// And: event can be replaced.
-	updatedEvent := common.NewMCPRequestEvent("http")
-	toolCtx.SetEventInfo(updatedEvent)
-	assert.Assert(t, toolCtx.GetEventInfo() == updatedEvent)
+	updatedMeta := common.NewRequestMetaContext("http")
+	toolCtx.SetMetaContext(updatedMeta)
+	assert.Assert(t, toolCtx.GetMetaContext() == updatedMeta)
 }
 
 func TestToolCallContextSetResultAndHandlers(t *testing.T) {
 	toolCtx := &ToolCallContext{
-		event: common.NewMCPRequestEvent("stdio"),
+		meta: common.NewRequestMetaContext("stdio"),
 	}
 
 	// Given: first and second results.
@@ -504,7 +500,7 @@ func TestToolCallContextSetResultAndHandlers(t *testing.T) {
 
 func TestToolCallContextSessionAndOriginalAccessors(t *testing.T) {
 	toolCtx := &ToolCallContext{
-		event: common.NewMCPRequestEvent("stdio").WithRequestID("req-1"),
+		meta: common.NewRequestMetaContext("stdio").WithRequestID("req-1"),
 	}
 
 	// Given: nil session and nil original request.

--- a/tests/contracts/v1/processor_input.json
+++ b/tests/contracts/v1/processor_input.json
@@ -1,46 +1,42 @@
 {
-  "version": "1.0",
-  "event": {
-    "status": 0,
-    "timestamp": "2026-01-01T00:00:00Z",
-    "transport": "http",
-    "request_id": "req-contract-v1",
-    "direction": "[CLIENT -> SERVER]",
-    "message_type": "request",
-    "success": true,
-    "modified": false,
-    "routing": {
-      "transport": "http",
-      "server_name": "test-server"
-    }
-  },
-  "payload": {
-    "request": {
-      "Params": {
-        "name": "test_tool",
-        "arguments": {
-          "key": "value"
-        }
-      }
-    },
-    "original_request": {
-      "Params": {
-        "name": "test_tool",
-        "arguments": {
-          "key": "value"
-        }
-      }
-    }
-  },
-  "routing": {
-    "server_name": "test-server",
-    "tool_name": "test_tool",
-    "original_server_name": "test-server",
-    "original_tool_name": "test_tool"
-  },
   "auth": {
     "authenticated": true,
     "principal_id": "test-user",
     "principal_type": "api_key"
-  }
+  },
+  "event": {
+    "direction": "[CLIENT -\u003e SERVER]",
+    "message_type": "request",
+    "modified": false,
+    "request_id": "req-contract-v1",
+    "status": 0,
+    "success": true,
+    "timestamp": "2026-01-01T00:00:00Z",
+    "transport": "http"
+  },
+  "payload": {
+    "original_request": {
+      "Params": {
+        "arguments": {
+          "key": "value"
+        },
+        "name": "test_tool"
+      }
+    },
+    "request": {
+      "Params": {
+        "arguments": {
+          "key": "value"
+        },
+        "name": "test_tool"
+      }
+    }
+  },
+  "routing": {
+    "original_server_name": "test-server",
+    "original_tool_name": "test_tool",
+    "server_name": "test-server",
+    "tool_name": "test_tool"
+  },
+  "version": "1.0"
 }

--- a/tests/contracts/v1/processor_input.json
+++ b/tests/contracts/v1/processor_input.json
@@ -1,0 +1,46 @@
+{
+  "version": "1.0",
+  "event": {
+    "status": 0,
+    "timestamp": "2026-01-01T00:00:00Z",
+    "transport": "http",
+    "request_id": "req-contract-v1",
+    "direction": "[CLIENT -> SERVER]",
+    "message_type": "request",
+    "success": true,
+    "modified": false,
+    "routing": {
+      "transport": "http",
+      "server_name": "test-server"
+    }
+  },
+  "payload": {
+    "request": {
+      "Params": {
+        "name": "test_tool",
+        "arguments": {
+          "key": "value"
+        }
+      }
+    },
+    "original_request": {
+      "Params": {
+        "name": "test_tool",
+        "arguments": {
+          "key": "value"
+        }
+      }
+    }
+  },
+  "routing": {
+    "server_name": "test-server",
+    "tool_name": "test_tool",
+    "original_server_name": "test-server",
+    "original_tool_name": "test_tool"
+  },
+  "auth": {
+    "authenticated": true,
+    "principal_id": "test-user",
+    "principal_type": "api_key"
+  }
+}

--- a/tests/contracts/v1/processor_output.json
+++ b/tests/contracts/v1/processor_output.json
@@ -1,14 +1,14 @@
 {
-  "version": "1.0",
   "payload": {
     "result": {
       "content": [
         {
-          "type": "text",
-          "text": "processed result"
+          "text": "processed result",
+          "type": "text"
         }
       ],
       "isError": false
     }
-  }
+  },
+  "version": "1.0"
 }

--- a/tests/contracts/v1/processor_output.json
+++ b/tests/contracts/v1/processor_output.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "payload": {
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "processed result"
+        }
+      ],
+      "isError": false
+    }
+  }
+}

--- a/tests/integrationtests/processor_test.go
+++ b/tests/integrationtests/processor_test.go
@@ -193,7 +193,7 @@ func requestContext(t *testing.T, toolName string, args map[string]any) *process
 	}
 	return &processor.DataContext{
 		Version: "1.0",
-		Event: &common.MCPEvent{
+		Event: &common.MetaContext{
 			BaseMcpEvent: common.BaseMcpEvent{
 				Status:      200,
 				Success:     true,
@@ -215,7 +215,7 @@ func responseContext(t *testing.T, text string) *processor.DataContext {
 	t.Helper()
 	return &processor.DataContext{
 		Version: "1.0",
-		Event: &common.MCPEvent{
+		Event: &common.MetaContext{
 			BaseMcpEvent: common.BaseMcpEvent{
 				Status:      200,
 				Success:     true,


### PR DESCRIPTION
## Summary

This PR formalizes the processor data contract (the JSON structure exchanged between Centian and external processors) as v1.0 by introducing golden fixture files and contract validation tests. It also updates all documentation and code examples to reflect the current, stable contract format.

## Key Changes

- **Data Contract Formalization**
  - Added `CurrentDataContextVersion = "1.0"` constant in `processor_context.go`
  - Created golden fixture files (`tests/contracts/v1/processor_input.json` and `processor_output.json`) that lock the v1 contract structure
  - Added comprehensive contract validation tests (`TestProcessorInputContractV1`, `TestProcessorOutputContractV1`) that prevent accidental drift
  - Included a `TestGenerateContractFixtures` test for intentional contract bumps

- **Documentation Updates**
  - Updated `docs/processor_development_guide.md` with the complete v1.0 event structure, including all fields (`status`, `timestamp`, `transport`, `request_id`, `direction`, `message_type`, `success`, `modified`, `routing`)
  - Clarified field semantics: `direction` uses `"[CLIENT -> SERVER]"` and `"[SERVER -> CLIENT]"` format; `message_type` is `"request"` or `"response"`
  - Marked `original_request` and `original_result` as read-only
  - Updated all five processor examples (passthrough, validator, transformer, logger, filter) to use the v1.0 contract format
  - Updated shell testing example to validate against `payload.result.isError` instead of HTTP status codes
  - Improved debugging and performance optimization sections with v1.0-aware code

- **Scaffold Template Updates**
  - Updated Python, JavaScript, TypeScript, and Bash scaffold templates to generate v1.0-compliant processor code
  - Removed incorrect event-level status/error manipulation; processors now set `payload.result` to block requests
  - Updated test input fixture in scaffold to match v1.0 structure

- **Contract Violation Safeguards**
  - Added detailed error message (`contractViolationMsg`) that guides developers on how to handle breaking vs. additive changes
  - Implemented `jsonDeepEqual` helper for structural JSON comparison (field order independent)
  - Tests fail fast if the contract drifts, preventing silent incompatibilities with external processors

## Notable Implementation Details

- The contract uses deterministic timestamps (`2026-01-01T00:00:00Z`) in fixtures for reproducibility
- Golden fixtures are committed to the repository; they serve as the source of truth for the v1 contract
- The validation approach is order-independent (JSON structure comparison), allowing flexibility in serialization while maintaining contract integrity
- All processor examples now consistently use `ctx.get("payload")` and `ctx.get("event")` patterns for safe field access
- The contract supports both additive (minor version bump) and breaking (major version bump) changes with clear upgrade paths

https://claude.ai/code/session_01NtPnn7KviLEXA47RuiyauN