### PR TITLE
Added retry mechanism for failing downstream connection

### DIFF
--- a/internal/proxy/downstream_connection_mock_test.go
+++ b/internal/proxy/downstream_connection_mock_test.go
@@ -53,21 +53,45 @@ func (m *MockDownstreamConnection) GetServerName() string {
 
 func (m *MockDownstreamConnection) Connect(ctx context.Context, options *DownstreamConnectOptions) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.ConnectCalls++
 	m.CapturedConnects = append(m.CapturedConnects, cloneConnectOptions(options))
 	m.CapturedConnectAuths = append(m.CapturedConnectAuths, cloneAuthHeaders(options.ForwardedHeaders))
-	if m.ConnectFunc != nil {
-		if err := m.ConnectFunc(ctx, options); err != nil {
+	connectFunc := m.ConnectFunc
+	errToReturn := m.ErrorToReturn
+	m.mu.Unlock()
+
+	if connectFunc != nil {
+		if err := connectFunc(ctx, options); err != nil {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			if authErr, ok := centoauth.IsAuthorizationRequired(err); ok {
+				if authErr.Reason == centoauth.AuthorizationReasonRefreshFailed {
+					m.Status = StatusRefreshFailed
+				} else {
+					m.Status = StatusAuthRequired
+				}
+				return err
+			}
 			m.Status = StatusFailed
 			return err
 		}
 	}
-	if m.ErrorToReturn != nil {
+	if errToReturn != nil {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if authErr, ok := centoauth.IsAuthorizationRequired(errToReturn); ok {
+			if authErr.Reason == centoauth.AuthorizationReasonRefreshFailed {
+				m.Status = StatusRefreshFailed
+			} else {
+				m.Status = StatusAuthRequired
+			}
+			return errToReturn
+		}
 		m.Status = StatusFailed
-		return m.ErrorToReturn
+		return errToReturn
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.Status = StatusConnected
 	return nil
 }

--- a/internal/proxy/proxy_auth_tools.go
+++ b/internal/proxy/proxy_auth_tools.go
@@ -53,6 +53,7 @@ func isProxyToolName(name string) bool {
 }
 
 func (p *CentianEndpoint) testToolsEnabled() bool {
+	// TODO: this method should be moved to the server level -> makes MUCH more sense
 	return p != nil &&
 		p.server != nil &&
 		p.server.Config != nil &&

--- a/internal/proxy/proxy_downstream_pool.go
+++ b/internal/proxy/proxy_downstream_pool.go
@@ -104,17 +104,40 @@ func (p *CentianEndpoint) getOrCreateSessionPoolLocked(session *UpstreamSession)
 func (p *CentianEndpoint) startMissingPoolConnectionsLocked(pool *DownstreamSessionPool, connectOptions *DownstreamConnectOptions) {
 	for serverName, serverConfig := range p.GetActiveMCPServerConfigs() {
 		conn, err := pool.GetConnectionByServerName(serverName)
-		if err != nil || conn.GetStatus().IsFailed() || conn.GetStatus().IsAuthRequired() || conn.GetStatus().IsRefreshFailed() {
+		if err != nil {
 			conn = p.newDownstreamConnection(serverName, serverConfig)
 			pool.SetConnection(serverName, conn)
 		}
-		isConnecting, _ := pool.IsConnecting(serverName)
-		if isConnecting || conn.IsConnected() {
+		if p.shouldSkipPoolConnectStartLocked(pool, serverName, conn) {
 			continue
 		}
-		pool.connecting[serverName] = true
-		go p.connectDownstreamPool(pool.downstreamSessionKey, conn, cloneDownstreamConnectOptions(connectOptions))
+		if conn.GetStatus().IsFailed() || conn.GetStatus().IsDisconnected() {
+			conn = p.newDownstreamConnection(serverName, serverConfig)
+			pool.SetConnection(serverName, conn)
+		}
+		p.launchPoolConnectRetryLocked(pool, serverName, connectOptions)
 	}
+}
+
+// shouldSkipPoolConnectStartLocked reports whether the pool already has an
+// owning connect worker or the current connection is in a state that should not
+// start a new pool connect flow.
+//
+// The pool-level worker state is the authoritative concurrency guard. It stays
+// true across backoff sleeps, while conn.IsConnecting() only describes one
+// concrete connection object being inside Connect() right now.
+func (p *CentianEndpoint) shouldSkipPoolConnectStartLocked(
+	pool *DownstreamSessionPool,
+	serverName string,
+	conn DownstreamConnectionInterface,
+) bool {
+	if pool == nil || conn == nil {
+		return true
+	}
+	if pool.HasActiveConnectWorker(serverName) {
+		return true
+	}
+	return conn.IsConnected() || conn.GetStatus().IsAuthRequired() || conn.GetStatus().IsRefreshFailed()
 }
 
 // waitForFirstUsableDownstream waits briefly for at least one connected downstream with tools.
@@ -142,7 +165,7 @@ func (p *CentianEndpoint) downstreamPoolHasUsableConnection(pool *DownstreamSess
 	defer p.mu.RUnlock()
 
 	for serverName, conn := range pool.downstreamConns {
-		if pool.connecting[serverName] {
+		if pool.HasActiveConnectWorker(serverName) {
 			continue
 		}
 		if conn.IsConnected() && len(conn.Tools()) > 0 {
@@ -154,15 +177,15 @@ func (p *CentianEndpoint) downstreamPoolHasUsableConnection(pool *DownstreamSess
 
 // connectDownstreamPool establishes one downstream connection owned by a reusable pool.
 func (p *CentianEndpoint) connectDownstreamPool(
+	ctx context.Context,
 	downstreamSessionKey string,
 	conn DownstreamConnectionInterface,
 	connectOptions *DownstreamConnectOptions,
-) {
+) error {
 	serverName := conn.GetServerName()
 	options := p.poolConnectOptions(downstreamSessionKey, serverName, conn, connectOptions)
-	if err := conn.Connect(context.Background(), options); err != nil {
-		p.handlePoolConnectError(downstreamSessionKey, serverName, conn, err)
-		return
+	if err := conn.Connect(ctx, options); err != nil {
+		return err
 	}
 
 	p.syncPoolLoggingLevel(downstreamSessionKey)
@@ -171,6 +194,7 @@ func (p *CentianEndpoint) connectDownstreamPool(
 	p.syncPoolSessions(serverName, sessions, oauthEnabled)
 	common.LogInfo("ProxyEndpoint[%s]: connected pooled downstream %s with %d tools, %d resources, %d resource templates, %d prompts",
 		p.name, sanitizeLogValue(serverName), len(conn.Tools()), len(conn.Resources()), len(conn.ResourceTemplates()), len(conn.Prompts()))
+	return nil
 }
 
 func (p *CentianEndpoint) poolConnectOptions(
@@ -185,7 +209,7 @@ func (p *CentianEndpoint) poolConnectOptions(
 	return options
 }
 
-func (p *CentianEndpoint) handlePoolConnectError(
+func (p *CentianEndpoint) handlePoolConnectAuthError(
 	downstreamSessionKey, serverName string,
 	conn DownstreamConnectionInterface,
 	err error,
@@ -206,7 +230,15 @@ func (p *CentianEndpoint) handlePoolConnectError(
 		)
 		return
 	}
-	common.LogWarn("ProxyEndpoint[%s]: failed to connect pooled downstream %s: %v", p.name, serverName, err)
+}
+
+func (p *CentianEndpoint) handlePoolConnectFailure(
+	downstreamSessionKey, serverName string,
+	conn DownstreamConnectionInterface,
+	err error,
+) {
+	p.releasePoolConnection(downstreamSessionKey, serverName, conn)
+	common.LogWarn("ProxyEndpoint[%s]: failed to connect pooled downstream %s: %v", p.name, sanitizeLogValue(serverName), err)
 }
 
 func (p *CentianEndpoint) releasePoolConnection(

--- a/internal/proxy/proxy_downstream_retry.go
+++ b/internal/proxy/proxy_downstream_retry.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"hash/fnv"
 	"os/exec"
@@ -80,15 +81,17 @@ func poolRetryDelay(serverName string, attempt int) time.Duration {
 	return delay + deterministicRetryJitter(serverName, attempt, jitterWindow)
 }
 
-func deterministicRetryJitter(serverName string, attempt int, max time.Duration) time.Duration {
-	if max <= 0 {
+func deterministicRetryJitter(serverName string, attempt int, jitterLimit time.Duration) time.Duration {
+	if jitterLimit <= 0 {
 		return 0
 	}
 
 	hasher := fnv.New64a()
 	_, _ = hasher.Write([]byte(serverName))
-	_, _ = hasher.Write([]byte{byte(attempt)})
-	return time.Duration(hasher.Sum64() % uint64(max))
+	var attemptBuf [8]byte
+	binary.LittleEndian.PutUint64(attemptBuf[:], uint64(attempt))
+	_, _ = hasher.Write(attemptBuf[:])
+	return time.Duration(hasher.Sum64() % uint64(jitterLimit))
 }
 
 func (p *CentianEndpoint) launchPoolConnectRetryLocked(
@@ -109,6 +112,7 @@ func (p *CentianEndpoint) launchPoolConnectRetryLocked(
 		pool.retryTokens = make(map[string]uint64)
 	}
 
+	//nolint:gosec // cancel is stored on the pool and invoked on worker completion or pool teardown.
 	ctx, cancel := context.WithCancel(context.Background())
 	pool.nextRetryToken++
 	token := pool.nextRetryToken

--- a/internal/proxy/proxy_downstream_retry.go
+++ b/internal/proxy/proxy_downstream_retry.go
@@ -2,10 +2,10 @@ package proxy
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"hash/fnv"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -88,10 +88,13 @@ func deterministicRetryJitter(serverName string, attempt int, jitterLimit time.D
 
 	hasher := fnv.New64a()
 	_, _ = hasher.Write([]byte(serverName))
-	var attemptBuf [8]byte
-	binary.LittleEndian.PutUint64(attemptBuf[:], uint64(attempt))
-	_, _ = hasher.Write(attemptBuf[:])
-	return time.Duration(hasher.Sum64() % uint64(jitterLimit))
+	_, _ = hasher.Write([]byte(strconv.Itoa(attempt)))
+
+	var folded time.Duration
+	for _, b := range hasher.Sum(nil) {
+		folded = folded*257 + time.Duration(b)
+	}
+	return folded % jitterLimit
 }
 
 func (p *CentianEndpoint) launchPoolConnectRetryLocked(

--- a/internal/proxy/proxy_downstream_retry.go
+++ b/internal/proxy/proxy_downstream_retry.go
@@ -1,0 +1,305 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"hash/fnv"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/T4cceptor/centian/internal/common"
+	centoauth "github.com/T4cceptor/centian/internal/oauth"
+)
+
+const (
+	poolRetryInitialDelay = 250 * time.Millisecond
+	poolRetryMaxDelay     = 5 * time.Second
+	poolRetryMaxWindow    = 30 * time.Second
+)
+
+type poolConnectFailureKind string
+
+const (
+	poolConnectFailureTransient poolConnectFailureKind = "transient"
+	poolConnectFailureAuth      poolConnectFailureKind = "auth"
+	poolConnectFailurePermanent poolConnectFailureKind = "permanent"
+)
+
+func classifyPoolConnectError(err error) poolConnectFailureKind {
+	if err == nil {
+		return poolConnectFailureTransient
+	}
+	if _, ok := centoauth.IsAuthorizationRequired(err); ok {
+		return poolConnectFailureAuth
+	}
+
+	message := err.Error()
+	switch {
+	case errors.Is(err, exec.ErrNotFound):
+		return poolConnectFailurePermanent
+	case strings.Contains(message, "both URL or Command configured"):
+		return poolConnectFailurePermanent
+	case strings.Contains(message, "no URL or Command configured"):
+		return poolConnectFailurePermanent
+	case strings.Contains(message, "missing downstream oauth context"):
+		return poolConnectFailurePermanent
+	case strings.Contains(message, "oauth manager not configured"):
+		return poolConnectFailurePermanent
+	case strings.Contains(message, "executable file not found"):
+		return poolConnectFailurePermanent
+	case strings.Contains(message, "permission denied"):
+		return poolConnectFailurePermanent
+	default:
+		var execErr *exec.Error
+		if errors.As(err, &execErr) {
+			return poolConnectFailurePermanent
+		}
+		return poolConnectFailureTransient
+	}
+}
+
+func poolRetryDelay(serverName string, attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	delay := poolRetryInitialDelay
+	for step := 1; step < attempt; step++ {
+		delay *= 2
+		if delay >= poolRetryMaxDelay {
+			delay = poolRetryMaxDelay
+			break
+		}
+	}
+
+	jitterWindow := delay / 4
+	if jitterWindow <= 0 {
+		return delay
+	}
+	return delay + deterministicRetryJitter(serverName, attempt, jitterWindow)
+}
+
+func deterministicRetryJitter(serverName string, attempt int, max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(serverName))
+	_, _ = hasher.Write([]byte{byte(attempt)})
+	return time.Duration(hasher.Sum64() % uint64(max))
+}
+
+func (p *CentianEndpoint) launchPoolConnectRetryLocked(
+	pool *DownstreamSessionPool,
+	serverName string,
+	connectOptions *DownstreamConnectOptions,
+) {
+	if pool == nil || serverName == "" {
+		return
+	}
+	if pool.retryCancels == nil {
+		pool.retryCancels = make(map[string]context.CancelFunc)
+	}
+	if pool.retryAttempts == nil {
+		pool.retryAttempts = make(map[string]int)
+	}
+	if pool.retryTokens == nil {
+		pool.retryTokens = make(map[string]uint64)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pool.nextRetryToken++
+	token := pool.nextRetryToken
+	pool.connecting[serverName] = true
+	pool.retryCancels[serverName] = cancel
+	pool.retryAttempts[serverName] = 0
+	pool.retryTokens[serverName] = token
+
+	go p.connectDownstreamPoolWithRetry(ctx, pool.downstreamSessionKey, serverName, token, cloneDownstreamConnectOptions(connectOptions))
+}
+
+func (p *CentianEndpoint) connectDownstreamPoolWithRetry(
+	ctx context.Context,
+	downstreamSessionKey, serverName string,
+	retryToken uint64,
+	connectOptions *DownstreamConnectOptions,
+) {
+	startedAt := time.Now()
+
+	for attempt := 1; ; attempt++ {
+		conn, ok := p.poolRetryConnection(downstreamSessionKey, serverName, retryToken)
+		if !ok {
+			p.clearPoolRetryState(downstreamSessionKey, serverName, retryToken, false)
+			return
+		}
+
+		p.setPoolRetryAttempt(downstreamSessionKey, serverName, retryToken, attempt)
+		if err := p.connectDownstreamPool(ctx, downstreamSessionKey, conn, connectOptions); err == nil {
+			p.clearPoolRetryState(downstreamSessionKey, serverName, retryToken, false)
+			return
+		} else if ctx.Err() != nil {
+			p.clearPoolRetryState(downstreamSessionKey, serverName, retryToken, true)
+			return
+		} else {
+			switch classifyPoolConnectError(err) {
+			case poolConnectFailureAuth:
+				p.handlePoolConnectAuthError(downstreamSessionKey, serverName, conn, err)
+				p.clearPoolRetryState(downstreamSessionKey, serverName, retryToken, false)
+				return
+			case poolConnectFailurePermanent:
+				p.handlePoolConnectFailure(downstreamSessionKey, serverName, conn, err)
+				p.clearPoolRetryState(downstreamSessionKey, serverName, retryToken, false)
+				return
+			}
+
+			if !p.poolRetryHasLiveSession(downstreamSessionKey, serverName, retryToken) {
+				p.clearPoolRetryState(downstreamSessionKey, serverName, retryToken, true)
+				return
+			}
+
+			delay := poolRetryDelay(serverName, attempt)
+			if time.Since(startedAt)+delay > poolRetryMaxWindow {
+				common.LogWarn(
+					"ProxyEndpoint[%s]: giving up on pooled downstream %s after %d attempts in %s: %v",
+					p.name,
+					sanitizeLogValue(serverName),
+					attempt,
+					time.Since(startedAt).Round(time.Millisecond),
+					err,
+				)
+				p.handlePoolConnectFailure(downstreamSessionKey, serverName, conn, err)
+				p.clearPoolRetryState(downstreamSessionKey, serverName, retryToken, false)
+				return
+			}
+
+			common.LogWarn(
+				"ProxyEndpoint[%s]: failed to connect pooled downstream %s (attempt %d), retrying in %s: %v",
+				p.name,
+				sanitizeLogValue(serverName),
+				attempt,
+				delay.Round(time.Millisecond),
+				err,
+			)
+
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				p.clearPoolRetryState(downstreamSessionKey, serverName, retryToken, true)
+				return
+			case <-timer.C:
+			}
+		}
+	}
+}
+
+func (p *CentianEndpoint) poolRetryConnection(
+	downstreamSessionKey, serverName string,
+	retryToken uint64,
+) (DownstreamConnectionInterface, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	pool := p.downstreamPools[downstreamSessionKey]
+	if pool == nil {
+		return nil, false
+	}
+	if pool.retryTokens[serverName] != retryToken {
+		return nil, false
+	}
+	conn, ok := pool.downstreamConns[serverName]
+	return conn, ok
+}
+
+func (p *CentianEndpoint) poolRetryHasLiveSession(
+	downstreamSessionKey, serverName string,
+	retryToken uint64,
+) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	pool := p.downstreamPools[downstreamSessionKey]
+	if pool == nil {
+		return false
+	}
+	if pool.retryTokens[serverName] != retryToken {
+		return false
+	}
+	return p.poolHasLiveUpstreamSessionLocked(pool)
+}
+
+func (p *CentianEndpoint) poolHasLiveUpstreamSessionLocked(pool *DownstreamSessionPool) bool {
+	if pool == nil {
+		return false
+	}
+	for _, session := range pool.upstreamSessions {
+		if session == nil {
+			continue
+		}
+		if p.currentUpstreamServerSession(session) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *CentianEndpoint) setPoolRetryAttempt(
+	downstreamSessionKey, serverName string,
+	retryToken uint64,
+	attempt int,
+) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	pool := p.downstreamPools[downstreamSessionKey]
+	if pool == nil || pool.retryTokens[serverName] != retryToken {
+		return
+	}
+	pool.retryAttempts[serverName] = attempt
+}
+
+func (p *CentianEndpoint) clearPoolRetryState(
+	downstreamSessionKey, serverName string,
+	retryToken uint64,
+	clearConnecting bool,
+) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	pool := p.downstreamPools[downstreamSessionKey]
+	if pool == nil || pool.retryTokens[serverName] != retryToken {
+		return
+	}
+
+	delete(pool.retryCancels, serverName)
+	delete(pool.retryAttempts, serverName)
+	delete(pool.retryTokens, serverName)
+	if clearConnecting {
+		delete(pool.connecting, serverName)
+	}
+}
+
+func (p *CentianEndpoint) cancelPoolRetryWorkers(pool *DownstreamSessionPool) {
+	if pool == nil {
+		return
+	}
+
+	p.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(pool.retryCancels))
+	for serverName, cancel := range pool.retryCancels {
+		cancels = append(cancels, cancel)
+		delete(pool.retryAttempts, serverName)
+		delete(pool.retryTokens, serverName)
+		delete(pool.connecting, serverName)
+	}
+	pool.retryCancels = make(map[string]context.CancelFunc)
+	p.mu.Unlock()
+
+	for _, cancel := range cancels {
+		if cancel != nil {
+			cancel()
+		}
+	}
+}

--- a/internal/proxy/proxy_oauth.go
+++ b/internal/proxy/proxy_oauth.go
@@ -101,14 +101,11 @@ func (p *CentianEndpoint) handleOAuthAuthorized(binding centoauth.Binding) {
 
 	p.mu.Lock()
 	type reconnectRequest struct {
-		downstreamSessionKey string
-		oldConn              DownstreamConnectionInterface
-		conn                 DownstreamConnectionInterface
-		options              *DownstreamConnectOptions
+		oldConn DownstreamConnectionInterface
 	}
 	reconnects := make([]reconnectRequest, 0)
 
-	for downstreamSessionKey, pool := range p.downstreamPools {
+	for _, pool := range p.downstreamPools {
 		if pool == nil || pool.identityKey != binding.PrincipalID {
 			continue
 		}
@@ -135,12 +132,9 @@ func (p *CentianEndpoint) handleOAuthAuthorized(binding centoauth.Binding) {
 		}
 		newConn := p.newDownstreamConnection(binding.Server, serverConfig)
 		pool.downstreamConns[binding.Server] = newConn
-		pool.connecting[binding.Server] = true
+		p.launchPoolConnectRetryLocked(pool, binding.Server, p.buildDownstreamConnectOptions(session))
 		reconnects = append(reconnects, reconnectRequest{
-			downstreamSessionKey: downstreamSessionKey,
-			oldConn:              conn,
-			conn:                 newConn,
-			options:              cloneDownstreamConnectOptions(p.buildDownstreamConnectOptions(session)),
+			oldConn: conn,
 		})
 	}
 	p.mu.Unlock()
@@ -156,6 +150,5 @@ func (p *CentianEndpoint) handleOAuthAuthorized(binding centoauth.Binding) {
 				)
 			}
 		}
-		go p.connectDownstreamPool(reconnect.downstreamSessionKey, reconnect.conn, reconnect.options)
 	}
 }

--- a/internal/proxy/proxy_server_helpers_test.go
+++ b/internal/proxy/proxy_server_helpers_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -12,6 +13,31 @@ import (
 
 // DownstreamConnectionPool is a test-only alias kept for readability in existing test setups.
 type DownstreamConnectionPool = DownstreamSessionPool
+
+func connectUpstreamTestClient(
+	t *testing.T,
+	session *UpstreamSession,
+	options *mcp.ClientOptions,
+) (*mcp.ClientSession, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := session.upstreamServer.Connect(ctx, serverTransport, nil)
+	assert.NilError(t, err)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "1.0.0"}, options)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	assert.NilError(t, err)
+
+	// Tests use the existing empty-ID fallback to resolve the live server session.
+	session.id = ""
+
+	return clientSession, func() {
+		_ = clientSession.Close()
+		_ = serverSession.Close()
+	}
+}
 
 func TestCreateSession_AuthHeaders(t *testing.T) {
 	// Given: a proxy with a configured auth header

--- a/internal/proxy/proxy_server_setup_test.go
+++ b/internal/proxy/proxy_server_setup_test.go
@@ -184,3 +184,26 @@ func TestSetup_ProcessorsInitializedForBothEndpointTypes(t *testing.T) {
 	assert.Assert(t, singleHandler != nil)
 	assert.Equal(t, "/mcp/gateway/server1", singlePattern)
 }
+
+func TestCentianServerClose_ClosesEndpointPools(t *testing.T) {
+	conn := &MockDownstreamConnection{serverName: "server-a", Status: StatusConnected}
+	endpoint := &CentianEndpoint{
+		downstreamPools: map[string]*DownstreamSessionPool{
+			"pool-1": {
+				downstreamConns: map[string]DownstreamConnectionInterface{
+					"server-a": conn,
+				},
+				connecting: make(map[string]bool),
+			},
+		},
+	}
+	server := &CentianServer{
+		Endpoints: []*CentianEndpoint{nil, endpoint},
+	}
+
+	errs := server.Close()
+
+	assert.Assert(t, len(errs) == 0)
+	assert.Equal(t, conn.CloseCalls, 1)
+	assert.Equal(t, len(endpoint.downstreamPools), 0)
+}

--- a/internal/proxy/proxy_server_unit_test.go
+++ b/internal/proxy/proxy_server_unit_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/T4cceptor/centian/internal/auth"
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
+	centoauth "github.com/T4cceptor/centian/internal/oauth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/assert"
 )
@@ -455,7 +456,7 @@ func TestGetServerForRequest_DoesNotReusePoolWhenForwardedAuthChanges(t *testing
 }
 
 func TestGetServerForRequest_RetriesFailedDownstreamsForLaterSessions(t *testing.T) {
-	// Given: an aggregated proxy where one downstream fails the first time
+	// Given: an aggregated proxy where a later session encounters a failed pooled downstream
 	createdByServer := make(map[string]int)
 	proxy := &CentianEndpoint{
 		name:              "gateway",
@@ -474,10 +475,6 @@ func TestGetServerForRequest_RetriesFailedDownstreamsForLaterSessions(t *testing
 					{Name: "ping", Description: "ping", InputSchema: map[string]any{"type": "object"}},
 				},
 			}
-			if name == "server2" && createdByServer[name] == 1 {
-				conn.ErrorToReturn = errors.New("dial failed")
-				conn.Status = StatusFailed
-			}
 			return conn
 		},
 		server: &CentianServer{
@@ -494,20 +491,24 @@ func TestGetServerForRequest_RetriesFailedDownstreamsForLaterSessions(t *testing
 	request2.Header.Set("Mcp-Session-Id", "session-2")
 	request2 = request2.WithContext(withRequestIdentity(context.Background(), "auth:key_1"))
 
-	// When: the first session creates a partial failure
+	// When: the first session establishes the pooled downstream set
 	server1 := proxy.GetOrCreateServerForRequest(request1)
 	firstSessionID := findOnlyUpstreamSessionIDForTest(t, proxy)
-	firstSession := attachInitializedSessionForTest(t, proxy, firstSessionID, &mcp.ClientCapabilities{})
-	waitForCondition(t, time.Second, func() bool {
-		proxy.mu.RLock()
-		defer proxy.mu.RUnlock()
-		entry, ok := proxy.downstreamPools[firstSession.downstreamSessionKey]
-		if !ok {
-			return false
-		}
-		conn, exists := entry.downstreamConns["server2"]
-		return exists && conn.GetStatus().IsFailed() && !entry.connecting["server2"]
-	})
+	attachInitializedSessionForTest(t, proxy, firstSessionID, &mcp.ClientCapabilities{})
+	waitForCondition(t, time.Second, func() bool { return createdByServer["server2"] >= 1 })
+	beforeRetry := createdByServer["server2"]
+
+	proxy.mu.Lock()
+	firstSession := proxy.upstreamSessions[firstSessionID]
+	pool := proxy.downstreamPools[firstSession.downstreamSessionKey]
+	pool.downstreamConns["server2"] = &MockDownstreamConnection{
+		serverName:    "server2",
+		cfg:           proxy.config.MCPServers["server2"],
+		Status:        StatusFailed,
+		ErrorToReturn: errors.New("terminal failure"),
+	}
+	delete(pool.connecting, "server2")
+	proxy.mu.Unlock()
 
 	// And: a later session with the same identity arrives after that failure settled
 	server2 := proxy.GetOrCreateServerForRequest(request2)
@@ -516,7 +517,340 @@ func TestGetServerForRequest_RetriesFailedDownstreamsForLaterSessions(t *testing
 	// Then: the failed downstream should be retried for the later session
 	assert.Assert(t, server1 != nil)
 	assert.Assert(t, server2 != nil)
-	assert.Equal(t, createdByServer["server2"], 2)
+	waitForCondition(t, time.Second, func() bool {
+		return createdByServer["server2"] == beforeRetry+1
+	})
+}
+
+func TestGetServerForRequest_RetriesTransientFailureInBackground(t *testing.T) {
+	conn := &MockDownstreamConnection{
+		serverName: "server1",
+		cfg:        &config.MCPServerConfig{Command: "node"},
+		tools: []*mcp.Tool{
+			{Name: "ping", Description: "ping", InputSchema: map[string]any{"type": "object"}},
+		},
+	}
+	conn.ConnectFunc = func(context.Context, *DownstreamConnectOptions) error {
+		if conn.ConnectCalls == 1 {
+			return errors.New("dial failed")
+		}
+		return nil
+	}
+
+	proxy := &CentianEndpoint{
+		name:              "gateway",
+		endpoint:          "/mcp/gateway",
+		config:            testGatewayConfig("server1"),
+		isAggregatedProxy: true,
+		upstreamSessions:  make(map[string]*UpstreamSession),
+		downstreamPools:   make(map[string]*DownstreamConnectionPool),
+		connectionFactory: func(string, *config.MCPServerConfig) DownstreamConnectionInterface {
+			return conn
+		},
+		server: &CentianServer{
+			APIKeys:    createTestAPIKeyStore(t),
+			AuthHeader: "Authorization",
+			Config:     &config.GlobalConfig{Version: "1.0.0"},
+		},
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway", http.NoBody)
+	request = request.WithContext(withRequestIdentity(context.Background(), "auth:key_1"))
+
+	server := proxy.GetOrCreateServerForRequest(request)
+	assert.Assert(t, server != nil)
+
+	sessionID := findOnlyUpstreamSessionIDForTest(t, proxy)
+	proxy.mu.RLock()
+	session := proxy.upstreamSessions[sessionID]
+	proxy.mu.RUnlock()
+	assert.Assert(t, session != nil)
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	attachInitializedSessionForTest(t, proxy, sessionID, &mcp.ClientCapabilities{})
+
+	waitForCondition(t, 3*time.Second, func() bool {
+		toolsResult, err := clientSession.ListTools(context.Background(), nil)
+		return err == nil && len(toolsResult.Tools) == 1
+	})
+	assert.Equal(t, conn.ConnectCalls, 2)
+}
+
+func TestGetServerForRequest_DoesNotRetryPermanentFailures(t *testing.T) {
+	conn := &MockDownstreamConnection{
+		serverName:    "server1",
+		cfg:           &config.MCPServerConfig{Command: "node"},
+		ErrorToReturn: errors.New("failed to create transport: no URL or Command configured for server server1"),
+		Status:        StatusPending,
+	}
+
+	proxy := &CentianEndpoint{
+		name:              "gateway",
+		endpoint:          "/mcp/gateway",
+		config:            testGatewayConfig("server1"),
+		isAggregatedProxy: true,
+		upstreamSessions:  make(map[string]*UpstreamSession),
+		downstreamPools:   make(map[string]*DownstreamConnectionPool),
+		connectionFactory: func(string, *config.MCPServerConfig) DownstreamConnectionInterface {
+			return conn
+		},
+		server: &CentianServer{
+			APIKeys:    createTestAPIKeyStore(t),
+			AuthHeader: "Authorization",
+			Config:     &config.GlobalConfig{Version: "1.0.0"},
+		},
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway", http.NoBody)
+	request = request.WithContext(withRequestIdentity(context.Background(), "auth:key_1"))
+
+	server := proxy.GetOrCreateServerForRequest(request)
+	assert.Assert(t, server != nil)
+
+	sessionID := findOnlyUpstreamSessionIDForTest(t, proxy)
+	proxy.mu.RLock()
+	session := proxy.upstreamSessions[sessionID]
+	proxy.mu.RUnlock()
+	assert.Assert(t, session != nil)
+
+	_, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	attachInitializedSessionForTest(t, proxy, sessionID, &mcp.ClientCapabilities{})
+
+	waitForCondition(t, time.Second, func() bool {
+		proxy.mu.RLock()
+		defer proxy.mu.RUnlock()
+		pool := proxy.downstreamPools[session.downstreamSessionKey]
+		return pool != nil && !pool.connecting["server1"]
+	})
+	time.Sleep(350 * time.Millisecond)
+	assert.Equal(t, conn.ConnectCalls, 1)
+}
+
+func TestGetServerForRequest_DoesNotRetryAuthorizationFailures(t *testing.T) {
+	testCases := []struct {
+		name   string
+		reason string
+	}{
+		{name: "auth required", reason: centoauth.AuthorizationReasonRequired},
+		{name: "refresh failed", reason: centoauth.AuthorizationReasonRefreshFailed},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &MockDownstreamConnection{
+				serverName: "server1",
+				cfg:        &config.MCPServerConfig{Command: "node"},
+				ErrorToReturn: &centoauth.AuthorizationRequiredError{
+					Binding: centoauth.Binding{
+						PrincipalID: "auth:key_1",
+						Gateway:     "gateway",
+						Server:      "server1",
+					},
+					AuthURL: "http://127.0.0.1:8080/oauth/start?id=test",
+					Reason:  tc.reason,
+				},
+			}
+
+			proxy := &CentianEndpoint{
+				name:              "gateway",
+				endpoint:          "/mcp/gateway",
+				config:            testGatewayConfig("server1"),
+				isAggregatedProxy: true,
+				upstreamSessions:  make(map[string]*UpstreamSession),
+				downstreamPools:   make(map[string]*DownstreamConnectionPool),
+				connectionFactory: func(string, *config.MCPServerConfig) DownstreamConnectionInterface {
+					return conn
+				},
+				server: &CentianServer{
+					APIKeys:    createTestAPIKeyStore(t),
+					AuthHeader: "Authorization",
+					Config:     &config.GlobalConfig{Version: "1.0.0"},
+				},
+			}
+
+			request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway", http.NoBody)
+			request = request.WithContext(withRequestIdentity(context.Background(), "auth:key_1"))
+
+			server := proxy.GetOrCreateServerForRequest(request)
+			assert.Assert(t, server != nil)
+
+			sessionID := findOnlyUpstreamSessionIDForTest(t, proxy)
+			proxy.mu.RLock()
+			session := proxy.upstreamSessions[sessionID]
+			proxy.mu.RUnlock()
+			assert.Assert(t, session != nil)
+
+			_, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+			defer cleanup()
+
+			attachInitializedSessionForTest(t, proxy, sessionID, &mcp.ClientCapabilities{})
+
+			waitForCondition(t, time.Second, func() bool {
+				proxy.mu.RLock()
+				defer proxy.mu.RUnlock()
+				pool := proxy.downstreamPools[session.downstreamSessionKey]
+				return pool != nil && !pool.connecting["server1"]
+			})
+			time.Sleep(350 * time.Millisecond)
+			assert.Equal(t, conn.ConnectCalls, 1)
+		})
+	}
+}
+
+func TestInvalidatePooledDownstream_CancelsActiveRetry(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	conn := &MockDownstreamConnection{
+		serverName: "server1",
+		cfg:        &config.MCPServerConfig{Command: "node"},
+	}
+	conn.ConnectFunc = func(ctx context.Context, _ *DownstreamConnectOptions) error {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-release:
+			return nil
+		}
+	}
+
+	proxy := &CentianEndpoint{
+		name:              "gateway",
+		endpoint:          "/mcp/gateway",
+		config:            testGatewayConfig("server1"),
+		isAggregatedProxy: true,
+		upstreamSessions:  make(map[string]*UpstreamSession),
+		downstreamPools:   make(map[string]*DownstreamConnectionPool),
+		connectionFactory: func(string, *config.MCPServerConfig) DownstreamConnectionInterface {
+			return conn
+		},
+		server: &CentianServer{
+			APIKeys:    createTestAPIKeyStore(t),
+			AuthHeader: "Authorization",
+			Config:     &config.GlobalConfig{Version: "1.0.0"},
+		},
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway", http.NoBody)
+	request = request.WithContext(withRequestIdentity(context.Background(), "auth:key_1"))
+
+	server := proxy.GetOrCreateServerForRequest(request)
+	assert.Assert(t, server != nil)
+
+	sessionID := findOnlyUpstreamSessionIDForTest(t, proxy)
+	proxy.mu.RLock()
+	session := proxy.upstreamSessions[sessionID]
+	proxy.mu.RUnlock()
+	assert.Assert(t, session != nil)
+
+	_, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	attachInitializedSessionForTest(t, proxy, sessionID, &mcp.ClientCapabilities{})
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("connect attempt did not start in time")
+	}
+
+	proxy.invalidateDownstreamPool(session.downstreamSessionKey)
+	close(release)
+
+	waitForCondition(t, time.Second, func() bool {
+		proxy.mu.RLock()
+		defer proxy.mu.RUnlock()
+		_, ok := proxy.downstreamPools[session.downstreamSessionKey]
+		return !ok
+	})
+	waitForCondition(t, time.Second, func() bool {
+		return conn.CloseCalls == 1
+	})
+	assert.Equal(t, conn.ConnectCalls, 1)
+}
+
+func TestGetServerForRequest_DoesNotSpawnDuplicateRetryWorker(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	created := 0
+
+	conn := &MockDownstreamConnection{
+		serverName: "server1",
+		cfg:        &config.MCPServerConfig{Command: "node"},
+		tools: []*mcp.Tool{
+			{Name: "ping", Description: "ping", InputSchema: map[string]any{"type": "object"}},
+		},
+	}
+	conn.ConnectFunc = func(ctx context.Context, _ *DownstreamConnectOptions) error {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-release:
+			return nil
+		}
+	}
+
+	proxy := &CentianEndpoint{
+		name:              "gateway",
+		endpoint:          "/mcp/gateway",
+		config:            testGatewayConfig("server1"),
+		isAggregatedProxy: true,
+		upstreamSessions:  make(map[string]*UpstreamSession),
+		downstreamPools:   make(map[string]*DownstreamConnectionPool),
+		connectionFactory: func(string, *config.MCPServerConfig) DownstreamConnectionInterface {
+			created++
+			return conn
+		},
+		server: &CentianServer{
+			APIKeys:    createTestAPIKeyStore(t),
+			AuthHeader: "Authorization",
+			Config:     &config.GlobalConfig{Version: "1.0.0"},
+		},
+	}
+
+	request1 := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway", http.NoBody)
+	request1 = request1.WithContext(withRequestIdentity(context.Background(), "auth:key_1"))
+	request2 := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway", http.NoBody)
+	request2.Header.Set("Mcp-Session-Id", "session-2")
+	request2 = request2.WithContext(withRequestIdentity(context.Background(), "auth:key_1"))
+
+	server1 := proxy.GetOrCreateServerForRequest(request1)
+	assert.Assert(t, server1 != nil)
+
+	firstSessionID := findOnlyUpstreamSessionIDForTest(t, proxy)
+	proxy.mu.RLock()
+	firstSession := proxy.upstreamSessions[firstSessionID]
+	proxy.mu.RUnlock()
+	assert.Assert(t, firstSession != nil)
+
+	_, cleanup := connectUpstreamTestClient(t, firstSession, &mcp.ClientOptions{})
+	defer cleanup()
+
+	attachInitializedSessionForTest(t, proxy, firstSessionID, &mcp.ClientCapabilities{})
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("connect attempt did not start in time")
+	}
+
+	server2 := proxy.GetOrCreateServerForRequest(request2)
+	assert.Assert(t, server2 != nil)
+	attachInitializedSessionForTest(t, proxy, "session-2", &mcp.ClientCapabilities{})
+
+	assert.Equal(t, created, 1)
+	close(release)
 }
 
 func TestLogRequestForDebugPreservesRequestBody(t *testing.T) {

--- a/internal/proxy/proxy_session_test_helpers.go
+++ b/internal/proxy/proxy_session_test_helpers.go
@@ -13,7 +13,7 @@ func attachInitializedSessionForTest(
 	proxy *CentianEndpoint,
 	sessionID string,
 	capabilities *mcp.ClientCapabilities,
-) *UpstreamSession {
+) {
 	t.Helper()
 
 	proxy.mu.RLock()
@@ -29,7 +29,6 @@ func attachInitializedSessionForTest(
 	proxy.mu.Unlock()
 
 	proxy.finalizeDownstreamPoolUpdate(context.Background(), session, update)
-	return session
 }
 
 func findOnlyUpstreamSessionIDForTest(t *testing.T, proxy *CentianEndpoint) string {

--- a/internal/proxy/proxy_sessions.go
+++ b/internal/proxy/proxy_sessions.go
@@ -450,6 +450,7 @@ func (p *CentianEndpoint) closeDownstreamSessionPool(pool *DownstreamSessionPool
 	if pool == nil {
 		return nil
 	}
+	p.cancelPoolRetryWorkers(pool)
 	errs := make([]error, 0)
 	for _, conn := range pool.downstreamConns {
 		if err := conn.Close(); err != nil {

--- a/internal/proxy/proxy_sessions_test.go
+++ b/internal/proxy/proxy_sessions_test.go
@@ -108,7 +108,7 @@ func TestSessionNeedsInitialRootsBootstrap(t *testing.T) {
 	assert.Assert(t, !proxy.sessionNeedsInitialRootsBootstrap(session.id))
 }
 
-func TestApplyClientStateLockedConnectsWithResolvedRoots(t *testing.T) {
+func TestApplyClientStateLockedPropagatesResolvedRoots(t *testing.T) {
 	proxy := NewSingleEndpoint("server-a", "/mcp/server-a", &config.GatewayConfig{
 		MCPServers: map[string]*config.MCPServerConfig{
 			"server-a": {Command: "node"},
@@ -152,29 +152,17 @@ func TestApplyClientStateLockedConnectsWithResolvedRoots(t *testing.T) {
 	assert.Assert(t, session.downstreamSessionKey != "")
 	assert.Assert(t, !proxy.sessionNeedsInitialRootsBootstrap(session.id))
 
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
+	waitForCondition(t, 3*time.Second, func() bool {
 		mockConn.mu.RLock()
-		connected := mockConn.ConnectCalls > 0
-		foundResolvedRoots := false
-		if connected {
-			for _, captured := range mockConn.CapturedConnects {
-				if reflect.DeepEqual(normalizeRoots(captured.ClientState.Roots), normalizeRoots(resolvedRoots)) {
-					foundResolvedRoots = true
-					break
-				}
+		defer mockConn.mu.RUnlock()
+
+		for _, captured := range mockConn.CapturedConnects {
+			if reflect.DeepEqual(normalizeRoots(captured.ClientState.Roots), normalizeRoots(resolvedRoots)) {
+				return true
 			}
 		}
-		mockConn.mu.RUnlock()
-
-		if connected {
-			assert.Assert(t, foundResolvedRoots)
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	t.Fatal("expected downstream connect with resolved roots")
+		return false
+	})
 }
 
 func TestMarkUpstreamSessionRootsDirty(t *testing.T) {

--- a/internal/proxy/proxy_setup.go
+++ b/internal/proxy/proxy_setup.go
@@ -62,7 +62,7 @@ func NewCentianServer(globalConfig *config.GlobalConfig) (*CentianServer, error)
 		common.LogInfo("API key auth disabled via config\n")
 	}
 
-	return &CentianServer{
+	centianServer := &CentianServer{
 		Config:     globalConfig,
 		Mux:        mux,
 		Server:     server,
@@ -72,7 +72,14 @@ func NewCentianServer(globalConfig *config.GlobalConfig) (*CentianServer, error)
 		Endpoints:  []*CentianEndpoint{},
 		APIKeys:    apiKeyStore,
 		AuthHeader: globalConfig.GetAuthHeader(),
-	}, nil
+	}
+	server.RegisterOnShutdown(func() {
+		for _, err := range centianServer.Close() {
+			common.LogWarn("error during centian shutdown cleanup: %v", err)
+		}
+	})
+
+	return centianServer, nil
 }
 
 // Setup uses CentianServer.config to create all gateways and endpoints.
@@ -122,6 +129,22 @@ func (c *CentianServer) Setup() error {
 		}
 	}
 	return nil
+}
+
+// Close releases endpoint-owned resources such as pooled downstream sessions.
+func (c *CentianServer) Close() []error {
+	if c == nil {
+		return nil
+	}
+
+	errs := make([]error, 0)
+	for _, endpoint := range c.Endpoints {
+		if endpoint == nil {
+			continue
+		}
+		errs = append(errs, endpoint.Close()...)
+	}
+	return errs
 }
 
 // initEventProcessor initializes the event processor for this ProxyEndpoint.

--- a/internal/proxy/proxy_tools.go
+++ b/internal/proxy/proxy_tools.go
@@ -51,6 +51,12 @@ func (p *CentianEndpoint) newUpstreamServer(session *UpstreamSession) *mcp.Serve
 			return session.id
 		},
 	})
+	// TODO: refactor registerStaticProxyTools into 2 functions:
+	// 1. for auth tools
+	// 2. for test notifications (they should be separated)
+	// then call both from here
+	// and move registerStaticProxyTools away from CentianEndpoint
+	// it should be a session.upstreamServer function actually
 	p.registerStaticProxyTools(session, server)
 	return server
 }
@@ -186,7 +192,7 @@ func (p *CentianEndpoint) collectDownstreamToolState(
 	conn DownstreamConnectionInterface,
 	summary *downstreamRegistrationSummary,
 ) {
-	if pool.connecting[serverName] {
+	if pool.HasActiveConnectWorker(serverName) {
 		summary.connectingCount++
 		return
 	}

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -69,8 +69,16 @@ type DownstreamSessionPool struct {
 	downstreamSessionKey string
 	downstreamConns      map[string]DownstreamConnectionInterface
 	upstreamSessions     map[string]*UpstreamSession
-	connecting           map[string]bool
-	lastUsed             time.Time
+	// connecting tracks whether a pool-owned connect/retry worker currently owns
+	// this server slot. This is broader than conn.IsConnecting(): the worker may
+	// exist while sleeping between retries, even when no concrete connection is
+	// inside Connect().
+	connecting     map[string]bool
+	retryCancels   map[string]context.CancelFunc
+	retryAttempts  map[string]int
+	retryTokens    map[string]uint64
+	nextRetryToken uint64
+	lastUsed       time.Time
 }
 
 type notificationJob struct {
@@ -95,6 +103,12 @@ func (p *DownstreamSessionPool) GetConnectionByServerName(serverName string) (Do
 // SetConnection sets a downstream connection for the given server name.
 func (p *DownstreamSessionPool) SetConnection(serverName string, conn DownstreamConnectionInterface) {
 	p.downstreamConns[serverName] = conn
+}
+
+// HasActiveConnectWorker reports whether the pool already has a connect/retry
+// worker responsible for this server slot.
+func (p *DownstreamSessionPool) HasActiveConnectWorker(serverName string) bool {
+	return p != nil && p.connecting[serverName]
 }
 
 // IsConnecting returns true if the connection for the given serverName is currently in state Connecting.

--- a/internal/proxy/proxy_types_test.go
+++ b/internal/proxy/proxy_types_test.go
@@ -32,3 +32,16 @@ func TestDownstreamSessionPoolIsConnecting(t *testing.T) {
 	_, err = pool.IsConnecting("missing")
 	assert.ErrorContains(t, err, `no connection to server "missing" found`)
 }
+
+func TestDownstreamSessionPoolHasActiveConnectWorker(t *testing.T) {
+	pool := &DownstreamSessionPool{
+		connecting: map[string]bool{
+			"server-a": true,
+			"server-b": false,
+		},
+	}
+
+	assert.Assert(t, pool.HasActiveConnectWorker("server-a"))
+	assert.Assert(t, !pool.HasActiveConnectWorker("server-b"))
+	assert.Assert(t, !pool.HasActiveConnectWorker("missing"))
+}

--- a/tests/integrationtests/everything/harness_test.go
+++ b/tests/integrationtests/everything/harness_test.go
@@ -27,6 +27,7 @@ const (
 	defaultSessionTimeout       = 30 * time.Second
 	defaultDirectTerminateWait  = 250 * time.Millisecond
 	defaultToolsWaitTimeout     = 20 * time.Second
+	defaultShutdownTimeout      = 10 * time.Second
 	defaultEverythingServerCmd  = "npx"
 	defaultEverythingServerArgs = "-y @modelcontextprotocol/server-everything"
 )
@@ -379,7 +380,7 @@ func startCentianProxyForEverything(t *testing.T, downstream everythingServerCom
 	waitForProxyListener(t, server.Server.Addr)
 
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
 		defer cancel()
 
 		if err := server.Server.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/tests/integrationtests/realworld/harness_test.go
+++ b/tests/integrationtests/realworld/harness_test.go
@@ -28,6 +28,7 @@ const (
 	runRealworldIntegrationEnv = "CENTIAN_RUN_REALWORLD_INTEGRATION"
 	defaultSessionTimeout      = 30 * time.Second
 	defaultToolsWaitTimeout    = 20 * time.Second
+	defaultShutdownTimeout     = 10 * time.Second
 )
 
 type serverMode string
@@ -269,7 +270,7 @@ func startCentianProxyForRealworld(t *testing.T, manifest *serverManifest, downs
 	waitForProxyListener(t, server.Server.Addr)
 
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
 		defer cancel()
 
 		if err := server.Server.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {


### PR DESCRIPTION
## Summary

Fixes #78 by adding bounded background retry for pooled downstream connection startup failures, so transient downstream failures can recover without requiring upstream reconciliation from a later tool call.

## What changed

- Added a pool-owned retry worker for downstream connects with:
  - bounded exponential backoff
  - deterministic jitter
  - cancellation tied to pool invalidation / shutdown
  - live-session checks to avoid retrying for dead pools
- Classified connect failures into:
  - transient: retried in background
  - auth-gated: not timer-retried, existing OAuth flow remains authoritative
  - permanent local startup/config errors: fail fast
- Kept retry ownership at the pool level rather than on the connection object, since retry state spans backoff sleeps and connection replacement.
- Reused the same retry launcher for OAuth-triggered reconnects.
- Clarified pool connect state by:
  - introducing a helper for pool-level worker ownership
  - replacing the large inline connect-start condition with a helper
  - documenting why pool-level state exists separately from connection-level `IsConnecting()`

## Tests

Added/updated proxy tests covering:

- transient failure recovers in background and tools appear via `tools/list` polling
- permanent failures are not retried
- auth-required and refresh-failed states are not background retried
- pool invalidation cancels an active retry worker
- duplicate retry workers are not spawned for the same pooled downstream
- existing OAuth reconnect / pooled downstream behavior remains intact
