### PR TITLE
Feature/119 allow steps without checks

### DIFF
--- a/docs/TASKVERIFICATION.md
+++ b/docs/TASKVERIFICATION.md
@@ -258,12 +258,12 @@ Execution then reads from that frozen contract rather than from mutable shell st
 
 `centian.task_complete_onboarding`:
 
-- stores reusable project discovery context
+- stores reusable task and environment context
 - moves the run into `planning`
 
 Typical onboarding data includes:
 
-- project summary
+- task summary
 - artifact map
 - common commands
 - constraints

--- a/docs/TASKVERIFICATION.md
+++ b/docs/TASKVERIFICATION.md
@@ -79,6 +79,7 @@ If `proxy.capabilities.taskVerification.templatesPath` is set:
 - a relative path is resolved from Centian's current working directory
 
 This repository includes example templates under [task-templates](../task-templates).
+For a schema-focused authoring guide, see [TASK_TEMPLATE_AUTHORING.md](./TASK_TEMPLATE_AUTHORING.md).
 
 ### 3. Expose downstream tools through a normal gateway
 

--- a/docs/TASK_TEMPLATE_AUTHORING.md
+++ b/docs/TASK_TEMPLATE_AUTHORING.md
@@ -209,7 +209,7 @@ The workflow has four authoring areas:
 
 ### Onboarding
 
-Use onboarding for project discovery and context gathering.
+Use onboarding for task and environment discovery context.
 
 ```yaml
 workflow:

--- a/docs/TASK_TEMPLATE_AUTHORING.md
+++ b/docs/TASK_TEMPLATE_AUTHORING.md
@@ -1,0 +1,729 @@
+# How To Create a Taskverification Template
+
+**Version:** 1.0
+**Last Updated:** 2026-03-29
+
+This guide explains how to create a new taskverification template for Centian.
+The template itself is a YAML file. This document is the Markdown authoring guide for that YAML file.
+
+Use this guide together with [TASKVERIFICATION.md](./TASKVERIFICATION.md).
+
+## What a Template Does
+
+A taskverification template defines:
+
+- the task identity shown to the agent
+- the parameters the agent can provide
+- the onboarding and planning phases
+- the executable workflow steps
+- the checks and invariants Centian uses to verify each step
+- the tool allowlist for each workflow node
+
+At runtime, Centian:
+
+1. Loads the YAML file from the configured templates directory.
+2. Validates and compiles the workflow.
+3. Registers a task run from that template.
+4. Freezes a runnable version of the template when planning completes.
+5. Uses the compiled checks and invariants to gate step execution.
+
+## Where to Put the File
+
+Create the template as a `.yaml` or `.yml` file in the task template directory:
+
+- default: `<current-working-directory>/task-templates`
+- override: `proxy.capabilities.taskVerification.templatesPath`
+
+Template IDs must be unique across every YAML file in that directory.
+
+## Authoring Flow
+
+Create templates in this order:
+
+1. Define top-level metadata: `version`, `task`, `workflow`.
+2. Add `parameters` for every placeholder you want to substitute.
+3. Define `workflow.onboarding` and `workflow.planning`.
+4. Add optional `workflow.scaffolding` steps.
+5. Add required `workflow.execution` steps.
+6. Add `checks` for every executable step.
+7. Add `invariants` only where output must remain stable between start and complete.
+8. Add explicit `next` edges only when the default linear order is not what you want.
+9. Load the template through Centian and fix any validation errors before using it.
+
+## Minimal Working Template
+
+```yaml
+version: "0.1"
+task:
+  id: "go_bugfix"
+  name: "Go Bugfix Task"
+  description: "Drive a focused bugfix with an explicit failing baseline and implementation step."
+  instructions: |
+    Register the task first, finish onboarding and planning, then follow the workflow steps in order.
+
+parameters:
+  - name: "testCommand"
+    description: "Command prefix used to run the targeted test."
+  - name: "testTarget"
+    description: "Concrete test target."
+  - name: "expectedFailure"
+    description: "Stable failing output expected before the fix."
+  - name: "sourceFile"
+    description: "Implementation file expected to change."
+
+workflow:
+  onboarding:
+    instructions: |
+      Identify the relevant package, test target, and implementation file.
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+
+  planning:
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+    editable_fields:
+      - "parameters.testCommand"
+      - "parameters.testTarget"
+      - "parameters.expectedFailure"
+      - "parameters.sourceFile"
+    required_outputs:
+      - "selectedFiles"
+      - "testTarget"
+      - "expectedFailure"
+      - "implementationTarget"
+
+  execution:
+    - id: "establish_failing_baseline"
+      name: "Establish failing baseline"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      checks:
+        - id: "selected_test_fails"
+          command: "${testCommand} ${testTarget}"
+          post_conditions:
+            - type: exit_code
+              value: 1
+            - type: stdout_contains
+              value: "${expectedFailure}"
+
+    - id: "implement_fix"
+      name: "Implement fix"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      checks:
+        - id: "selected_test_passes"
+          command: "${testCommand} ${testTarget}"
+          pre_conditions:
+            - type: exit_code
+              value: 1
+          post_conditions:
+            - type: exit_code
+              value: 0
+      invariants:
+        - id: "test_target_stable"
+          command: "printf '%s' '${testTarget}'"
+```
+
+## Template Schema
+
+### Top-Level Fields
+
+Every template must include:
+
+- `version`
+- `task.id`
+- `task.name`
+- `task.description`
+- `workflow`
+- `workflow.onboarding`
+- `workflow.planning`
+- `workflow.execution`
+
+`workflow.execution` must contain at least one executable node.
+
+### `task`
+
+`task` is the human-facing identity:
+
+```yaml
+task:
+  id: "go_bugfix"
+  name: "Go Bugfix Task"
+  description: "Drive a focused bugfix."
+  instructions: |
+    Optional long-form instructions shown to the agent.
+```
+
+Rules:
+
+- `task.id` is required and must be unique across all loaded templates.
+- `task.name` is required.
+- `task.description` is required.
+- `task.instructions` is optional.
+
+## Parameters and Placeholders
+
+Use `parameters` when you want a value substituted into the YAML before execution:
+
+```yaml
+parameters:
+  - name: "testCommand"
+    description: "Command prefix used to run the selected test."
+```
+
+Reference parameters with `${name}` inside any string field:
+
+```yaml
+command: "${testCommand} ${testTarget}"
+value: "${expectedFailure}"
+path: "${relativePath}"
+```
+
+Rules:
+
+- Placeholder names must match `${[a-zA-Z0-9_]+}`.
+- Parameter names must be unique.
+- If `parameters` is present, every defined parameter must be used by at least one placeholder.
+- If a placeholder is used, it must be declared in `parameters`.
+- Unknown parameters passed during task registration are rejected.
+- Missing parameter values are tolerated at registration time, but planning completion fails if placeholder substitution still leaves unresolved `${...}` values.
+
+Practical guidance:
+
+- Keep parameters focused on values that vary per task run.
+- Do not create parameters for static strings that belong in the template itself.
+- Prefer relative file paths in parameters when they are later used by `file_*` conditions.
+
+## Workflow Structure
+
+The workflow has four authoring areas:
+
+- `onboarding`
+- `planning`
+- `scaffolding` optional
+- `execution` required
+
+### Onboarding
+
+Use onboarding for project discovery and context gathering.
+
+```yaml
+workflow:
+  onboarding:
+    instructions: |
+      Discover the target package, test command, and relevant files.
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+    checkpoint:
+      enabled: true
+```
+
+Supported fields:
+
+- `instructions`
+- `tools_allowed`
+- `checkpoint.enabled`
+
+### Planning
+
+Use planning to freeze the execution contract.
+
+```yaml
+planning:
+  instructions: |
+    Confirm the concrete target files and expected failure mode.
+  tools_allowed:
+    - "shell__*"
+    - "filesystem__*"
+  editable_fields:
+    - "parameters.testCommand"
+    - "parameters.testTarget"
+  required_outputs:
+    - "selectedFiles"
+    - "testTarget"
+  next: "execution.establish_failing_baseline"
+```
+
+Supported fields:
+
+- `instructions`
+- `tools_allowed`
+- `checkpoint.enabled`
+- `editable_fields`
+- `required_outputs`
+- `next`
+
+Rules for `editable_fields`:
+
+- Each value must be unique.
+- Only `parameters.<name>` is supported.
+- `<name>` must refer to a declared or placeholder-derived parameter.
+
+Rules for `required_outputs`:
+
+- Each value must be unique.
+- Only these outputs are supported:
+  - `selectedFiles`
+  - `testTarget`
+  - `lintCommand`
+  - `expectedFailure`
+  - `implementationTarget`
+  - `invariants`
+
+These outputs map to fields on the planning artifact sent to `centian.task_complete_planning`:
+
+- `selectedFiles`: non-empty `[]string`, each entry trimmed and unique
+- `testTarget`: non-empty string
+- `lintCommand`: non-empty string
+- `expectedFailure`: non-empty string
+- `implementationTarget`: non-empty string
+- `invariants`: non-empty `[]string`, each entry trimmed and unique
+
+If `planning.next` is omitted, Centian automatically advances to the first executable step after planning.
+
+### Scaffolding
+
+Use scaffolding for additive setup before the main execution path. This is optional.
+
+```yaml
+scaffolding:
+  - id: "create_test_file"
+    name: "Create test file"
+    checks:
+      - id: "test_file_created"
+        command: "printf 'created'"
+        pre_conditions:
+          - type: file_not_exists
+            path: "tests/new_test.go"
+        post_conditions:
+          - type: file_exists
+            path: "tests/new_test.go"
+```
+
+Scaffolding nodes are executable steps, just like execution nodes.
+
+### Execution
+
+Use execution for the steps that define task success.
+
+```yaml
+execution:
+  - id: "establish_failing_baseline"
+    checks:
+      - id: "selected_test_fails"
+        command: "${testCommand} ${testTarget}"
+        post_conditions:
+          - type: exit_code
+            value: 1
+
+  - id: "implement_fix"
+    checks:
+      - id: "selected_test_passes"
+        command: "${testCommand} ${testTarget}"
+        post_conditions:
+          - type: exit_code
+            value: 0
+```
+
+Executable leaf nodes may omit `checks` entirely.
+This is useful for free-form templates that are intended to track and monitor a task run without enforcing verification at each step.
+
+## Execution Nodes
+
+Scaffolding and execution lists use the same node schema:
+
+```yaml
+- id: "implement_fix"
+  kind: "execution"
+  name: "Implement fix"
+  description: "Make the selected test pass."
+  instructions: |
+    Start the step before editing code.
+  tools_allowed:
+    - "shell__*"
+    - "filesystem__*"
+  checkpoint:
+    enabled: true
+  checks:
+    - id: "selected_test_passes"
+      command: "${testCommand} ${testTarget}"
+  invariants:
+    - id: "test_file_stable"
+      command: "cat ${testFile}"
+  next: "waiting_for_approval.review_plan"
+```
+
+Supported fields:
+
+- `id`
+- `kind`
+- `name`
+- `description`
+- `instructions`
+- `tools_allowed`
+- `checkpoint.enabled`
+- `checks`
+- `invariants`
+- `next`
+- `sub_steps`
+
+Rules:
+
+- `id` is required.
+- Node IDs must be unique across the whole workflow, not just inside one list.
+- `kind` defaults to the containing list kind:
+  - nodes under `scaffolding` default to `scaffolding`
+  - nodes under `execution` default to `execution`
+- The only non-default `kind` currently allowed is `waiting_for_approval`.
+- `checks` are optional. If provided, they must be valid.
+- `invariants` are optional. If provided, they must be valid.
+
+## Checks
+
+Checks are the actual verification units run by Centian.
+
+```yaml
+checks:
+  - id: "selected_test_fails"
+    command: "${testCommand} ${testTarget}"
+    pre_conditions:
+      - type: exit_code_in
+        values: [0, 1]
+    post_conditions:
+      - type: exit_code
+        value: 1
+      - type: stdout_contains
+        value: "${expectedFailure}"
+```
+
+Rules:
+
+- Each check needs `id`.
+- Check IDs must be unique within the step.
+- Each check needs `command`.
+- `pre_conditions` are evaluated when `centian.task_start_step` runs.
+- `post_conditions` are evaluated when `centian.task_complete_step` runs.
+
+### Supported Condition Types
+
+`exit_code`
+
+- required field: `value`
+- `value` must be numeric
+
+`exit_code_in`
+
+- required field: `values`
+- `values` must be a non-empty numeric list
+
+`stdout_contains`
+
+- required field: `value`
+- `value` must be a non-empty string
+
+`stdout_not_contains`
+
+- required field: `value`
+- `value` must be a non-empty string
+
+`file_exists`
+
+- required field: `path`
+- `path` must be relative to the service working directory
+
+`file_not_exists`
+
+- required field: `path`
+- `path` must be relative to the service working directory
+
+`file_contains`
+
+- required fields: `path`, `value`
+- `path` must be relative to the service working directory
+- `value` must be a non-empty string
+
+`file_not_contains`
+
+- required fields: `path`, `value`
+- `path` must be relative to the service working directory
+- `value` must be a non-empty string
+
+Path safety rules for all `file_*` conditions:
+
+- absolute paths are rejected
+- paths that escape the working directory through `..` are rejected
+
+## Invariants
+
+Invariants capture stdout at step start and require the same stdout at step completion.
+
+```yaml
+invariants:
+  - id: "test_file_stable"
+    command: "cat ${testFile}"
+```
+
+Rules:
+
+- Each invariant needs `id`.
+- Invariant IDs must be unique within the step.
+- Each invariant needs `command`.
+- Invariant commands must exit with code `0` during capture and verification.
+- Verification compares stdout exactly.
+
+Use invariants when a file, selector, or other derived output must remain unchanged for the duration of a step.
+
+## Nested Steps with `sub_steps`
+
+You can group steps hierarchically with `sub_steps`:
+
+```yaml
+execution:
+  - id: "implement"
+    sub_steps:
+      - id: "update_tests"
+        checks:
+          - id: "tests_changed"
+            command: "printf 'ok'"
+      - id: "update_code"
+        checks:
+          - id: "code_changed"
+            command: "printf 'ok'"
+```
+
+Behavior:
+
+- Centian compiles only leaf nodes into executable steps.
+- Leaf workflow paths are built from IDs:
+  - `execution.implement.update_tests`
+  - `execution.implement.update_code`
+- Step order follows leaf discovery order.
+
+Rules for nodes with `sub_steps`:
+
+- they cannot define `checks`
+- they cannot define `invariants`
+- they cannot define `next`
+- they cannot use `kind: waiting_for_approval`
+
+## Approval Wait Nodes
+
+You can insert manual approval pauses by using `kind: waiting_for_approval` inside `execution` or `scaffolding`.
+
+```yaml
+execution:
+  - id: "review_plan"
+    kind: "waiting_for_approval"
+    instructions: |
+      Wait for approval before implementation starts.
+    next: "execution.implement_fix"
+
+  - id: "implement_fix"
+    checks:
+      - id: "selected_test_passes"
+        command: "${testCommand} ${testTarget}"
+```
+
+Rules:
+
+- waiting nodes cannot define `checks`
+- waiting nodes cannot define `invariants`
+- a waiting node cannot be terminal; it must define or inherit a valid next step
+- active workflow paths for these nodes are under `waiting_for_approval.<id>`
+
+Step execution is not allowed while the run is parked in a waiting-for-approval node.
+
+## Transition Rules
+
+Centian wires transitions like this:
+
+- `onboarding` always moves to `planning`
+- `planning` moves to `planning.next` if set, otherwise to the first executable leaf node
+- each executable leaf node moves to its explicit `next` if set
+- otherwise each executable leaf node moves to the next compiled leaf node in order
+- the final executable leaf node completes the task if it has no next node
+
+Validation rules:
+
+- `next` must target an existing compiled node
+- `next` may target only `scaffolding`, `execution`, or `waiting_for_approval` nodes
+- a node cannot target itself
+- the workflow cannot contain cycles
+- every compiled node must be reachable from onboarding
+
+## Command Execution Model
+
+Template commands are executed as shell commands:
+
+- runtime shell: `/bin/sh -c`
+- working directory: the taskverification service working directory
+- default timeout per command: `30s`
+
+Important behavior:
+
+- a non-zero process exit does not automatically fail the check
+- Centian records the exit code and lets conditions decide whether that result passes
+- command execution failures are reserved for OS-level failures and timeouts
+
+Design commands and conditions together. If failure is expected, declare it with conditions instead of assuming the runtime will reject the command automatically.
+
+## Common Validation Failures
+
+These are the errors template authors hit most often:
+
+- missing required fields such as `task.id` or `workflow.execution`
+- duplicate template IDs across files
+- duplicate parameter names
+- parameter declared but never referenced by a placeholder
+- placeholder used but missing from `parameters`
+- unsupported `editable_fields` entry
+- unsupported `required_outputs` value
+- executable step with no checks
+- duplicate check or invariant IDs within a step
+- unsupported condition type
+- absolute or escaping paths in `file_*` conditions
+- `waiting_for_approval` node with no valid next target
+- explicit `next` pointing at an unknown node
+- workflow cycles or unreachable nodes
+
+## Authoring Recommendations
+
+- Keep step scope narrow. One verification intent per step is easier to debug.
+- Prefer `post_conditions` for outcome verification and `pre_conditions` for baseline verification.
+- Use `scaffolding` only for additive setup work.
+- Use `invariants` sparingly and only when the exact stdout comparison is meaningful.
+- Keep file-based conditions relative to the project working directory.
+- Use stable substrings in `stdout_contains` checks instead of brittle full-output matches.
+- If planning is expected to refine task inputs, list those specific parameter fields in `editable_fields`.
+- If a workflow needs a pause for human review, model it explicitly with `waiting_for_approval`.
+
+## A Larger Example
+
+```yaml
+version: "0.1"
+task:
+  id: "go_tdd_with_review"
+  name: "Go TDD With Review"
+  description: "Create a failing Go test, implement the fix, then pause for review."
+  instructions: |
+    Use the task runtime as the authoritative workflow.
+
+parameters:
+  - name: "testCommand"
+    description: "Go test command prefix, for example `go test ./... -run`."
+  - name: "testTarget"
+    description: "Concrete Go test selector."
+  - name: "testFile"
+    description: "Relative path to the Go test file."
+  - name: "expectedFailure"
+    description: "Stable failing output before the fix."
+  - name: "implementationTarget"
+    description: "Relative path to the implementation file."
+
+workflow:
+  onboarding:
+    instructions: |
+      Identify the package under test, test file, and implementation target.
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+
+  planning:
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+    editable_fields:
+      - "parameters.testCommand"
+      - "parameters.testTarget"
+      - "parameters.testFile"
+      - "parameters.expectedFailure"
+      - "parameters.implementationTarget"
+    required_outputs:
+      - "selectedFiles"
+      - "testTarget"
+      - "expectedFailure"
+      - "implementationTarget"
+
+  scaffolding:
+    - id: "create_test_file"
+      name: "Create test file"
+      checks:
+        - id: "test_file_created"
+          command: "printf 'test-file-created'"
+          pre_conditions:
+            - type: file_not_exists
+              path: "${testFile}"
+          post_conditions:
+            - type: file_exists
+              path: "${testFile}"
+
+  execution:
+    - id: "establish_failing_baseline"
+      name: "Establish failing baseline"
+      checks:
+        - id: "target_fails"
+          command: "${testCommand} ${testTarget}"
+          post_conditions:
+            - type: exit_code
+              value: 1
+            - type: stdout_contains
+              value: "${expectedFailure}"
+
+    - id: "implement_fix"
+      name: "Implement fix"
+      next: "waiting_for_approval.review_changes"
+      checks:
+        - id: "target_passes"
+          command: "${testCommand} ${testTarget}"
+          pre_conditions:
+            - type: exit_code
+              value: 1
+          post_conditions:
+            - type: exit_code
+              value: 0
+      invariants:
+        - id: "test_file_stable"
+          command: "cat ${testFile}"
+
+    - id: "review_changes"
+      kind: "waiting_for_approval"
+      instructions: |
+        Wait for review approval before any follow-up work.
+      next: "execution.final_verification"
+
+    - id: "final_verification"
+      name: "Final verification"
+      checks:
+        - id: "target_still_passes"
+          command: "${testCommand} ${testTarget}"
+          post_conditions:
+            - type: exit_code
+              value: 0
+        - id: "implementation_file_exists"
+          command: "printf 'check-file'"
+          post_conditions:
+            - type: file_exists
+              path: "${implementationTarget}"
+```
+
+## Validation Checklist
+
+Before using a new template, confirm:
+
+- the file is in the configured template directory
+- the file extension is `.yaml` or `.yml`
+- `task.id` is unique
+- every placeholder has a matching parameter definition
+- every declared parameter is actually used
+- planning outputs match what `centian.task_complete_planning` will provide
+- every executable leaf node has at least one check
+- every `file_*` condition path is relative
+- every `next` target exists and is reachable
+- no `waiting_for_approval` node is terminal
+
+If the template loads successfully through `centian.task_list_templates`, the structural validation pass has succeeded.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,8 +187,9 @@ type CapabilitiesSettings struct {
 
 // TaskVerificationCapabilitySettings controls taskverification capability behavior.
 type TaskVerificationCapabilitySettings struct {
-	Enabled       *bool  `json:"enabled,omitempty"`
-	TemplatesPath string `json:"templatesPath,omitempty"`
+	Enabled            *bool  `json:"enabled,omitempty"`
+	TemplatesPath      string `json:"templatesPath,omitempty"`
+	IdleTimeoutSeconds int    `json:"idleTimeoutSeconds,omitempty"`
 }
 
 // EventStorageCapabilitySettings controls durable storage for task and action events.
@@ -285,6 +286,14 @@ func (t *TaskVerificationCapabilitySettings) GetTemplatesPath() string {
 		return ""
 	}
 	return strings.TrimSpace(t.TemplatesPath)
+}
+
+// GetIdleTimeoutSeconds returns the configured task idle timeout in seconds.
+func (t *TaskVerificationCapabilitySettings) GetIdleTimeoutSeconds() int {
+	if t == nil || t.IdleTimeoutSeconds <= 0 {
+		return 0
+	}
+	return t.IdleTimeoutSeconds
 }
 
 // TaskVerificationCapability returns the configured taskverification capability block.

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -472,7 +472,7 @@ ORDER BY agg.started_at DESC, agg.task_run_id DESC
 			PrincipalID:      row.PrincipalID,
 			SessionID:        row.SessionID,
 			StartedAt:        row.StartedAt,
-			Status:           row.Status,
+			Status:           taskRunStatus(row.LatestEventType, row.LatestEventPayload, row.Status),
 			CurrentPhase:     row.CurrentPhase,
 			CurrentNodeKind:  row.CurrentNodeKind,
 			TaskEventCount:   row.TaskEventCount,
@@ -709,6 +709,33 @@ func isTerminalTaskEvent(eventType string, payload json.RawMessage) bool {
 	}
 	status, _ := body["status"].(string)
 	return status == string(taskverification.TaskStatusCompleted) || status == string(taskverification.TaskStatusFailed)
+}
+
+func taskRunStatus(eventType string, payload json.RawMessage, fallback string) string {
+	status := payloadTaskStatus(payload)
+	if status != "" {
+		return status
+	}
+	switch eventType {
+	case string(taskverification.TaskEventTypeFailed):
+		return string(taskverification.TaskStatusFailed)
+	case string(taskverification.TaskEventTypeTimedOut):
+		return string(taskverification.TaskStatusTimedOut)
+	}
+	return fallback
+}
+
+func payloadTaskStatus(payload json.RawMessage) string {
+	if len(payload) == 0 {
+		return ""
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(payload, &body); err != nil {
+		return ""
+	}
+	status, _ := body["status"].(string)
+	return status
 }
 
 func newActionEventRowID() string {

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -427,7 +427,7 @@ func TestListTaskRunsAggregatesSummaries(t *testing.T) {
 	assert.Equal(t, summaries[2].RunID, "run-active")
 
 	assert.Equal(t, summaries[0].TemplateID, "template-completed")
-	assert.Equal(t, summaries[0].Status, string(taskverification.TaskEventOutcomeSucceeded))
+	assert.Equal(t, summaries[0].Status, string(taskverification.TaskStatusCompleted))
 	assert.Equal(t, summaries[0].CurrentPhase, string(taskverification.TaskPhaseExecution))
 	assert.Equal(t, summaries[0].CurrentNodeKind, string(taskverification.WorkflowNodeKindExecution))
 	assert.Equal(t, summaries[0].TaskEventCount, 3)
@@ -436,18 +436,66 @@ func TestListTaskRunsAggregatesSummaries(t *testing.T) {
 	assert.Assert(t, summaries[0].EndedAt != nil)
 	assert.Equal(t, *summaries[0].EndedAt, int64(2_100))
 
-	assert.Equal(t, summaries[1].Status, string(taskverification.TaskEventOutcomeSucceeded))
+	assert.Equal(t, summaries[1].Status, string(taskverification.TaskStatusFailed))
 	assert.Equal(t, summaries[1].TaskEventCount, 2)
 	assert.Equal(t, summaries[1].ActionEventCount, 0)
 	assert.Assert(t, summaries[1].EndedAt != nil)
 	assert.Equal(t, *summaries[1].EndedAt, int64(1_800))
 
-	assert.Equal(t, summaries[2].Status, string(taskverification.TaskEventOutcomeSucceeded))
+	assert.Equal(t, summaries[2].Status, string(taskverification.TaskStatusActive))
 	assert.Equal(t, summaries[2].CurrentPhase, "execution.step_one")
 	assert.Equal(t, summaries[2].TaskEventCount, 2)
 	assert.Equal(t, summaries[2].ActionEventCount, 1)
 	assert.Equal(t, summaries[2].EventCount, 3)
 	assert.Assert(t, summaries[2].EndedAt == nil)
+}
+
+func TestListTaskRunsKeepsTimedOutRunsOpen(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "events.sqlite"))
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	seedTaskEvent(t, store, &taskverification.TaskEvent{
+		ID:                 "run-timeout-1",
+		SchemaVersion:      1,
+		CreatedAtUnixMilli: 1_000,
+		TaskRunID:          "run-timeout",
+		SessionID:          "session-timeout",
+		TemplateID:         "template-timeout",
+		PrincipalID:        "principal-timeout",
+		PhasePath:          taskverification.TaskPhasePlanning,
+		NodeKind:           taskverification.WorkflowNodeKindPlanning,
+		ResultingPhasePath: taskverification.TaskPhase("execution.step_one"),
+		ResultingNodeKind:  taskverification.WorkflowNodeKindExecution,
+		EventType:          taskverification.TaskEventTypePlanningCompleted,
+		Outcome:            taskverification.TaskEventOutcomeSucceeded,
+		Payload:            json.RawMessage(`{"status":"active"}`),
+	})
+	seedTaskEvent(t, store, &taskverification.TaskEvent{
+		ID:                 "run-timeout-2",
+		SchemaVersion:      1,
+		CreatedAtUnixMilli: 2_000,
+		TaskRunID:          "run-timeout",
+		SessionID:          "session-timeout",
+		TemplateID:         "template-timeout",
+		PrincipalID:        "principal-timeout",
+		PhasePath:          taskverification.TaskPhase("execution.step_one"),
+		NodeKind:           taskverification.WorkflowNodeKindExecution,
+		ResultingPhasePath: taskverification.TaskPhase("execution.step_one"),
+		ResultingNodeKind:  taskverification.WorkflowNodeKindExecution,
+		EventType:          taskverification.TaskEventTypeTimedOut,
+		Outcome:            taskverification.TaskEventOutcomeSucceeded,
+		Payload:            json.RawMessage(`{"status":"timed_out"}`),
+	})
+
+	summaries, err := store.ListTaskRuns(context.Background())
+	assert.NilError(t, err)
+	assert.Equal(t, len(summaries), 1)
+	assert.Equal(t, summaries[0].Status, string(taskverification.TaskStatusTimedOut))
+	assert.Equal(t, summaries[0].CurrentPhase, "execution.step_one")
+	assert.Assert(t, summaries[0].EndedAt == nil)
 }
 
 func TestGetTaskRunEventsReturnsUnifiedChronologicalTimeline(t *testing.T) {

--- a/internal/proxy/proxy_sessions.go
+++ b/internal/proxy/proxy_sessions.go
@@ -437,7 +437,17 @@ func (p *CentianEndpoint) Close() []error {
 		pools = append(pools, pool)
 		delete(p.downstreamPools, key)
 	}
+	sessions := make([]*UpstreamSession, 0, len(p.upstreamSessions))
+	for _, session := range p.upstreamSessions {
+		sessions = append(sessions, session)
+	}
 	p.mu.Unlock()
+
+	for _, session := range sessions {
+		session.taskMu.Lock()
+		p.cancelTaskTimeoutLocked(session)
+		session.taskMu.Unlock()
+	}
 
 	errs := make([]error, 0)
 	for _, pool := range pools {

--- a/internal/proxy/proxy_task_timeout.go
+++ b/internal/proxy/proxy_task_timeout.go
@@ -1,0 +1,125 @@
+package proxy
+
+import (
+	"time"
+
+	"github.com/T4cceptor/centian/internal/taskverification"
+)
+
+func (p *CentianEndpoint) taskIdleTimeout() time.Duration {
+	if p == nil || p.server == nil || p.server.Config == nil || p.server.Config.Proxy == nil {
+		return 0
+	}
+	seconds := p.server.Config.Proxy.TaskVerificationCapability().GetIdleTimeoutSeconds()
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func (p *CentianEndpoint) refreshTaskActivityLocked(session *UpstreamSession) {
+	if session == nil || session.taskRun == nil {
+		return
+	}
+	run := session.taskRun
+	timeout := p.taskIdleTimeout()
+	if run.Status != taskverification.TaskStatusActive || timeout <= 0 {
+		p.cancelTaskTimeoutLocked(session)
+		if timeout <= 0 {
+			run.LastActivityAt = 0
+		}
+		if run.Status != taskverification.TaskStatusTimedOut {
+			run.ExpiresAt = 0
+		}
+		return
+	}
+
+	now := time.Now().UTC()
+	run.LastActivityAt = now.UnixMilli()
+	run.ExpiresAt = now.Add(timeout).UnixMilli()
+	session.taskTimeoutVersion++
+	version := session.taskTimeoutVersion
+	runID := run.RunID
+	expiresAt := run.ExpiresAt
+	if session.taskTimeoutTimer != nil {
+		session.taskTimeoutTimer.Stop()
+	}
+	session.taskTimeoutTimer = time.AfterFunc(timeout, func() {
+		p.handleTaskIdleTimeout(session, runID, version, expiresAt)
+	})
+}
+
+func (p *CentianEndpoint) cancelTaskTimeoutLocked(session *UpstreamSession) {
+	if session == nil {
+		return
+	}
+	session.taskTimeoutVersion++
+	if session.taskTimeoutTimer != nil {
+		session.taskTimeoutTimer.Stop()
+		session.taskTimeoutTimer = nil
+	}
+}
+
+func (p *CentianEndpoint) maybeExpireActiveTaskLocked(session *UpstreamSession, relatedActionRequestID string) {
+	if p.taskIdleTimeout() <= 0 || session == nil || session.taskRun == nil {
+		return
+	}
+	run := session.taskRun
+	if run.Status != taskverification.TaskStatusActive || run.ExpiresAt == 0 || time.Now().UTC().UnixMilli() < run.ExpiresAt {
+		return
+	}
+	p.timeoutActiveTaskLocked(session, relatedActionRequestID)
+}
+
+func (p *CentianEndpoint) timeoutActiveTaskLocked(session *UpstreamSession, relatedActionRequestID string) {
+	if session == nil || session.taskRun == nil || p == nil || p.server == nil || p.server.TaskVerification == nil {
+		return
+	}
+	run := session.taskRun
+	if run.Status != taskverification.TaskStatusActive {
+		return
+	}
+
+	sourcePhase, sourceNodeKind := taskPhaseSnapshot(run)
+	if err := p.server.TaskVerification.TimeoutTask(run); err != nil {
+		return
+	}
+	session.taskTimeoutVersion++
+	if session.taskTimeoutTimer != nil {
+		session.taskTimeoutTimer.Stop()
+		session.taskTimeoutTimer = nil
+	}
+	resultingPhase, resultingNodeKind := taskPhaseSnapshot(run)
+	p.recordTaskEvent(
+		session,
+		run,
+		sourcePhase,
+		sourceNodeKind,
+		resultingPhase,
+		resultingNodeKind,
+		taskverification.TaskEventTypeTimedOut,
+		taskverification.TaskEventOutcomeSucceeded,
+		relatedActionRequestID,
+		map[string]any{"reason": "idle_timeout"},
+	)
+}
+
+func (p *CentianEndpoint) handleTaskIdleTimeout(session *UpstreamSession, runID string, version uint64, expiresAt int64) {
+	if session == nil {
+		return
+	}
+
+	session.taskMu.Lock()
+	defer session.taskMu.Unlock()
+
+	if session.taskTimeoutVersion != version || session.taskRun == nil {
+		return
+	}
+	if session.taskRun.RunID != runID || session.taskRun.Status != taskverification.TaskStatusActive {
+		return
+	}
+	if session.taskRun.ExpiresAt != expiresAt {
+		return
+	}
+	p.timeoutActiveTaskLocked(session, "")
+}

--- a/internal/proxy/proxy_taskverification_tools.go
+++ b/internal/proxy/proxy_taskverification_tools.go
@@ -285,7 +285,7 @@ func taskCompleteOnboardingSchema() map[string]any {
 			"onboarding": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"projectSummary": map[string]any{"type": "string"},
+					"taskSummary": map[string]any{"type": "string"},
 					"artifactMap": map[string]any{
 						"type": "array",
 						"items": map[string]any{
@@ -318,7 +318,7 @@ func taskCompleteOnboardingSchema() map[string]any {
 						"items": map[string]any{"type": "string"},
 					},
 				},
-				"required": []string{"projectSummary"},
+				"required": []string{"taskSummary"},
 			},
 		},
 		"required": []string{"onboarding"},
@@ -432,7 +432,7 @@ func (p *CentianEndpoint) handleTaskCompleteOnboardingTool(ctx context.Context, 
 	}
 	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeOnboardingCompleted, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), map[string]any{
-		"projectSummary": args.Onboarding.ProjectSummary,
+		"taskSummary": args.Onboarding.TaskSummary,
 	})
 	structured := runStructuredContent(session.taskRun)
 	if session.taskRun.Onboarding != nil {
@@ -707,7 +707,7 @@ func addPlanningNodeContext(structured map[string]any, run *taskverification.Run
 
 func addArtifactSummaries(structured map[string]any, run *taskverification.RunState) {
 	if run.Onboarding != nil {
-		structured["onboardingSummary"] = run.Onboarding.ProjectSummary
+		structured["taskSummary"] = run.Onboarding.TaskSummary
 	}
 	if run.Planning == nil {
 		return
@@ -743,7 +743,7 @@ func workflowStepsSummary(run *taskverification.RunState) []map[string]any {
 
 func onboardingContract() map[string]any {
 	return map[string]any{
-		"requiredFields": []string{"projectSummary"},
+		"requiredFields": []string{"taskSummary"},
 		"artifactMapItem": map[string]any{
 			"requiredFields": []string{"path", "kind"},
 			"optionalFields": []string{"notes"},

--- a/internal/proxy/proxy_taskverification_tools.go
+++ b/internal/proxy/proxy_taskverification_tools.go
@@ -19,6 +19,7 @@ const (
 	taskCompletePlanningTool   = "centian.task_complete_planning"
 	taskStartStepTool          = "centian.task_start_step"
 	taskCompleteStepTool       = "centian.task_complete_step"
+	taskResumeTool             = "centian.task_resume"
 	taskRestartTool            = "centian.task_restart"
 	taskFailTool               = "centian.task_fail"
 )
@@ -119,6 +120,16 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 	session.registeredStaticTools[taskCompleteStepTool] = struct{}{}
 
 	server.AddTool(&mcp.Tool{
+		Name:        taskResumeTool,
+		Description: "Resume a timed-out task verification run without resetting workflow progress.",
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	}, p.wrapTaskToolHandler(session, taskResumeTool, p.handleTaskResumeTool))
+	session.registeredStaticTools[taskResumeTool] = struct{}{}
+
+	server.AddTool(&mcp.Tool{
 		Name:        taskRestartTool,
 		Description: "Restart the active task verification run and clear step state.",
 		InputSchema: map[string]any{
@@ -150,7 +161,11 @@ func (p *CentianEndpoint) wrapTaskToolHandler(
 		requestID := getNewUUIDV7()
 		ctx = withTaskActionRequestID(ctx, requestID)
 		session.taskMu.Lock()
+		p.maybeExpireActiveTaskLocked(session, requestID)
 		invocationSnapshot := snapshotTaskRun(session.taskRun)
+		if invocationSnapshot.Status == taskverification.TaskStatusActive {
+			p.cancelTaskTimeoutLocked(session)
+		}
 		session.taskMu.Unlock()
 		var (
 			result *mcp.CallToolResult
@@ -163,7 +178,19 @@ func (p *CentianEndpoint) wrapTaskToolHandler(
 		}
 		p.logTaskToolCall(session, requestID, toolName, req, result, err)
 		session.taskMu.Lock()
+		switch {
+		case session.taskRun == nil:
+			p.cancelTaskTimeoutLocked(session)
+		case session.taskRun.Status == taskverification.TaskStatusActive:
+			p.refreshTaskActivityLocked(session)
+		default:
+			p.cancelTaskTimeoutLocked(session)
+			if session.taskRun.Status != taskverification.TaskStatusTimedOut {
+				session.taskRun.ExpiresAt = 0
+			}
+		}
 		currentSnapshot := snapshotTaskRun(session.taskRun)
+		addTaskTimingToToolResult(result, session.taskRun)
 		session.taskMu.Unlock()
 		if currentSnapshot.RunID != "" {
 			invocationPhase := invocationSnapshot.Phase
@@ -530,6 +557,22 @@ func (p *CentianEndpoint) handleTaskCompleteStepTool(ctx context.Context, sessio
 	return stepToolResult(result, session.taskRun), nil
 }
 
+func (p *CentianEndpoint) handleTaskResumeTool(ctx context.Context, session *UpstreamSession, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	session.taskMu.Lock()
+	defer session.taskMu.Unlock()
+
+	sourcePhase, sourceNodeKind := taskPhaseSnapshot(session.taskRun)
+	if err := p.server.TaskVerification.ResumeTask(session.taskRun); err != nil {
+		p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, sourcePhase, sourceNodeKind, taskverification.TaskEventTypeResumed, taskverification.TaskEventOutcomeFailed, taskActionRequestIDFromContext(ctx), map[string]any{
+			"error": err.Error(),
+		})
+		return nil, err
+	}
+	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
+	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeResumed, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
+	return toolResult("Task resumed.", runStructuredContent(session.taskRun)), nil
+}
+
 func (p *CentianEndpoint) handleTaskRestartTool(ctx context.Context, session *UpstreamSession, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	session.taskMu.Lock()
 	defer session.taskMu.Unlock()
@@ -651,6 +694,7 @@ func runStructuredContent(run *taskverification.RunState) map[string]any {
 		"lastFailureMessage": run.LastFailureMessage,
 		"explicitFailReason": run.ExplicitFailReason,
 	}
+	addTaskTimingFields(structured, run)
 	addTaskContracts(structured)
 	addCurrentNodeContext(structured, run)
 	addPlanningNodeContext(structured, run)
@@ -753,6 +797,29 @@ func onboardingContract() map[string]any {
 		},
 		"optionalFields": []string{"artifactMap", "commonCommands", "constraints", "openQuestions"},
 	}
+}
+
+func addTaskTimingFields(structured map[string]any, run *taskverification.RunState) {
+	if structured == nil || run == nil {
+		return
+	}
+	if run.LastActivityAt > 0 {
+		structured["lastActivityAtUnixMilli"] = run.LastActivityAt
+	}
+	if run.ExpiresAt > 0 {
+		structured["expiresAtUnixMilli"] = run.ExpiresAt
+	}
+}
+
+func addTaskTimingToToolResult(result *mcp.CallToolResult, run *taskverification.RunState) {
+	if result == nil {
+		return
+	}
+	structured, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		return
+	}
+	addTaskTimingFields(structured, run)
 }
 
 func planningContract() map[string]any {

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
@@ -22,6 +23,10 @@ func newTaskToolTestProxy(t *testing.T, templateContent string) (*CentianEndpoin
 }
 
 func newTaskToolTestProxyWithEnabled(t *testing.T, templateContent string, enabled bool) (*CentianEndpoint, *UpstreamSession) {
+	return newTaskToolTestProxyWithTimeout(t, templateContent, enabled, 0)
+}
+
+func newTaskToolTestProxyWithTimeout(t *testing.T, templateContent string, enabled bool, idleTimeoutSeconds int) (*CentianEndpoint, *UpstreamSession) {
 	t.Helper()
 
 	t.Setenv("HOME", t.TempDir())
@@ -47,7 +52,8 @@ func newTaskToolTestProxyWithEnabled(t *testing.T, templateContent string, enabl
 				Proxy: &config.ProxySettings{
 					Capabilities: &config.CapabilitiesSettings{
 						TaskVerification: &config.TaskVerificationCapabilitySettings{
-							Enabled: &taskVerificationEnabled,
+							Enabled:            &taskVerificationEnabled,
+							IdleTimeoutSeconds: idleTimeoutSeconds,
 						},
 					},
 				},
@@ -126,6 +132,28 @@ func attachTaskToolDownstream(
 	return conn
 }
 
+func waitForTaskStatus(t *testing.T, session *UpstreamSession, expected taskverification.TaskStatus, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		session.taskMu.Lock()
+		matches := session.taskRun != nil && session.taskRun.Status == expected
+		session.taskMu.Unlock()
+		if matches {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	session.taskMu.Lock()
+	defer session.taskMu.Unlock()
+	if session.taskRun == nil {
+		t.Fatalf("expected task status %s, but no task run was registered", expected)
+	}
+	t.Fatalf("expected task status %s, got %s", expected, session.taskRun.Status)
+}
+
 func TestNewUpstreamServerRegistersTaskVerificationTools(t *testing.T) {
 	_, session := newTaskToolTestProxy(t, basicTaskTemplate())
 
@@ -140,6 +168,7 @@ func TestNewUpstreamServerRegistersTaskVerificationTools(t *testing.T) {
 		taskListTemplatesTool,
 		taskRegisterTool,
 		taskRestartTool,
+		taskResumeTool,
 		taskStartStepTool,
 	})
 }
@@ -995,6 +1024,235 @@ func TestWorkflowNodeToolGovernanceAllowsMatchingTool(t *testing.T) {
 	assert.Assert(t, result != nil)
 	assert.Assert(t, !result.IsError)
 	assert.Equal(t, downstream.CapturedToolName, "shell__exec")
+}
+
+func TestWorkflowNodeToolGovernanceDeniesCompletedTask(t *testing.T) {
+	endpoint, session := newTaskToolTestProxy(t, basicTaskTemplate())
+	downstream := attachTaskToolDownstream(t, endpoint, session, "shell__exec")
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskRegisterTool,
+		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompleteOnboardingTool,
+		Arguments: map[string]any{"onboarding": map[string]any{"taskSummary": "Stored summary"}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompletePlanningTool,
+		Arguments: map[string]any{"planning": map[string]any{"testTarget": "pytest -q"}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskStartStepTool,
+		Arguments: map[string]any{"step": 1},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompleteStepTool,
+		Arguments: map[string]any{"step": 1},
+	})
+	assert.NilError(t, err)
+
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "shell__exec",
+		Arguments: map[string]any{"command": "pwd"},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.Assert(t, result.IsError)
+	structured := result.StructuredContent.(map[string]any)
+	assert.Equal(t, structured["reason"], governanceDeniedTaskCompleted)
+	assert.Equal(t, structured["status"], string(taskverification.TaskStatusCompleted))
+	assert.Assert(t, downstream.CapturedRequest == nil)
+}
+
+func TestWorkflowNodeToolGovernanceDeniesFailedTask(t *testing.T) {
+	endpoint, session := newTaskToolTestProxy(t, basicTaskTemplate())
+	downstream := attachTaskToolDownstream(t, endpoint, session, "shell__exec")
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskRegisterTool,
+		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskFailTool,
+		Arguments: map[string]any{"reason": "stuck"},
+	})
+	assert.NilError(t, err)
+
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "shell__exec",
+		Arguments: map[string]any{"command": "pwd"},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.Assert(t, result.IsError)
+	structured := result.StructuredContent.(map[string]any)
+	assert.Equal(t, structured["reason"], governanceDeniedTaskFailed)
+	assert.Equal(t, structured["status"], string(taskverification.TaskStatusFailed))
+	assert.Assert(t, downstream.CapturedRequest == nil)
+}
+
+func TestTaskIdleTimeoutDeniesDownstreamToolsAndRecordsEvent(t *testing.T) {
+	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, 1)
+	downstream := attachTaskToolDownstream(t, endpoint, session, "shell__exec")
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	registerResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskRegisterTool,
+		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+	})
+	assert.NilError(t, err)
+	registerStructured := registerResult.StructuredContent.(map[string]any)
+	assert.Assert(t, registerStructured["lastActivityAtUnixMilli"] != nil)
+	assert.Assert(t, registerStructured["expiresAtUnixMilli"] != nil)
+
+	waitForTaskStatus(t, session, taskverification.TaskStatusTimedOut, 2*time.Second)
+
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "shell__exec",
+		Arguments: map[string]any{"command": "pwd"},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.Assert(t, result.IsError)
+	structured := result.StructuredContent.(map[string]any)
+	assert.Equal(t, structured["reason"], governanceDeniedTaskTimedOut)
+	assert.Equal(t, structured["status"], string(taskverification.TaskStatusTimedOut))
+	assert.Assert(t, downstream.CapturedRequest == nil)
+
+	events, err := endpoint.server.TaskVerification.TaskEvents()
+	assert.NilError(t, err)
+	assert.Equal(t, events[len(events)-1].EventType, taskverification.TaskEventTypeTimedOut)
+	timeoutEvents := 0
+	for _, event := range events {
+		if event.EventType == taskverification.TaskEventTypeTimedOut {
+			timeoutEvents++
+		}
+	}
+	assert.Equal(t, timeoutEvents, 1)
+}
+
+func TestTaskActivityRefreshesIdleTimeoutForTaskAndDownstreamCalls(t *testing.T) {
+	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, 1)
+	attachTaskToolDownstream(t, endpoint, session, "shell__exec")
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskRegisterTool,
+		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+	})
+	assert.NilError(t, err)
+
+	time.Sleep(400 * time.Millisecond)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskListTemplatesTool,
+		Arguments: map[string]any{},
+	})
+	assert.NilError(t, err)
+
+	time.Sleep(700 * time.Millisecond)
+	session.taskMu.Lock()
+	assert.Equal(t, session.taskRun.Status, taskverification.TaskStatusActive)
+	session.taskMu.Unlock()
+
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "shell__exec",
+		Arguments: map[string]any{"command": "pwd"},
+	})
+	assert.NilError(t, err)
+
+	time.Sleep(700 * time.Millisecond)
+	session.taskMu.Lock()
+	assert.Equal(t, session.taskRun.Status, taskverification.TaskStatusActive)
+	session.taskMu.Unlock()
+
+	waitForTaskStatus(t, session, taskverification.TaskStatusTimedOut, 1500*time.Millisecond)
+}
+
+func TestTaskResumeRequiresTimedOutRunAndPreservesWorkflowProgress(t *testing.T) {
+	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, 1)
+	downstream := attachTaskToolDownstream(t, endpoint, session, "shell__exec")
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskRegisterTool,
+		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompleteOnboardingTool,
+		Arguments: map[string]any{"onboarding": map[string]any{"taskSummary": "Stored summary"}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompletePlanningTool,
+		Arguments: map[string]any{"planning": map[string]any{"testTarget": "pytest -q"}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskStartStepTool,
+		Arguments: map[string]any{"step": 1},
+	})
+	assert.NilError(t, err)
+
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskResumeTool,
+		Arguments: map[string]any{},
+	})
+	assert.ErrorContains(t, err, "task is active")
+
+	waitForTaskStatus(t, session, taskverification.TaskStatusTimedOut, 2*time.Second)
+
+	session.taskMu.Lock()
+	assert.Equal(t, session.taskRun.Phase, taskverification.TaskPhase("execution.step_one"))
+	assert.Equal(t, session.taskRun.Steps[0].Status, taskverification.StepStatusActive)
+	session.taskMu.Unlock()
+
+	resumeResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskResumeTool,
+		Arguments: map[string]any{},
+	})
+	assert.NilError(t, err)
+	resumeStructured := resumeResult.StructuredContent.(map[string]any)
+	assert.Equal(t, resumeStructured["status"], string(taskverification.TaskStatusActive))
+	assert.Equal(t, resumeStructured["phase"], "execution.step_one")
+	assert.Assert(t, resumeStructured["lastActivityAtUnixMilli"] != nil)
+	assert.Assert(t, resumeStructured["expiresAtUnixMilli"] != nil)
+
+	session.taskMu.Lock()
+	assert.Equal(t, session.taskRun.Steps[0].Status, taskverification.StepStatusActive)
+	session.taskMu.Unlock()
+
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "shell__exec",
+		Arguments: map[string]any{"command": "pwd"},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.Assert(t, !result.IsError)
+	assert.Equal(t, downstream.CapturedToolName, "shell__exec")
+
+	events, err := endpoint.server.TaskVerification.TaskEvents()
+	assert.NilError(t, err)
+	assert.Equal(t, events[len(events)-2].EventType, taskverification.TaskEventTypeTimedOut)
+	assert.Equal(t, events[len(events)-1].EventType, taskverification.TaskEventTypeResumed)
 }
 
 func TestTaskLifecycleToolsRequireRegistrationFirst(t *testing.T) {

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -177,7 +177,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
 			"onboarding": map[string]any{
-				"projectSummary": "Small test project with one shell validation path.",
+				"taskSummary": "Small test task context with one shell validation path.",
 				"artifactMap": []map[string]any{
 					{
 						"path":  "/workspace/project/tests",
@@ -207,7 +207,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.DeepEqual(t, completeOnboardingStructured["planningRequiredOutputs"], []any{"testTarget"})
 	assert.Equal(t, completeOnboardingStructured["shellCommandHint"], "For compound shell commands or directory changes, use bash -lc '...'.")
 	assert.Equal(t, completeOnboardingStructured["hasOnboarding"], true)
-	assert.Equal(t, completeOnboardingStructured["onboardingSummary"], "Small test project with one shell validation path.")
+	assert.Equal(t, completeOnboardingStructured["taskSummary"], "Small test task context with one shell validation path.")
 	assert.DeepEqual(t, completeOnboardingStructured["allowedTools"], []any{"shell__*", "filesystem__*"})
 	assert.Assert(t, completeOnboardingStructured["onboarding"] != nil)
 	assert.Equal(t, completeOnboardingStructured["hasPlanning"], false)
@@ -276,7 +276,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, restartStructured["currentNodeKind"], string(taskverification.WorkflowNodeKindOnboarding))
 	assert.Equal(t, restartStructured["hasOnboarding"], true)
 	assert.Equal(t, restartStructured["hasPlanning"], false)
-	assert.Equal(t, restartStructured["onboardingSummary"], "Small test project with one shell validation path.")
+	assert.Equal(t, restartStructured["taskSummary"], "Small test task context with one shell validation path.")
 
 	failResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskFailTool,
@@ -323,7 +323,7 @@ func TestTaskToolFlowAllowsNoCheckTemplate(t *testing.T) {
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
 			"onboarding": map[string]any{
-				"projectSummary": "Minimal free-form task.",
+				"taskSummary": "Minimal free-form task.",
 			},
 		},
 	})
@@ -383,7 +383,7 @@ func TestTaskVerificationToolSchemasExposeNestedArtifacts(t *testing.T) {
 
 	onboardingSchema := byName[taskCompleteOnboardingTool].InputSchema.(map[string]any)
 	onboardingProps := onboardingSchema["properties"].(map[string]any)["onboarding"].(map[string]any)["properties"].(map[string]any)
-	assert.Assert(t, onboardingProps["projectSummary"] != nil)
+	assert.Assert(t, onboardingProps["taskSummary"] != nil)
 	artifactMapItems := onboardingProps["artifactMap"].(map[string]any)["items"].(map[string]any)
 	assert.DeepEqual(t, artifactMapItems["required"], []any{"path", "kind"})
 	commonCommandItems := onboardingProps["commonCommands"].(map[string]any)["items"].(map[string]any)
@@ -421,7 +421,7 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
 			"onboarding": map[string]any{
-				"projectSummary": "Small project with parameterized planning fields.",
+				"taskSummary": "Small task context with parameterized planning fields.",
 			},
 		},
 	})
@@ -475,7 +475,7 @@ func TestTaskLifecycleEventsRecorded(t *testing.T) {
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
-			"onboarding": map[string]any{"projectSummary": "Stored summary"},
+			"onboarding": map[string]any{"taskSummary": "Stored summary"},
 		},
 	})
 	assert.NilError(t, err)
@@ -590,7 +590,7 @@ workflow:
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
-			"onboarding": map[string]any{"projectSummary": "Stored summary"},
+			"onboarding": map[string]any{"taskSummary": "Stored summary"},
 		},
 	})
 	assert.NilError(t, err)
@@ -627,7 +627,7 @@ func TestActionEventTaskContextCreatedForBuiltInTaskTools(t *testing.T) {
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
-			"onboarding": map[string]any{"projectSummary": "Stored summary"},
+			"onboarding": map[string]any{"taskSummary": "Stored summary"},
 		},
 	})
 	assert.NilError(t, err)
@@ -714,7 +714,7 @@ func TestTaskToolCallsPersistToSQLiteActionAndTaskStores(t *testing.T) {
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
-			"onboarding": map[string]any{"projectSummary": "Stored summary"},
+			"onboarding": map[string]any{"taskSummary": "Stored summary"},
 		},
 	})
 	assert.NilError(t, err)
@@ -825,7 +825,7 @@ workflow:
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
 			"onboarding": map[string]any{
-				"projectSummary": "Stored summary",
+				"taskSummary": "Stored summary",
 			},
 		},
 	})
@@ -938,7 +938,7 @@ workflow:
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
-			"onboarding": map[string]any{"projectSummary": "Stored summary"},
+			"onboarding": map[string]any{"taskSummary": "Stored summary"},
 		},
 	})
 	assert.NilError(t, err)
@@ -1006,7 +1006,7 @@ func TestTaskLifecycleToolsRequireRegistrationFirst(t *testing.T) {
 	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
-			"onboarding": map[string]any{"projectSummary": "blocked"},
+			"onboarding": map[string]any{"taskSummary": "blocked"},
 		},
 	})
 	assert.NilError(t, err)
@@ -1168,7 +1168,7 @@ workflow:
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
-			"onboarding": map[string]any{"projectSummary": "Stored summary"},
+			"onboarding": map[string]any{"taskSummary": "Stored summary"},
 		},
 	})
 	assert.NilError(t, err)
@@ -1235,7 +1235,7 @@ workflow:
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
-			"onboarding": map[string]any{"projectSummary": "Stored summary"},
+			"onboarding": map[string]any{"taskSummary": "Stored summary"},
 		},
 	})
 	assert.NilError(t, err)
@@ -1291,7 +1291,7 @@ func TestTaskToolCallsAreWrittenToRequestLog(t *testing.T) {
 		Name: taskCompleteOnboardingTool,
 		Arguments: map[string]any{
 			"onboarding": map[string]any{
-				"projectSummary": "Stored summary",
+				"taskSummary": "Stored summary",
 			},
 		},
 	})

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -291,6 +291,79 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, failStructured["phase"], string(taskverification.TaskPhaseOnboarding))
 }
 
+func TestTaskToolFlowAllowsNoCheckTemplate(t *testing.T) {
+	_, session := newTaskToolTestProxy(t, noCheckTaskTemplate())
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	listResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{Name: taskListTemplatesTool})
+	assert.NilError(t, err)
+	listStructured := listResult.StructuredContent.(map[string]any)
+	templates := listStructured["templates"].([]any)
+	assert.Equal(t, len(templates), 1)
+	template := templates[0].(map[string]any)
+	assert.Equal(t, template["id"], "minimal")
+
+	registerResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskRegisterTool,
+		Arguments: map[string]any{
+			"templateId": "minimal",
+			"parameters": map[string]any{
+				"taskName": "Investigate issue",
+			},
+		},
+	})
+	assert.NilError(t, err)
+	registerStructured := registerResult.StructuredContent.(map[string]any)
+	assert.Equal(t, registerStructured["phase"], string(taskverification.TaskPhaseOnboarding))
+	assertAllowedTools(t, registerStructured["allowedTools"], "*")
+
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskCompleteOnboardingTool,
+		Arguments: map[string]any{
+			"onboarding": map[string]any{
+				"projectSummary": "Minimal free-form task.",
+			},
+		},
+	})
+	assert.NilError(t, err)
+
+	completePlanningResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskCompletePlanningTool,
+		Arguments: map[string]any{
+			"planning": map[string]any{},
+		},
+	})
+	assert.NilError(t, err)
+	completePlanningStructured := completePlanningResult.StructuredContent.(map[string]any)
+	assertAllowedTools(t, completePlanningStructured["allowedTools"], "*")
+	assert.Equal(t, completePlanningStructured["executionReady"], true)
+
+	startStepResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskStartStepTool,
+		Arguments: map[string]any{
+			"step": 1,
+		},
+	})
+	assert.NilError(t, err)
+	startStepStructured := startStepResult.StructuredContent.(map[string]any)
+	assert.Equal(t, startStepStructured["passed"], true)
+	assert.Equal(t, startStepStructured["stepStatus"], string(taskverification.StepStatusActive))
+
+	completeStepResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskCompleteStepTool,
+		Arguments: map[string]any{
+			"step": 1,
+		},
+	})
+	assert.NilError(t, err)
+	completeStepStructured := completeStepResult.StructuredContent.(map[string]any)
+	assert.Equal(t, completeStepStructured["passed"], true)
+	assert.Equal(t, completeStepStructured["status"], string(taskverification.TaskStatusCompleted))
+	assert.Equal(t, completeStepStructured["stepStatus"], string(taskverification.StepStatusPassed))
+}
+
 func TestTaskVerificationToolSchemasExposeNestedArtifacts(t *testing.T) {
 	_, session := newTaskToolTestProxy(t, basicTaskTemplate())
 
@@ -1319,6 +1392,44 @@ workflow:
             - type: stdout_contains
               value: "pytest:boom"
 `
+}
+
+func noCheckTaskTemplate() string {
+	return `
+version: "0.1"
+task:
+  id: "minimal"
+  name: "Minimal"
+  description: "Smallest task template that still allows work."
+parameters:
+  - name: "taskName"
+    description: "Human-readable task name."
+workflow:
+  onboarding:
+    tools_allowed: ["*"]
+  planning:
+    tools_allowed: ["*"]
+  execution:
+    - id: "Task ${taskName}"
+      tools_allowed: ["*"]
+`
+}
+
+func assertAllowedTools(t *testing.T, value any, expected ...string) {
+	t.Helper()
+
+	switch typed := value.(type) {
+	case []string:
+		assert.DeepEqual(t, typed, expected)
+	case []any:
+		actual := make([]string, 0, len(typed))
+		for _, item := range typed {
+			actual = append(actual, item.(string))
+		}
+		assert.DeepEqual(t, actual, expected)
+	default:
+		t.Fatalf("unexpected allowedTools type %T", value)
+	}
 }
 
 func readTaskToolLogEntries(t *testing.T, path string) []common.LogEntry {

--- a/internal/proxy/proxy_tool_governance.go
+++ b/internal/proxy/proxy_tool_governance.go
@@ -14,6 +14,9 @@ const (
 	governanceDeniedNoAllowlist        = "no_allowlist"
 	governanceDeniedNoPatternMatch     = "no_matching_pattern"
 	governanceDeniedRegistrationNeeded = "registration_required"
+	governanceDeniedTaskCompleted      = "task_completed"
+	governanceDeniedTaskFailed         = "task_failed"
+	governanceDeniedTaskTimedOut       = "task_timed_out"
 )
 
 func (p *CentianEndpoint) enforceWorkflowNodeToolGovernance(session *UpstreamSession, callCtx CallContext) (*mcp.CallToolResult, bool) {
@@ -27,28 +30,28 @@ func (p *CentianEndpoint) enforceWorkflowNodeToolGovernance(session *UpstreamSes
 	run := session.taskRun
 	if run == nil {
 		if p.server != nil && p.server.Config != nil && p.server.Config.Proxy.TaskVerificationEnabled() {
-			return p.governanceDeniedResult(callCtx, "", "", nil, governanceDeniedRegistrationNeeded), true
+			return p.governanceDeniedResult(callCtx, "", "", "", nil, governanceDeniedRegistrationNeeded), true
 		}
 		return nil, false
 	}
 	if run.Status != taskverification.TaskStatusActive {
-		return nil, false
+		return p.governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, governanceReasonForTaskStatus(run.Status)), true
 	}
 
 	node, exists := run.CurrentNode()
 	if !exists {
-		return p.governanceDeniedResult(callCtx, run.Phase, "", nil, "unknown_workflow_node"), true
+		return p.governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, "unknown_workflow_node"), true
 	}
 	if node.Kind == taskverification.WorkflowNodeKindWaitingForApproval {
-		return p.governanceDeniedResult(callCtx, run.Phase, node.Kind, node.AllowedTools, governanceDeniedWaitingForApproval), true
+		return p.governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedWaitingForApproval), true
 	}
 	if len(node.AllowedTools) == 0 {
-		return p.governanceDeniedResult(callCtx, run.Phase, node.Kind, node.AllowedTools, governanceDeniedNoAllowlist), true
+		return p.governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoAllowlist), true
 	}
 	if matchesAllowedTool(node.AllowedTools, callCtx.GetOriginalToolName(), callCtx.GetToolName()) {
 		return nil, false
 	}
-	return p.governanceDeniedResult(callCtx, run.Phase, node.Kind, node.AllowedTools, governanceDeniedNoPatternMatch), true
+	return p.governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoPatternMatch), true
 }
 
 func matchesAllowedTool(patterns []string, upstreamName, canonicalName string) bool {
@@ -69,6 +72,7 @@ func matchesAllowedTool(patterns []string, upstreamName, canonicalName string) b
 func (p *CentianEndpoint) governanceDeniedResult(
 	callCtx CallContext,
 	phase taskverification.TaskPhase,
+	status taskverification.TaskStatus,
 	nodeKind taskverification.WorkflowNodeKind,
 	allowedTools []string,
 	reason string,
@@ -106,6 +110,7 @@ func (p *CentianEndpoint) governanceDeniedResult(
 		StructuredContent: map[string]any{
 			"error":           message,
 			"requestedTool":   requestedTool,
+			"status":          string(status),
 			"phase":           string(phase),
 			"currentNodeKind": string(nodeKind),
 			"reason":          reason,
@@ -125,4 +130,17 @@ func (p *CentianEndpoint) governanceDeniedResult(
 	}
 
 	return result
+}
+
+func governanceReasonForTaskStatus(status taskverification.TaskStatus) string {
+	switch status {
+	case taskverification.TaskStatusCompleted:
+		return governanceDeniedTaskCompleted
+	case taskverification.TaskStatusFailed:
+		return governanceDeniedTaskFailed
+	case taskverification.TaskStatusTimedOut:
+		return governanceDeniedTaskTimedOut
+	default:
+		return governanceDeniedRegistrationNeeded
+	}
 }

--- a/internal/proxy/proxy_tools.go
+++ b/internal/proxy/proxy_tools.go
@@ -263,11 +263,30 @@ func (p *CentianEndpoint) handleToolCall(ctx context.Context, session *UpstreamS
 	ctx = WithCallContext(ctx, callCtx)
 	common.LogInfo("Tool called: %s :: %s", callCtx.GetServerName(), callCtx.GetToolName())
 	session.taskMu.Lock()
+	p.maybeExpireActiveTaskLocked(session, callCtx.GetRequestID())
 	activeRun := snapshotTaskRun(session.taskRun)
+	if activeRun.Status == taskverification.TaskStatusActive {
+		p.cancelTaskTimeoutLocked(session)
+	}
 	session.taskMu.Unlock()
 	if activeRun.Status == taskverification.TaskStatusActive {
 		p.recordTaskActionContext(activeRun.RunID, callCtx.GetRequestID(), activeRun.Phase, activeRun.NodeKind)
 	}
+	defer func() {
+		session.taskMu.Lock()
+		defer session.taskMu.Unlock()
+		switch {
+		case session.taskRun == nil:
+			p.cancelTaskTimeoutLocked(session)
+		case session.taskRun.Status == taskverification.TaskStatusActive:
+			p.refreshTaskActivityLocked(session)
+		default:
+			p.cancelTaskTimeoutLocked(session)
+			if session.taskRun.Status != taskverification.TaskStatusTimedOut {
+				session.taskRun.ExpiresAt = 0
+			}
+		}
+	}()
 	if denied, blocked := p.enforceWorkflowNodeToolGovernance(session, callCtx); blocked {
 		return denied, nil
 	}

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -70,6 +70,9 @@ type UpstreamSession struct {
 
 	taskMu  sync.Mutex
 	taskRun *taskverification.RunState
+
+	taskTimeoutTimer   *time.Timer
+	taskTimeoutVersion uint64
 }
 
 // DownstreamSessionPool owns the reusable downstream connection set for one downstream session key.

--- a/internal/taskverification/runtime.go
+++ b/internal/taskverification/runtime.go
@@ -106,6 +106,7 @@ func completeWorkflowStep(run *RunState, stepIndex int, step *Step) *StepResult 
 	message := fmt.Sprintf("step %d (%s) completed", stepIndex+1, step.ID)
 	if step.NextPath == "" {
 		run.Status = TaskStatusCompleted
+		run.ExpiresAt = 0
 		message = fmt.Sprintf("%s; task completed", message)
 	} else {
 		run.Phase = step.NextPath
@@ -167,6 +168,8 @@ func validateTaskExecutable(run *RunState) error {
 		return fmt.Errorf("task is already completed")
 	case TaskStatusFailed:
 		return fmt.Errorf("task is failed; restart or register a new task")
+	case TaskStatusTimedOut:
+		return fmt.Errorf("task is timed out; resume or restart the task")
 	default:
 		return fmt.Errorf("task is %s", run.Status)
 	}

--- a/internal/taskverification/runtime_test.go
+++ b/internal/taskverification/runtime_test.go
@@ -283,7 +283,7 @@ workflow:
           command: "printf 'ok'"
 `)
 
-	err := service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready to plan"})
+	err := service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready to plan"})
 	assert.NilError(t, err)
 
 	_, err = service.StartStep(context.Background(), run, 1)
@@ -517,7 +517,7 @@ workflow:
 	assert.NilError(t, err)
 	assert.Equal(t, run.Status, TaskStatusFailed)
 
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.ErrorContains(t, err, "task is failed")
 
 	err = service.RestartTask(run)
@@ -582,7 +582,7 @@ func newRuntimeTestService(t *testing.T, content string) (*Service, *RunState) {
 	service := NewService(dir, dir)
 	run, err := service.RegisterTask("task", map[string]string{})
 	assert.NilError(t, err)
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 	err = service.CompletePlanning(run, &PlanningArtifact{
 		TestTarget: "pytest -q",

--- a/internal/taskverification/runtime_test.go
+++ b/internal/taskverification/runtime_test.go
@@ -65,6 +65,84 @@ func TestStartAndCompleteStepHappyPath(t *testing.T) {
 	assert.Equal(t, run.Steps[0].Status, StepStatusPassed)
 }
 
+func TestStartAndCompleteStepWithoutChecksOrInvariants(t *testing.T) {
+	dir := t.TempDir()
+	template := mustCompileRuntimeTemplate(t, &Template{
+		Version: "0.1",
+		Task: Task{
+			ID:          "task",
+			Name:        "Task",
+			Description: "desc",
+		},
+		Workflow: &Workflow{
+			Onboarding: &LifecycleNodeSpec{},
+			Planning:   &PlanningNodeSpec{},
+			Execution: []ExecutionNodeSpec{
+				{
+					ID: "step_one",
+				},
+			},
+		},
+	})
+	service := NewService(dir, dir)
+	run := newWorkflowReadyRun(&template)
+
+	start, err := service.StartStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, start.Passed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
+
+	complete, err := service.CompleteStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, complete.Passed)
+	assert.Equal(t, run.Status, TaskStatusCompleted)
+	assert.Equal(t, run.Steps[0].Status, StepStatusPassed)
+}
+
+func TestStepWithoutChecksStillVerifiesInvariantDrift(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "state.txt")
+	err := os.WriteFile(stateFile, []byte("before"), 0o644)
+	assert.NilError(t, err)
+
+	template := mustCompileRuntimeTemplate(t, &Template{
+		Version: "0.1",
+		Task: Task{
+			ID:          "task",
+			Name:        "Task",
+			Description: "desc",
+		},
+		Workflow: &Workflow{
+			Onboarding: &LifecycleNodeSpec{},
+			Planning:   &PlanningNodeSpec{},
+			Execution: []ExecutionNodeSpec{
+				{
+					ID: "step_one",
+					Invariants: []Invariant{
+						{ID: "stable_file", Command: "cat state.txt"},
+					},
+				},
+			},
+		},
+	})
+	service := NewService(dir, dir)
+	run := newWorkflowReadyRun(&template)
+
+	_, err = service.StartStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	err = os.WriteFile(stateFile, []byte("after"), 0o644)
+	assert.NilError(t, err)
+
+	result, err := service.CompleteStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, !result.Passed)
+	assert.Equal(t, result.FailureKind, StepFailureKindInvariant)
+	assert.Equal(t, result.FailurePhase, StepFailurePhaseInvariantVerify)
+	assert.Equal(t, result.FailedInvariantID, "stable_file")
+	assert.Assert(t, strings.Contains(result.StdoutSnippet, "after"))
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
+}
+
 func TestStartStepFailsPreconditions(t *testing.T) {
 	service, run := newRuntimeTestService(t, `
 version: "0.1"

--- a/internal/taskverification/templates.go
+++ b/internal/taskverification/templates.go
@@ -106,7 +106,11 @@ func (s *Service) CompletePlanning(run *RunState, artifact *PlanningArtifact) er
 	if err != nil {
 		return err
 	}
-	nextPath := run.SelectedTemplate.CompiledWorkflow.Nodes[TaskPhasePlanning].NextPath
+	planningNode, exists := resolved.CompiledWorkflow.Nodes[resolved.CompiledWorkflow.PlanningPath]
+	if !exists {
+		return fmt.Errorf("planning has no compiled workflow node")
+	}
+	nextPath := planningNode.NextPath
 	if nextPath == "" {
 		return fmt.Errorf("planning has no configured next workflow node")
 	}
@@ -328,9 +332,6 @@ func validateStep(stepIndex int, step *Step, stepIDs map[string]struct{}) error 
 		return fmt.Errorf("duplicate step id %q", step.ID)
 	}
 	stepIDs[step.ID] = struct{}{}
-	if len(step.Checks) == 0 {
-		return fmt.Errorf("step %q must define at least one check", step.ID)
-	}
 
 	if err := validateChecks(step); err != nil {
 		return err

--- a/internal/taskverification/templates.go
+++ b/internal/taskverification/templates.go
@@ -141,6 +141,8 @@ func (s *Service) RestartTask(run *RunState) error {
 	run.Steps = nil
 	run.LastFailureMessage = ""
 	run.ExplicitFailReason = ""
+	run.LastActivityAt = 0
+	run.ExpiresAt = 0
 	return nil
 }
 
@@ -153,6 +155,35 @@ func (s *Service) FailTask(run *RunState, reason string) error {
 	run.Status = TaskStatusFailed
 	run.ExplicitFailReason = strings.TrimSpace(reason)
 	run.LastFailureMessage = run.ExplicitFailReason
+	run.ExpiresAt = 0
+	return nil
+}
+
+// TimeoutTask marks an active task run as timed out without changing its phase or steps.
+func (s *Service) TimeoutTask(run *RunState) error {
+	if run == nil {
+		return fmt.Errorf("task is not registered")
+	}
+	if run.Status != TaskStatusActive {
+		return fmt.Errorf("task is %s", run.Status)
+	}
+
+	run.Status = TaskStatusTimedOut
+	return nil
+}
+
+// ResumeTask reactivates a timed-out task run without resetting its workflow progress.
+func (s *Service) ResumeTask(run *RunState) error {
+	if run == nil {
+		return fmt.Errorf("task is not registered")
+	}
+	if run.Status != TaskStatusTimedOut {
+		return fmt.Errorf("task is %s", run.Status)
+	}
+
+	run.Status = TaskStatusActive
+	run.LastFailureMessage = ""
+	run.ExpiresAt = 0
 	return nil
 }
 
@@ -620,6 +651,8 @@ func transitionTaskPhase(run *RunState, next TaskPhase, allowed ...TaskPhase) er
 		return fmt.Errorf("task is already completed")
 	case TaskStatusFailed:
 		return fmt.Errorf("task is failed; restart or register a new task")
+	case TaskStatusTimedOut:
+		return fmt.Errorf("task is timed out; resume or restart the task")
 	default:
 		return fmt.Errorf("task is %s", run.Status)
 	}

--- a/internal/taskverification/templates.go
+++ b/internal/taskverification/templates.go
@@ -651,8 +651,8 @@ func validateOnboardingArtifact(artifact *OnboardingArtifact) error {
 	if artifact == nil {
 		return fmt.Errorf("onboarding artifact is required")
 	}
-	if strings.TrimSpace(artifact.ProjectSummary) == "" {
-		return fmt.Errorf("onboarding.projectSummary is required")
+	if strings.TrimSpace(artifact.TaskSummary) == "" {
+		return fmt.Errorf("onboarding.taskSummary is required")
 	}
 	for index, ref := range artifact.ArtifactMap {
 		if strings.TrimSpace(ref.Path) == "" {
@@ -678,9 +678,9 @@ func cloneOnboardingArtifact(artifact *OnboardingArtifact) OnboardingArtifact {
 		return OnboardingArtifact{}
 	}
 	cloned := OnboardingArtifact{
-		ProjectSummary: artifact.ProjectSummary,
-		Constraints:    append([]string(nil), artifact.Constraints...),
-		OpenQuestions:  append([]string(nil), artifact.OpenQuestions...),
+		TaskSummary:   artifact.TaskSummary,
+		Constraints:   append([]string(nil), artifact.Constraints...),
+		OpenQuestions: append([]string(nil), artifact.OpenQuestions...),
 	}
 	if len(artifact.ArtifactMap) > 0 {
 		cloned.ArtifactMap = make([]OnboardingArtifactRef, len(artifact.ArtifactMap))

--- a/internal/taskverification/templates_test.go
+++ b/internal/taskverification/templates_test.go
@@ -86,6 +86,47 @@ workflow:
 	assert.ErrorContains(t, err, `unknown task parameter "unknown"`)
 }
 
+func TestTimeoutAndResumeTaskPreserveWorkflowState(t *testing.T) {
+	service := newTemplateTestService(t, `
+version: "0.1"
+task:
+  id: "simple_tdd"
+  name: "Simple TDD"
+  description: "Test driven task"
+workflow:
+  onboarding: {}
+  planning: {}
+  execution:
+    - id: "step_one"
+`, "simple_tdd.yaml")
+
+	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	assert.NilError(t, err)
+	run.Phase = TaskPhase("execution.step_one")
+	run.WorkflowReady = true
+	run.Steps = []StepState{{
+		ID:                 "step_one",
+		Path:               TaskPhase("execution.step_one"),
+		Status:             StepStatusActive,
+		InvariantBaselines: map[string]string{},
+	}}
+	run.LastActivityAt = 123
+	run.ExpiresAt = 456
+
+	err = service.TimeoutTask(run)
+	assert.NilError(t, err)
+	assert.Equal(t, run.Status, TaskStatusTimedOut)
+	assert.Equal(t, run.Phase, TaskPhase("execution.step_one"))
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
+
+	err = service.ResumeTask(run)
+	assert.NilError(t, err)
+	assert.Equal(t, run.Status, TaskStatusActive)
+	assert.Equal(t, run.Phase, TaskPhase("execution.step_one"))
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
+	assert.Equal(t, run.ExpiresAt, int64(0))
+}
+
 func TestListTemplatesAllowsExecutionStepWithoutChecks(t *testing.T) {
 	service := newTemplateTestService(t, `
 version: "0.1"

--- a/internal/taskverification/templates_test.go
+++ b/internal/taskverification/templates_test.go
@@ -163,7 +163,7 @@ workflow:
 	})
 	assert.NilError(t, err)
 
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
 	err = service.CompletePlanning(run, &PlanningArtifact{
@@ -200,7 +200,7 @@ workflow:
 	})
 	assert.NilError(t, err)
 
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
 	err = service.CompletePlanning(run, &PlanningArtifact{})
@@ -244,7 +244,7 @@ workflow:
 	})
 	assert.NilError(t, err)
 
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
 	err = service.CompletePlanning(run, &PlanningArtifact{TestTarget: "tests/test_thing.py"})
@@ -276,7 +276,7 @@ workflow:
 	assert.Assert(t, run.Onboarding == nil)
 
 	artifact := OnboardingArtifact{
-		ProjectSummary: "Small Python project with one pytest target.",
+		TaskSummary: "Small Python task context with one pytest target.",
 		ArtifactMap: []OnboardingArtifactRef{
 			{Path: "/workspace/project/tests", Kind: "tests", Notes: "Pytest location"},
 		},
@@ -291,7 +291,7 @@ workflow:
 	assert.NilError(t, err)
 	assert.Equal(t, run.Phase, TaskPhasePlanning)
 	assert.Assert(t, run.Onboarding != nil)
-	assert.Equal(t, run.Onboarding.ProjectSummary, artifact.ProjectSummary)
+	assert.Equal(t, run.Onboarding.TaskSummary, artifact.TaskSummary)
 	assert.Equal(t, run.Onboarding.ArtifactMap[0].Path, artifact.ArtifactMap[0].Path)
 }
 
@@ -317,9 +317,9 @@ workflow:
 	assert.NilError(t, err)
 	assert.Assert(t, identifiers.IsKind(run.RunID, identifiers.KindTaskRun))
 	assert.Equal(t, run.Phase, TaskPhaseOnboarding)
-	run.Onboarding = &OnboardingArtifact{ProjectSummary: "existing summary"}
+	run.Onboarding = &OnboardingArtifact{TaskSummary: "existing summary"}
 	assert.Assert(t, run.Onboarding != nil)
-	assert.Equal(t, run.Onboarding.ProjectSummary, "existing summary")
+	assert.Equal(t, run.Onboarding.TaskSummary, "existing summary")
 }
 
 func TestCompleteOnboardingRequiresOnboardingPhase(t *testing.T) {
@@ -343,14 +343,14 @@ workflow:
 	run, err := service.RegisterTask("simple_tdd", map[string]string{})
 	assert.NilError(t, err)
 
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready again"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready again"})
 	assert.ErrorContains(t, err, "cannot transition to planning")
 }
 
-func TestCompleteOnboardingValidatesProjectSummary(t *testing.T) {
+func TestCompleteOnboardingValidatesTaskSummary(t *testing.T) {
 	service := newTemplateTestService(t, `
 version: "0.1"
 task:
@@ -372,7 +372,7 @@ workflow:
 	assert.NilError(t, err)
 
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{})
-	assert.ErrorContains(t, err, "onboarding.projectSummary is required")
+	assert.ErrorContains(t, err, "onboarding.taskSummary is required")
 	assert.Equal(t, run.Phase, TaskPhaseOnboarding)
 	assert.Assert(t, run.Onboarding == nil)
 }
@@ -397,14 +397,14 @@ workflow:
 
 	run, err := service.RegisterTask("simple_tdd", map[string]string{})
 	assert.NilError(t, err)
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "stored summary"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "stored summary"})
 	assert.NilError(t, err)
 
 	err = service.RestartTask(run)
 	assert.NilError(t, err)
 	assert.Equal(t, run.Phase, TaskPhaseOnboarding)
 	assert.Assert(t, run.Onboarding != nil)
-	assert.Equal(t, run.Onboarding.ProjectSummary, "stored summary")
+	assert.Equal(t, run.Onboarding.TaskSummary, "stored summary")
 	assert.Assert(t, run.Planning == nil)
 }
 
@@ -453,7 +453,7 @@ workflow:
 
 	run, err := service.RegisterTask("simple_tdd", map[string]string{})
 	assert.NilError(t, err)
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
 	err = service.CompletePlanning(run, &PlanningArtifact{})
@@ -502,7 +502,7 @@ workflow:
 
 	run, err := service.RegisterTask("approval_flow", map[string]string{})
 	assert.NilError(t, err)
-	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 	err = service.CompletePlanning(run, &PlanningArtifact{TestTarget: "pytest -q"})
 	assert.NilError(t, err)

--- a/internal/taskverification/templates_test.go
+++ b/internal/taskverification/templates_test.go
@@ -86,6 +86,53 @@ workflow:
 	assert.ErrorContains(t, err, `unknown task parameter "unknown"`)
 }
 
+func TestListTemplatesAllowsExecutionStepWithoutChecks(t *testing.T) {
+	service := newTemplateTestService(t, `
+version: "0.1"
+task:
+  id: "free_form"
+  name: "Free Form"
+  description: "Minimal execution flow without explicit checks."
+workflow:
+  onboarding: {}
+  planning: {}
+  execution:
+    - id: "step_one"
+`, "free_form.yaml")
+
+	summaries, err := service.ListTemplates()
+	assert.NilError(t, err)
+	assert.Equal(t, len(summaries), 1)
+	assert.Equal(t, summaries[0].ID, "free_form")
+	assert.Equal(t, summaries[0].StepCount, 1)
+	assert.Equal(t, summaries[0].Steps[0].ID, "step_one")
+}
+
+func TestListTemplatesAllowsExecutionStepWithoutChecksWhenInvariantsArePresent(t *testing.T) {
+	service := newTemplateTestService(t, `
+version: "0.1"
+task:
+  id: "free_form_with_invariant"
+  name: "Free Form With Invariant"
+  description: "Execution step uses invariants without checks."
+workflow:
+  onboarding: {}
+  planning: {}
+  execution:
+    - id: "step_one"
+      invariants:
+        - id: "stable"
+          command: "printf 'same'"
+`, "free_form_with_invariant.yaml")
+
+	summaries, err := service.ListTemplates()
+	assert.NilError(t, err)
+	assert.Equal(t, len(summaries), 1)
+	assert.Equal(t, summaries[0].ID, "free_form_with_invariant")
+	assert.Equal(t, summaries[0].StepCount, 1)
+	assert.Equal(t, summaries[0].Steps[0].ID, "step_one")
+}
+
 func TestCompletePlanningResolvesDraftParametersAndEntersConfiguredExecutionNode(t *testing.T) {
 	service := newTemplateTestService(t, `
 version: "0.1"
@@ -129,6 +176,36 @@ workflow:
 	assert.Assert(t, run.RunnableTemplate != nil)
 	assert.Equal(t, run.Phase, TaskPhase("execution.failing_test"))
 	assert.Equal(t, run.RunnableTemplate.CompiledWorkflow.WorkflowSteps[0].Checks[0].Command, "printf '%s' 'TestThing:boom'")
+}
+
+func TestCompletePlanningUsesResolvedExecutionPathForParameterizedStepID(t *testing.T) {
+	service := newTemplateTestService(t, `
+version: "0.1"
+task:
+  id: "free_form"
+  name: "Free Form"
+  description: "Parameterized step id."
+parameters:
+  - name: "taskName"
+    description: "Human-readable task name."
+workflow:
+  onboarding: {}
+  planning: {}
+  execution:
+    - id: "Task ${taskName}"
+`, "free_form.yaml")
+
+	run, err := service.RegisterTask("free_form", map[string]string{
+		"taskName": "Investigate issue",
+	})
+	assert.NilError(t, err)
+
+	err = service.CompleteOnboarding(run, &OnboardingArtifact{ProjectSummary: "ready"})
+	assert.NilError(t, err)
+
+	err = service.CompletePlanning(run, &PlanningArtifact{})
+	assert.NilError(t, err)
+	assert.Equal(t, run.Phase, TaskPhase("execution.Task Investigate issue"))
 }
 
 func TestCompletePlanningAllowsEditableFieldsForResolvedDeclaredParameters(t *testing.T) {

--- a/internal/taskverification/types.go
+++ b/internal/taskverification/types.go
@@ -107,9 +107,9 @@ type TemplateParameter struct {
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 }
 
-// OnboardingArtifact stores reusable project/environment discovery context.
+// OnboardingArtifact stores reusable task/environment discovery context.
 type OnboardingArtifact struct {
-	ProjectSummary string                  `json:"projectSummary"`
+	TaskSummary    string                  `json:"taskSummary"`
 	ArtifactMap    []OnboardingArtifactRef `json:"artifactMap,omitempty"`
 	CommonCommands []OnboardingCommand     `json:"commonCommands,omitempty"`
 	Constraints    []string                `json:"constraints,omitempty"`

--- a/internal/taskverification/types.go
+++ b/internal/taskverification/types.go
@@ -212,6 +212,8 @@ const (
 	TaskStatusCompleted TaskStatus = "completed"
 	// TaskStatusFailed indicates a task run ended in failure.
 	TaskStatusFailed TaskStatus = "failed"
+	// TaskStatusTimedOut indicates a task run was paused due to inactivity.
+	TaskStatusTimedOut TaskStatus = "timed_out"
 )
 
 // TaskPhase enumerates the workflow position of a task run.
@@ -295,6 +297,8 @@ type RunState struct {
 	Steps              []StepState         `json:"steps,omitempty"`
 	LastFailureMessage string              `json:"lastFailureMessage,omitempty"`
 	ExplicitFailReason string              `json:"explicitFailReason,omitempty"`
+	LastActivityAt     int64               `json:"lastActivityAtUnixMilli,omitempty"`
+	ExpiresAt          int64               `json:"expiresAtUnixMilli,omitempty"`
 }
 
 // StepResult is the MCP-facing outcome of starting or completing a step.
@@ -334,6 +338,10 @@ const (
 	TaskEventTypeRestarted TaskEventType = "task_restarted"
 	// TaskEventTypeFailed records explicit task failure.
 	TaskEventTypeFailed TaskEventType = "task_failed"
+	// TaskEventTypeTimedOut records automatic inactivity timeout.
+	TaskEventTypeTimedOut TaskEventType = "task_timed_out"
+	// TaskEventTypeResumed records resuming a timed-out run in place.
+	TaskEventTypeResumed TaskEventType = "task_resumed"
 	// TaskEventTypeApprovalWaitEntered records entry into an approval wait node.
 	TaskEventTypeApprovalWaitEntered TaskEventType = "approval_wait_entered"
 )

--- a/task-templates/minimal.yaml
+++ b/task-templates/minimal.yaml
@@ -1,0 +1,29 @@
+version: "0.1"
+
+task:
+  id: "minimal"
+  name: "Minimal"
+  description: |
+    Smallest task template that still allows work. 
+  instructions: |
+    Use this if you can't find any other more fitting task template.
+    This template does NOT impose any governance restrictions,
+    but allows the agent to provide its actions relative to a
+    given task, which still allows for review and optimization
+    of the executed workflow.
+
+parameters:
+  - name: "taskName"
+    description: "Human-readable task name."
+
+workflow:
+  onboarding:
+    tools_allowed: ["*"]
+
+  planning:
+    tools_allowed: ["*"]
+
+  execution:
+    - id: "step_one"
+      name: "Task ${taskName}"
+      tools_allowed: ["*"]

--- a/web/src/routes.test.tsx
+++ b/web/src/routes.test.tsx
@@ -179,7 +179,7 @@ describe("task run list", () => {
     expect((screen.getByLabelText("API key") as HTMLInputElement).value).toBe("");
   });
 
-  it("maps active success and failed status badges", async () => {
+  it("maps active success failed and timed out status badges", async () => {
     globalThis.fetch = vi.fn(() =>
       Promise.resolve(
         createFetchResponse([
@@ -215,6 +215,16 @@ describe("task run list", () => {
             actionEventCount: 1,
             eventCount: 3,
           },
+          {
+            runId: "tr_1742947200126_0000000004",
+            templateId: "timed_out_task",
+            startedAt: 1742947200123,
+            status: "timed_out",
+            currentPhase: "execution.run",
+            taskEventCount: 2,
+            actionEventCount: 1,
+            eventCount: 3,
+          },
         ]),
       ),
     ) as typeof fetch;
@@ -224,6 +234,7 @@ describe("task run list", () => {
     expect(await screen.findByText("active")).toBeInTheDocument();
     expect(screen.getByText("success")).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText("timed_out")).toBeInTheDocument();
   });
 
   it("uses endedAt for finished run duration instead of current time", async () => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -256,6 +256,12 @@ code,
   background: rgba(255, 140, 140, 0.08);
 }
 
+.status-badge--timed_out {
+  color: #9ed1ff;
+  border-color: rgba(158, 209, 255, 0.72);
+  background: rgba(110, 170, 255, 0.14);
+}
+
 .state-card {
   padding: 32px;
 }

--- a/web/src/ui/task-run-detail-page.tsx
+++ b/web/src/ui/task-run-detail-page.tsx
@@ -1033,7 +1033,7 @@ function extractPayloadPreview(payload: unknown, depth = 0): string {
     "cwd",
     "templateId",
     "template_id",
-    "projectSummary",
+    "taskSummary",
     "project_summary",
     "input",
     "message",

--- a/web/src/ui/task-run-detail-page.tsx
+++ b/web/src/ui/task-run-detail-page.tsx
@@ -792,8 +792,10 @@ function shouldStickToCurrentPhase(event: TaskRunEvent): boolean {
     event.eventType === "planning_completed" ||
     event.eventType === "step_completed" ||
     event.eventType === "task_completed" ||
+    event.eventType === "task_timed_out" ||
     event.eventType === "task_failed" ||
     payloadStatus === "completed" ||
+    payloadStatus === "timed_out" ||
     payloadStatus === "failed"
   );
 }
@@ -807,6 +809,9 @@ function deriveTaskRunDetailStatus(events: TaskRunEvent[]): TaskRunUIStatus {
     }
 
     const payloadStatus = readPayloadStatus(event.payloadJson);
+    if (payloadStatus === "timed_out" || event.eventType === "task_timed_out") {
+      return "timed_out";
+    }
     if (payloadStatus === "failed" || event.eventType === "task_failed" || event.outcome === "failed") {
       return "failed";
     }
@@ -1153,6 +1158,9 @@ function formatTaskPhaseLine(event: TaskRunEvent): string {
 // Maps task and action events into the shared tone model used by the UI.
 function getEventTone(event: TaskRunEvent): "neutral" | "active" | "completed" | "failed" {
   if (event.source === "task") {
+    if (event.eventType === "task_timed_out" || readPayloadStatus(event.payloadJson) === "timed_out") {
+      return "neutral";
+    }
     if (event.outcome === "failed" || event.eventType === "task_failed") {
       return "failed";
     }
@@ -1174,6 +1182,10 @@ function getEventTone(event: TaskRunEvent): "neutral" | "active" | "completed" |
 // Generates the compact status label shown next to event payloads.
 function getEventStatusLabel(event: TaskRunEvent): string {
   if (event.source === "task") {
+    const payloadStatus = readPayloadStatus(event.payloadJson);
+    if (payloadStatus) {
+      return payloadStatus;
+    }
     return event.outcome ?? "tracked";
   }
   if (event.isError === true || event.success === false) {

--- a/web/src/ui/task-run-list-page.tsx
+++ b/web/src/ui/task-run-list-page.tsx
@@ -15,6 +15,9 @@ function getTaskRunDisplayPhase(run: TaskRunSummary): string {
   if (uiStatus === "success") {
     return "Completed";
   }
+  if (uiStatus === "timed_out") {
+    return "Timed Out";
+  }
 
   return humanizePhase(run.currentPhase);
 }
@@ -57,7 +60,7 @@ export function TaskRunListPage() {
   }, [reloadToken]);
 
   useEffect(() => {
-    const activeRunExists = runs.some((run) => run.endedAt == null);
+    const activeRunExists = runs.some((run) => getTaskRunUIStatus(run.status, run.endedAt) === "active");
     if (!activeRunExists) {
       return;
     }

--- a/web/src/ui/task-run-status.ts
+++ b/web/src/ui/task-run-status.ts
@@ -1,7 +1,10 @@
-export type TaskRunUIStatus = "active" | "success" | "failed";
+export type TaskRunUIStatus = "active" | "success" | "failed" | "timed_out";
 
 // Maps backend task state into the smaller set of visual states used by the UI.
 export function getTaskRunUIStatus(status: string, endedAt?: number): TaskRunUIStatus {
+  if (status === "timed_out") {
+    return "timed_out";
+  }
   if (endedAt == null) {
     return "active";
   }


### PR DESCRIPTION
### Changes

- Solves:
  - #121 - "minimal" template, that allows all tools to be used, useful for when a task process is not yet clearly defined, or you want to research what your agent is up to
  - #119 - allow execution steps without checks - checks are now optional, but if present have to be well-defined, and working
- adds detailed documentation for how to create a task template
- added timeout to tasks, which is configurable using `proxy.capabilities.taskVerification.idleTimeoutSeconds`, default is `0` which mean timeout is off, tasks stay active indefinitely. However, they are attached to an upstream session in the proxy, which means, that if the session is destroyed the task effectively becomes idle. This is something I want to fix in a later stage, since some MCP clients (hello Codex...) seem to be eager to create a new session whenever they come into focus.

### Bugfixes
- fixed bug where agent was able to call tools after the task was completed without registering a new task.