### PR TITLE
Version 0.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ centian
 
 # local sqlite
 *.sqlite
+
+# local demo files
+.centian/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.2.2 - 2026-04-01
+
+### Major
+- Added a host-native black-box taskverification integration harness under `tests/integrationtests/taskverification` that runs real local coding agents against a real Centian process, preserves artifacts under `.tmp/`, and asserts the task lifecycle from Centian task runs, events, request logs, and produced project files.
+- Added the new `centian demo` command for a self-contained local product demo, backed by a new `internal/agentrunner` package with embedded demo assets, a generated Centian config and workspace, a Claude headless adapter, preserved agent stdout/stderr logs, and automatic UI startup while keeping Centian running after the agent exits.
+
+### Minor
+- Added detailed black-box integration documentation in `tests/integrationtests/taskverification/README.md`, plus README coverage for the new `centian demo` flow, generated artifacts, and current agent support.
+- Added explicit task-tool annotations and richer agent-facing metadata across the `centian.task_*` tools, including `workspaceRoot`, `pathMode`, `commandWorkingDirectory`, and short `nextAction` guidance to make the taskverification workflow easier for agents to follow.
+- Added a dedicated demo integration test and expanded taskverification fixture assets to keep the runtime demo flow and the stricter black-box harness aligned.
+
+### Bugfixes
+- Fixed taskverification step verification to support `output_contains` and `output_not_contains` conditions over combined stdout/stderr, removing the need for agent-side workarounds when standard-library Python test failures write to stderr.
+- Fixed the task run UI to poll the list view in place, poll active detail views once per second, pause hidden-tab refreshes, and avoid incorrectly stopping detail polling after non-terminal failed step events.
+- Fixed the host-native taskverification harness to use a consistent project-root workspace model with versioned local configs/prompts/templates instead of ad hoc demo-path assumptions.
+
+## v0.2.1 - 2026-03-29
+
+### Major
+- No code delta relative to `v0.2.0`. `v0.2.1` tags the same `Task Verification - Phase 1 (#108)` release commit and serves as a republished release marker for that rollout.
+
 ## v0.2.0 - 2026-03-29
 
 ### Major

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Build flags
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
-.PHONY: help build build-go clean test test-integration test-everything test-realworld test-taskverification test-all test-coverage test-coverage-html lint fmt vet tidy run dev web-install web-dev web-build web-stage web-test web-preview web-clean ensure-web-tooling check-main-branch tag-release release major minor patch
+.PHONY: help build build-go clean test test-integration test-everything test-realworld test-taskverification test-taskverification-blackbox test-all test-coverage test-coverage-html lint fmt vet tidy run dev web-install web-dev web-build web-stage web-test web-preview web-clean ensure-web-tooling check-main-branch tag-release release major minor patch
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -85,6 +85,16 @@ test-taskverification: ## Run opt-in Docker task verification integration test
 		echo "Note: gotestsum not found, using default go test output"; \
 		echo "Install with: go install gotest.tools/gotestsum@latest"; \
 		CENTIAN_RUN_TASKVERIFICATION_INTEGRATION=1 GOCACHE=/tmp/go-build go test -v ./demo/taskverification; \
+	fi
+
+test-taskverification-blackbox: ## Run opt-in host-native black-box taskverification test
+	@echo "Running host-native black-box taskverification test..."
+	@if command -v gotestsum >/dev/null 2>&1; then \
+		CENTIAN_RUN_TASKVERIFICATION_BLACKBOX=1 GOCACHE=/tmp/go-build gotestsum --format testname -- ./tests/integrationtests/taskverification -run TestTaskVerificationBlackBox; \
+	else \
+		echo "Note: gotestsum not found, using default go test output"; \
+		echo "Install with: go install gotest.tools/gotestsum@latest"; \
+		CENTIAN_RUN_TASKVERIFICATION_BLACKBOX=1 GOCACHE=/tmp/go-build go test -v ./tests/integrationtests/taskverification -run TestTaskVerificationBlackBox; \
 	fi
 
 test-all: test test-integration ## Run all tests (unit + integration)

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,16 @@ web-clean: ## Clean frontend build and generated config artifacts
 
 install: build ## Install binary to GOPATH/bin
 	@echo "Installing $(BINARY_NAME)..."
-	@cp $(BUILD_DIR)/$(BINARY_NAME) $(shell go env GOPATH)/bin/$(BINARY_NAME)
+	@dest_dir="$(shell go env GOPATH)/bin"; \
+	dest="$$dest_dir/$(BINARY_NAME)"; \
+	tmp="$$dest.tmp"; \
+	mkdir -p "$$dest_dir"; \
+	cp "$(BUILD_DIR)/$(BINARY_NAME)" "$$tmp"; \
+	chmod +x "$$tmp"; \
+	if [ "$$(uname -s)" = "Darwin" ]; then \
+		codesign --force --sign - "$$tmp"; \
+	fi; \
+	mv "$$tmp" "$$dest"
 	@echo "Installed $(BINARY_NAME) to $(shell go env GOPATH)/bin/$(BINARY_NAME)"
 
 tail-log: ## Tail the latest Centian log file

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-taskverification: ## Run opt-in Docker task verification integration test
 test-taskverification-blackbox: ## Run opt-in host-native black-box taskverification test
 	@echo "Running host-native black-box taskverification test..."
 	@if command -v gotestsum >/dev/null 2>&1; then \
-		CENTIAN_RUN_TASKVERIFICATION_BLACKBOX=1 GOCACHE=/tmp/go-build gotestsum --format testname -- ./tests/integrationtests/taskverification -run TestTaskVerificationBlackBox; \
+		CENTIAN_RUN_TASKVERIFICATION_BLACKBOX=1 GOCACHE=/tmp/go-build gotestsum --format standard-verbose -- -v ./tests/integrationtests/taskverification -run TestTaskVerificationBlackBox; \
 	else \
 		echo "Note: gotestsum not found, using default go test output"; \
 		echo "Install with: go install gotest.tools/gotestsum@latest"; \

--- a/README.md
+++ b/README.md
@@ -82,6 +82,60 @@ Example:
 
 ## Demo
 
+For the fastest end-to-end product demo, use the built-in `centian demo` command.
+
+### `centian demo`
+
+`centian demo` creates a self-contained demo workspace, starts a local Centian instance, launches a supported coding agent against that instance, and shows the live task UI.
+
+Current v1 support:
+
+- `claude`
+
+Example:
+
+```bash
+centian demo --agent claude
+```
+
+Optional path override:
+
+```bash
+centian demo --agent claude --path ./my-centian-demo
+```
+
+By default this creates the demo under:
+
+```text
+{cwd}/.centian/demo
+```
+
+The command creates:
+
+- `workspace/` for the agent task
+- `templates/` with the taskverification workflow
+- `logs/` with Centian-generated logs and event storage
+- `config.json`, `prompt.md`, `claude_mcp_config.json`, and `centian.pid`
+- `agent.stdout.log` and `agent.stderr.log` for the headless agent process output
+
+Behavior:
+
+- starts Centian locally
+- prints the live UI URL
+- best-effort opens the browser on macOS
+- runs the agent headlessly
+- keeps Centian running after the agent finishes
+
+To stop the demo server later:
+
+```bash
+kill $(cat ./.centian/demo/centian.pid)
+```
+
+This is a safe, isolated demo flow intended to showcase Centian taskverification. It is not yet a hardened sandbox boundary and does not currently support Codex or Gemini in the public command.
+
+### `demo/` walkthroughs
+
 The `demo/` folder contains three walkthroughs:
 - `demo/logging_demo/` for OpenTelemetry span export on MCP tool calls.
 - `demo/modification_demo/` for regex-based redaction of sensitive response values.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,6 +52,7 @@ func main() {
 		Commands: []*urfavecli.Command{
 			cli.InitCommand,
 			cli.StartCommand,
+			cli.DemoCommand,
 			cli.AuthCommand,
 			config.ServerCommand,
 			cli.ProcessorCommand,

--- a/internal/agentrunner/assets.go
+++ b/internal/agentrunner/assets.go
@@ -1,0 +1,17 @@
+package agentrunner
+
+import (
+	"embed"
+	"fmt"
+)
+
+//go:embed assets/*
+var embeddedAssets embed.FS
+
+func asset(name string) (string, error) {
+	data, err := embeddedAssets.ReadFile("assets/" + name)
+	if err != nil {
+		return "", fmt.Errorf("read asset %q: %w", name, err)
+	}
+	return string(data), nil
+}

--- a/internal/agentrunner/assets/centian_config.json
+++ b/internal/agentrunner/assets/centian_config.json
@@ -1,0 +1,56 @@
+{
+  "name": "Centian Demo",
+  "version": "1.0.0",
+  "auth": false,
+  "proxy": {
+    "host": "127.0.0.1",
+    "port": "__PORT__",
+    "timeout": 30,
+    "logLevel": "debug",
+    "logOutput": "file",
+    "logFile": "__INTERNAL_LOG__",
+    "capabilities": {
+      "taskVerification": {
+        "enabled": true,
+        "templatesPath": "__TEMPLATES_DIR__"
+      },
+      "eventStorage": {
+        "enabled": true,
+        "driver": "sqlite",
+        "path": "__EVENT_STORE_PATH__"
+      },
+      "ui": {
+        "enabled": true
+      }
+    }
+  },
+  "gateways": {
+    "taskverification": {
+      "setupGateway": true,
+      "mcpServers": {
+        "filesystem": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "@modelcontextprotocol/server-filesystem",
+            "__PROJECT_DIR__"
+          ],
+          "enabled": true,
+          "description": "Filesystem access to the demo workspace."
+        },
+        "shell": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "shell-command-mcp"
+          ],
+          "env": {
+            "ALLOWED_COMMANDS": "*"
+          },
+          "enabled": true,
+          "description": "Shell access for the Centian demo."
+        }
+      }
+    }
+  }
+}

--- a/internal/agentrunner/assets/claude_mcp_config.json
+++ b/internal/agentrunner/assets/claude_mcp_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "centian": {
+      "type": "http",
+      "url": "__MCP_URL__"
+    }
+  }
+}

--- a/internal/agentrunner/assets/prompt.md
+++ b/internal/agentrunner/assets/prompt.md
@@ -1,0 +1,23 @@
+Connect to the MCP server named `centian` and solve this Python TDD task through the Centian workflow.
+
+Problem:
+
+Implement a Python function named `score_parentheses(text: str) -> int`.
+
+The input string is guaranteed to be balanced and consists only of `(` and `)`.
+
+Scoring rules:
+
+- `()` has score `1`
+- `AB` has score `A + B`, where `A` and `B` are balanced parentheses strings
+- `(A)` has score `2 * A`
+
+Requirements:
+
+- Start from the problem statement only. There is no provided implementation or test for this exercise.
+- Create `score_parentheses.py` and `test_score_parentheses.py` in the same directory.
+- Treat the Centian project root as the working directory and use project-relative paths.
+- The environment only guarantees `python`; do not assume any third-party packages are installed.
+- Establish a failing test first, then implement the solution.
+
+Use Centian lifecycle tools as the source of truth, rely only on Centian-exposed project tools, and stop after the task is completed.

--- a/internal/agentrunner/assets/python_tdd_workflow.yaml
+++ b/internal/agentrunner/assets/python_tdd_workflow.yaml
@@ -1,0 +1,144 @@
+version: "0.1"
+task:
+  id: "python_tdd_workflow"
+  name: "Python TDD Workflow"
+  description: "Use Centian to drive a Python TDD loop with explicit scaffolding, a failing-baseline step, and an implementation step."
+  instructions: |
+    Use Centian task verification as the authoritative process for this task.
+
+    Expectations:
+    - Register the task before using any project-access MCP tool, then follow the step boundaries in order.
+    - Prefer `centian.task_start_step` and `centian.task_complete_step` over manually rebuilding the full validation flow.
+    - Treat `centian.task_complete_step` as the source of truth for whether a step passes.
+    - The Centian taskverification working directory is the project root.
+    - Use paths relative to the project root when filling template parameters.
+    - This workflow runs in a host-native test environment with only `python` guaranteed to exist.
+    - Do not assume `pytest` or `ruff` are installed; choose commands that work with plain `python`.
+    - Once the implementation step has started, keep the selected test file stable.
+parameters:
+  - name: "testCommand"
+    description: "The command prefix used to run the selected test target with standard-library-only Python, for example `python`."
+  - name: "testTarget"
+    description: "The test target to execute with the selected command. Use a plain file path such as `test_x.py`."
+  - name: "testFile"
+    description: "The concrete path to the test file used for invariants, for example `test_x.py`."
+  - name: "testName"
+    description: "The test entrypoint name that scaffolding should create inside the selected test file."
+  - name: "lintCommand"
+    description: "The command used to run a dependency-free syntax check for the project, for example `python -m py_compile score_parentheses.py test_score_parentheses.py`."
+  - name: "expectedError"
+    description: "A stable substring expected in the combined test output for the initial failing baseline, for example `FAIL`."
+  - name: "implementationTarget"
+    description: "The concrete implementation file path that scaffolding and execution will operate on. Use a path relative to the project root, for example `score_parentheses.py`."
+workflow:
+  onboarding:
+    instructions: |
+      Identify the concrete test target, relevant source files, and project commands before planning.
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+  planning:
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+    editable_fields:
+      - "parameters.testCommand"
+      - "parameters.testTarget"
+      - "parameters.testFile"
+      - "parameters.testName"
+      - "parameters.lintCommand"
+      - "parameters.expectedError"
+      - "parameters.implementationTarget"
+    required_outputs:
+      - "selectedFiles"
+      - "testTarget"
+      - "lintCommand"
+      - "expectedFailure"
+      - "implementationTarget"
+  scaffolding:
+    - id: "setup_test_file"
+      name: "Setup test file"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      instructions: |
+        Create the planned test file as a new artifact. Keep this step additive.
+      checks:
+        - id: "test_file_created"
+          command: "printf 'scaffold-test-file'"
+          pre_conditions:
+            - type: file_not_exists
+              path: "${testFile}"
+          post_conditions:
+            - type: file_exists
+              path: "${testFile}"
+    - id: "setup_test_scaffolding"
+      name: "Setup test scaffolding"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      instructions: |
+        Add the planned test scaffold and make sure the implementation target exists. If the implementation file does not exist yet, create a minimal stub that preserves the planned failing baseline.
+      checks:
+        - id: "test_scaffold_created"
+          command: "printf 'scaffold-test-content'"
+          pre_conditions:
+            - type: file_exists
+              path: "${testFile}"
+            - type: file_not_contains
+              path: "${testFile}"
+              value: "${testName}"
+          post_conditions:
+            - type: file_contains
+              path: "${testFile}"
+              value: "${testName}"
+            - type: file_exists
+              path: "${implementationTarget}"
+  execution:
+    - id: "establish_failing_baseline"
+      name: "Establish failing baseline"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      instructions: |
+        Verify the planned test target already fails for the intended reason. No additional file edits should be required in this step.
+        The pass/fail decision for this step comes from `centian.task_complete_step`.
+      checks:
+        - id: "selected_test_fails"
+          command: "${testCommand} ${testTarget}"
+          pre_conditions:
+            - type: exit_code
+              value: 1
+            - type: output_contains
+              value: "${expectedError}"
+          post_conditions:
+            - type: exit_code
+              value: 1
+            - type: output_contains
+              value: "${expectedError}"
+    - id: "implement_solution"
+      name: "Implement solution"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      instructions: |
+        Start this step before changing production code.
+        Make the implementation pass the selected test, then let Centian verify the step.
+        Once this step is active, keep the selected test file stable.
+      checks:
+        - id: "selected_test_passes"
+          command: "${testCommand} ${testTarget}"
+          pre_conditions:
+            - type: exit_code
+              value: 1
+          post_conditions:
+            - type: exit_code
+              value: 0
+        - id: "project_lint_passes"
+          command: "${lintCommand}"
+          post_conditions:
+            - type: exit_code
+              value: 0
+      invariants:
+        - id: "test_file_stable"
+          command: "cat ${testFile}"

--- a/internal/agentrunner/claude.go
+++ b/internal/agentrunner/claude.go
@@ -1,0 +1,59 @@
+package agentrunner
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type claudeAdapter struct {
+	model string
+}
+
+func (claudeAdapter) name() string { return AgentClaude }
+
+func (claudeAdapter) isAvailable() error {
+	_, err := exec.LookPath("claude")
+	return err
+}
+
+func (c claudeAdapter) writeConfig(layout *demoLayout) error {
+	content, err := asset("claude_mcp_config.json")
+	if err != nil {
+		return err
+	}
+	content = strings.ReplaceAll(content, "__MCP_URL__", layout.MCPURL)
+	var payload any
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		return fmt.Errorf("parse claude MCP config: %w", err)
+	}
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode claude MCP config: %w", err)
+	}
+	if err := os.WriteFile(layout.ClaudeConfig, encoded, 0o600); err != nil {
+		return fmt.Errorf("write claude_mcp_config.json: %w", err)
+	}
+	return nil
+}
+
+func (c claudeAdapter) command(layout *demoLayout, _ string) ([]string, error) {
+	command := []string{
+		"claude",
+		"-p",
+		"--output-format", "json",
+		"--no-session-persistence",
+		"--permission-mode", "default",
+		"--allowedTools", "mcp__centian__*",
+		"--mcp-config", layout.ClaudeConfig,
+		"--strict-mcp-config",
+		"--tools", "",
+	}
+	model := strings.TrimSpace(c.model)
+	if model != "" {
+		command = append(command, "--model", model)
+	}
+	return command, nil
+}

--- a/internal/agentrunner/demo.go
+++ b/internal/agentrunner/demo.go
@@ -1,0 +1,438 @@
+package agentrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// AgentClaude is the supported public agent identifier for the Claude CLI.
+	AgentClaude = "claude"
+	// DefaultClaudeModel is the default Claude model alias for demo runs.
+	DefaultClaudeModel = "sonnet"
+	// DefaultAgentTimeout is the default maximum runtime for a demo agent invocation.
+	DefaultAgentTimeout = 5 * time.Minute
+)
+
+var allocateFreePortFunc = allocateFreePort
+
+// DemoOptions configures a single demo run.
+type DemoOptions struct {
+	Agent             string
+	RootPath          string
+	CentianBinaryPath string
+	Timeout           time.Duration
+	ClaudeModel       string
+	OpenBrowser       bool
+	Stdout            io.Writer
+	Stderr            io.Writer
+}
+
+// DemoResult describes the generated demo workspace and running Centian instance.
+type DemoResult struct {
+	RootPath      string
+	WorkspacePath string
+	ConfigPath    string
+	PromptPath    string
+	AgentStdout   string
+	AgentStderr   string
+	UIPublicURL   string
+	MCPURL        string
+	PID           int
+	StopHint      string
+}
+
+// DemoRunner provisions and launches a self-contained Centian demo workspace.
+type DemoRunner struct{}
+
+type agentAdapter interface {
+	name() string
+	isAvailable() error
+	writeConfig(*demoLayout) error
+	command(*demoLayout, string) ([]string, error)
+}
+
+type demoLayout struct {
+	RootPath        string
+	WorkspacePath   string
+	TemplatesPath   string
+	LogsPath        string
+	ConfigPath      string
+	PromptPath      string
+	AgentStdoutPath string
+	AgentStderrPath string
+	InternalLogPath string
+	EventStorePath  string
+	PIDPath         string
+	ClaudeConfig    string
+	BaseURL         string
+	MCPURL          string
+	Port            string
+}
+
+// RunDemo creates the demo workspace, starts Centian, launches the selected
+// agent, and leaves Centian running after the agent exits.
+func (DemoRunner) RunDemo(ctx context.Context, opts *DemoOptions) (*DemoResult, error) {
+	options := normalizeOptions(opts)
+	layout, err := prepareLayout(options)
+	if err != nil {
+		return nil, err
+	}
+
+	adapter, err := selectAdapter(options)
+	if err != nil {
+		return nil, err
+	}
+	if err := adapter.isAvailable(); err != nil {
+		return nil, fmt.Errorf("%s is not available: %w", adapter.name(), err)
+	}
+	if err := renderAssets(layout); err != nil {
+		return nil, err
+	}
+	if err := adapter.writeConfig(layout); err != nil {
+		return nil, err
+	}
+
+	centianCmd, errCh, err := startCentianProcess(layout, options)
+	if err != nil {
+		return nil, err
+	}
+	if err := writePID(layout.PIDPath, centianCmd.Process.Pid); err != nil {
+		_ = centianCmd.Process.Kill()
+		return nil, err
+	}
+
+	if err := waitForCentian(layout, errCh); err != nil {
+		_ = centianCmd.Process.Kill()
+		return nil, err
+	}
+
+	result := &DemoResult{
+		RootPath:      layout.RootPath,
+		WorkspacePath: layout.WorkspacePath,
+		ConfigPath:    layout.ConfigPath,
+		PromptPath:    layout.PromptPath,
+		AgentStdout:   layout.AgentStdoutPath,
+		AgentStderr:   layout.AgentStderrPath,
+		UIPublicURL:   layout.BaseURL + "/ui/tasks",
+		MCPURL:        layout.MCPURL,
+		PID:           centianCmd.Process.Pid,
+		StopHint:      fmt.Sprintf("kill $(cat %s)", shellQuote(layout.PIDPath)),
+	}
+
+	if options.OpenBrowser && runtime.GOOS == "darwin" {
+		//nolint:gosec // UI URL is generated locally from the bound loopback port.
+		_ = exec.Command("open", result.UIPublicURL).Start()
+	}
+	printDemoStatus(options.Stdout, result)
+
+	if err := runAgent(ctx, adapter, layout, options); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func normalizeOptions(opts *DemoOptions) *DemoOptions {
+	if opts.Timeout <= 0 {
+		opts.Timeout = DefaultAgentTimeout
+	}
+	if strings.TrimSpace(opts.ClaudeModel) == "" {
+		opts.ClaudeModel = DefaultClaudeModel
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = io.Discard
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
+	if !opts.OpenBrowser && runtime.GOOS == "darwin" {
+		opts.OpenBrowser = true
+	}
+	return opts
+}
+
+func prepareLayout(opts *DemoOptions) (*demoLayout, error) {
+	root := strings.TrimSpace(opts.RootPath)
+	if root == "" {
+		return nil, fmt.Errorf("demo root path is required")
+	}
+	if err := ensureEmptyOrNewDir(root); err != nil {
+		return nil, err
+	}
+	layout := &demoLayout{
+		RootPath:        root,
+		WorkspacePath:   filepath.Join(root, "workspace"),
+		TemplatesPath:   filepath.Join(root, "templates"),
+		LogsPath:        filepath.Join(root, "logs"),
+		ConfigPath:      filepath.Join(root, "config.json"),
+		PromptPath:      filepath.Join(root, "prompt.md"),
+		AgentStdoutPath: filepath.Join(root, "agent.stdout.log"),
+		AgentStderrPath: filepath.Join(root, "agent.stderr.log"),
+		InternalLogPath: filepath.Join(root, "logs", "internal.log"),
+		EventStorePath:  filepath.Join(root, "logs", "events.sqlite"),
+		PIDPath:         filepath.Join(root, "centian.pid"),
+		ClaudeConfig:    filepath.Join(root, "claude_mcp_config.json"),
+	}
+	for _, dir := range []string{layout.RootPath, layout.WorkspacePath, layout.TemplatesPath, layout.LogsPath} {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return nil, fmt.Errorf("create %s: %w", dir, err)
+		}
+	}
+	port, err := allocateFreePortFunc()
+	if err != nil {
+		return nil, err
+	}
+	layout.Port = port
+	layout.BaseURL = "http://127.0.0.1:" + port
+	layout.MCPURL = layout.BaseURL + "/mcp/taskverification"
+	return layout, nil
+}
+
+func ensureEmptyOrNewDir(path string) error {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat demo path: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("demo path exists and is not a directory: %s", path)
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("read demo path: %w", err)
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("demo path exists and is not empty: %s", path)
+	}
+	return nil
+}
+
+func renderAssets(layout *demoLayout) error {
+	configTemplate, err := asset("centian_config.json")
+	if err != nil {
+		return err
+	}
+	configResolved := strings.NewReplacer(
+		"__PORT__", layout.Port,
+		"__TEMPLATES_DIR__", layout.TemplatesPath,
+		"__PROJECT_DIR__", layout.WorkspacePath,
+		"__INTERNAL_LOG__", layout.InternalLogPath,
+		"__EVENT_STORE_PATH__", layout.EventStorePath,
+	).Replace(configTemplate)
+	var payload any
+	if err := json.Unmarshal([]byte(configResolved), &payload); err != nil {
+		return fmt.Errorf("parse rendered centian config: %w", err)
+	}
+	configBytes, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode rendered centian config: %w", err)
+	}
+	if err := os.WriteFile(layout.ConfigPath, configBytes, 0o600); err != nil {
+		return fmt.Errorf("write config.json: %w", err)
+	}
+
+	prompt, err := asset("prompt.md")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(layout.PromptPath, []byte(prompt), 0o600); err != nil {
+		return fmt.Errorf("write prompt.md: %w", err)
+	}
+
+	template, err := asset("python_tdd_workflow.yaml")
+	if err != nil {
+		return err
+	}
+	templatePath := filepath.Join(layout.TemplatesPath, "python_tdd_workflow.yaml")
+	if err := os.WriteFile(templatePath, []byte(template), 0o600); err != nil {
+		return fmt.Errorf("write template: %w", err)
+	}
+	return nil
+}
+
+func selectAdapter(opts *DemoOptions) (agentAdapter, error) {
+	switch strings.ToLower(strings.TrimSpace(opts.Agent)) {
+	case AgentClaude:
+		return claudeAdapter{model: opts.ClaudeModel}, nil
+	default:
+		return nil, fmt.Errorf("unsupported agent %q; v1 supports %q only", opts.Agent, AgentClaude)
+	}
+}
+
+func startCentianProcess(layout *demoLayout, opts *DemoOptions) (*exec.Cmd, <-chan error, error) {
+	binary := strings.TrimSpace(opts.CentianBinaryPath)
+	if binary == "" {
+		return nil, nil, fmt.Errorf("centian binary path is required")
+	}
+	//nolint:gosec // The executable path comes from the current Centian binary or explicit CLI input.
+	cmd := exec.Command(binary, "start", "--config-path", layout.ConfigPath)
+	cmd.Dir = layout.WorkspacePath
+	cmd.Env = append(os.Environ(), "CENTIAN_LOG_DIR="+layout.LogsPath)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	cmd.SysProcAttr = detachedProcessAttrs()
+	if err := cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("start centian: %w", err)
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		err := cmd.Wait()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+	return cmd, errCh, nil
+}
+
+func writePID(path string, pid int) error {
+	return os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0o600)
+}
+
+func waitForCentian(layout *demoLayout, errCh <-chan error) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(45 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			if err == nil {
+				return fmt.Errorf("centian exited before becoming ready")
+			}
+			return fmt.Errorf("centian exited before becoming ready: %w", err)
+		default:
+		}
+		if isEndpointReachable(client, layout.MCPURL) && isJSONEndpointReady(client, layout.BaseURL+"/api/task-runs") {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("centian did not become ready in time; inspect %s", layout.InternalLogPath)
+}
+
+func runAgent(ctx context.Context, adapter agentAdapter, layout *demoLayout, opts *DemoOptions) error {
+	command, err := adapter.command(layout, loadPrompt(layout.PromptPath))
+	if err != nil {
+		return err
+	}
+	stdoutFile, err := os.Create(layout.AgentStdoutPath)
+	if err != nil {
+		return fmt.Errorf("create agent stdout log: %w", err)
+	}
+	defer func() {
+		_ = stdoutFile.Close()
+	}()
+
+	stderrFile, err := os.Create(layout.AgentStderrPath)
+	if err != nil {
+		return fmt.Errorf("create agent stderr log: %w", err)
+	}
+	defer func() {
+		_ = stderrFile.Close()
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	//nolint:gosec // The command is constructed by the selected internal agent adapter.
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	cmd.Dir = layout.WorkspacePath
+	cmd.Stdout = io.MultiWriter(stdoutFile, &stdout)
+	cmd.Stderr = io.MultiWriter(stderrFile, &stderr)
+	cmd.Stdin = strings.NewReader(loadPrompt(layout.PromptPath))
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("agent timed out after %s", opts.Timeout)
+		}
+		return fmt.Errorf("agent failed: %w\nstdout:\n%s\nstderr:\n%s", err, trimOutput(stdout.String()), trimOutput(stderr.String()))
+	}
+	if opts.Stdout != nil && stdout.Len() > 0 {
+		_, _ = io.Copy(opts.Stdout, &stdout)
+	}
+	if opts.Stderr != nil && stderr.Len() > 0 {
+		_, _ = io.Copy(opts.Stderr, &stderr)
+	}
+	return nil
+}
+
+func loadPrompt(path string) string {
+	//nolint:gosec // The prompt file path is generated inside the demo workspace layout.
+	data, _ := os.ReadFile(path)
+	return string(data)
+}
+
+func isEndpointReachable(client *http.Client, endpoint string) bool {
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	return resp.StatusCode < 500
+}
+
+func isJSONEndpointReady(client *http.Client, endpoint string) bool {
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	return resp.StatusCode == http.StatusOK
+}
+
+func allocateFreePort() (string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("allocate port: %w", err)
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		return "", fmt.Errorf("split host port: %w", err)
+	}
+	return port, nil
+}
+
+func trimOutput(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > 4000 {
+		return value[:4000] + "\n...truncated..."
+	}
+	return value
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+func printDemoStatus(w io.Writer, result *DemoResult) {
+	if w == nil || result == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "Demo root: %s\n", result.RootPath)
+	_, _ = fmt.Fprintf(w, "Workspace: %s\n", result.WorkspacePath)
+	_, _ = fmt.Fprintf(w, "UI: %s\n", result.UIPublicURL)
+	_, _ = fmt.Fprintf(w, "Agent stdout: %s\n", result.AgentStdout)
+	_, _ = fmt.Fprintf(w, "Agent stderr: %s\n", result.AgentStderr)
+	_, _ = fmt.Fprintf(w, "Centian PID: %d\n", result.PID)
+	_, _ = fmt.Fprintf(w, "Stop: %s\n", result.StopHint)
+}

--- a/internal/agentrunner/demo_test.go
+++ b/internal/agentrunner/demo_test.go
@@ -1,0 +1,155 @@
+package agentrunner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrepareLayoutRejectsNonEmptyDir(t *testing.T) {
+	allocateFreePortFunc = func() (string, error) { return "40123", nil }
+	defer func() { allocateFreePortFunc = allocateFreePort }()
+
+	root := filepath.Join(t.TempDir(), "demo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "existing.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := prepareLayout(&DemoOptions{RootPath: root})
+	if err == nil || !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("expected non-empty dir error, got %v", err)
+	}
+}
+
+func TestPrepareLayoutAllowsEmptyExistingDir(t *testing.T) {
+	allocateFreePortFunc = func() (string, error) { return "40123", nil }
+	defer func() { allocateFreePortFunc = allocateFreePort }()
+
+	root := filepath.Join(t.TempDir(), "demo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	layout, err := prepareLayout(&DemoOptions{RootPath: root})
+	if err != nil {
+		t.Fatalf("prepareLayout: %v", err)
+	}
+	if layout.RootPath != root {
+		t.Fatalf("unexpected root path: %s", layout.RootPath)
+	}
+	for _, dir := range []string{layout.WorkspacePath, layout.TemplatesPath, layout.LogsPath} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("expected dir %s: %v", dir, err)
+		}
+	}
+	if layout.AgentStdoutPath == "" || layout.AgentStderrPath == "" {
+		t.Fatal("expected agent log paths to be initialized")
+	}
+}
+
+func TestRenderAssetsWritesExpectedFiles(t *testing.T) {
+	allocateFreePortFunc = func() (string, error) { return "40123", nil }
+	defer func() { allocateFreePortFunc = allocateFreePort }()
+
+	root := filepath.Join(t.TempDir(), "demo")
+	layout, err := prepareLayout(&DemoOptions{RootPath: root})
+	if err != nil {
+		t.Fatalf("prepareLayout: %v", err)
+	}
+
+	if err := renderAssets(layout); err != nil {
+		t.Fatalf("renderAssets: %v", err)
+	}
+
+	assertFileContains(t, layout.ConfigPath, `"port": "`+layout.Port+`"`)
+	assertFileContains(t, layout.ConfigPath, layout.WorkspacePath)
+	assertFileContains(t, layout.PromptPath, "score_parentheses")
+	assertFileContains(t, filepath.Join(layout.TemplatesPath, "python_tdd_workflow.yaml"), "Python TDD Workflow")
+	if filepath.Base(layout.AgentStdoutPath) != "agent.stdout.log" {
+		t.Fatalf("unexpected agent stdout path: %s", layout.AgentStdoutPath)
+	}
+	if filepath.Base(layout.AgentStderrPath) != "agent.stderr.log" {
+		t.Fatalf("unexpected agent stderr path: %s", layout.AgentStderrPath)
+	}
+}
+
+func TestClaudeCommandConstruction(t *testing.T) {
+	layout := &demoLayout{
+		ClaudeConfig:  "/tmp/demo/claude_mcp_config.json",
+		WorkspacePath: "/tmp/demo/workspace",
+	}
+	command, err := claudeAdapter{model: "sonnet"}.command(layout, "prompt")
+	if err != nil {
+		t.Fatalf("Command: %v", err)
+	}
+	joined := strings.Join(command, " ")
+	for _, expected := range []string{
+		"claude",
+		"-p",
+		"--output-format json",
+		"--permission-mode default",
+		"--allowedTools mcp__centian__*",
+		"--mcp-config /tmp/demo/claude_mcp_config.json",
+		"--strict-mcp-config",
+		"--tools ",
+		"--model sonnet",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("expected %q in command %q", expected, joined)
+		}
+	}
+	for _, forbidden := range []string{"bypassPermissions", "dangerously-skip-permissions"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("unexpected unsafe flag %q in %q", forbidden, joined)
+		}
+	}
+}
+
+func TestWritePIDAndStopHint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "centian.pid")
+	if err := writePID(path, 12345); err != nil {
+		t.Fatalf("writePID: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pid: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "12345" {
+		t.Fatalf("unexpected pid file contents: %q", string(data))
+	}
+	if got := shellQuote(path); !strings.HasPrefix(got, "'") || !strings.HasSuffix(got, "'") {
+		t.Fatalf("shellQuote should single-quote the path, got %q", got)
+	}
+}
+
+func TestRunDemoUnsupportedAgent(t *testing.T) {
+	allocateFreePortFunc = func() (string, error) { return "40123", nil }
+	defer func() { allocateFreePortFunc = allocateFreePort }()
+
+	_, err := (DemoRunner{}).RunDemo(context.Background(), &DemoOptions{
+		Agent:             "codex",
+		RootPath:          filepath.Join(t.TempDir(), "demo"),
+		CentianBinaryPath: "/tmp/centian",
+		Timeout:           time.Second,
+	})
+	if err == nil || !strings.Contains(err.Error(), "supports") {
+		t.Fatalf("expected unsupported agent error, got %v", err)
+	}
+}
+
+func assertFileContains(t *testing.T, path, fragment string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), fragment) {
+		t.Fatalf("expected %q in %s", fragment, path)
+	}
+}

--- a/internal/agentrunner/process_unix.go
+++ b/internal/agentrunner/process_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package agentrunner
+
+import "syscall"
+
+func detachedProcessAttrs() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/agentrunner/process_windows.go
+++ b/internal/agentrunner/process_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package agentrunner
+
+import "syscall"
+
+func detachedProcessAttrs() *syscall.SysProcAttr {
+	return nil
+}

--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/T4cceptor/centian/internal/agentrunner"
+	"github.com/urfave/cli/v3"
+)
+
+// DemoCommand launches a self-contained Centian demo workspace.
+var DemoCommand = &cli.Command{
+	Name:  "demo",
+	Usage: "Start a self-contained Centian demo workspace",
+	Description: `Create a local Centian demo workspace, start Centian, launch a supported
+coding agent against it, and print the live UI URL.
+
+Examples:
+  centian demo --agent claude
+  centian demo --agent claude --path ./my-demo
+`,
+	Action: handleDemoCommand,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "agent",
+			Aliases:  []string{"a"},
+			Usage:    "Agent to run for the demo (v1 supports: claude)",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:    "path",
+			Aliases: []string{"p"},
+			Usage:   "Path where the demo workspace should be created",
+		},
+	},
+}
+
+func handleDemoCommand(ctx context.Context, cmd *cli.Command) error {
+	if cmd.String("agent") == "" {
+		return fmt.Errorf("--agent is required")
+	}
+	rootPath, err := resolveDemoRoot(cmd.String("path"))
+	if err != nil {
+		return err
+	}
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve centian executable: %w", err)
+	}
+
+	runner := agentrunner.DemoRunner{}
+	_, err = runner.RunDemo(ctx, &agentrunner.DemoOptions{
+		Agent:             cmd.String("agent"),
+		RootPath:          rootPath,
+		CentianBinaryPath: binaryPath,
+		Timeout:           5 * time.Minute,
+		ClaudeModel:       agentrunner.DefaultClaudeModel,
+		Stdout:            os.Stdout,
+		Stderr:            os.Stderr,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Println("Agent run finished. Centian is still running.")
+	return nil
+}
+
+func resolveDemoRoot(flagValue string) (string, error) {
+	if flagValue != "" {
+		return filepath.Abs(flagValue)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	return filepath.Abs(filepath.Join(cwd, ".centian", "demo"))
+}

--- a/internal/cli/demo_test.go
+++ b/internal/cli/demo_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	urfavecli "github.com/urfave/cli/v3"
+)
+
+func TestDemoCommandStructure(t *testing.T) {
+	if DemoCommand == nil {
+		t.Fatal("DemoCommand is nil")
+	}
+	if DemoCommand.Name != "demo" {
+		t.Fatalf("expected demo command name, got %q", DemoCommand.Name)
+	}
+	if DemoCommand.Action == nil {
+		t.Fatal("DemoCommand.Action is nil")
+	}
+	flagNames := map[string]bool{}
+	for _, flag := range DemoCommand.Flags {
+		if typed, ok := flag.(*urfavecli.StringFlag); ok {
+			flagNames[typed.Name] = true
+		}
+	}
+	for _, expected := range []string{"agent", "path"} {
+		if !flagNames[expected] {
+			t.Fatalf("expected %q flag on DemoCommand", expected)
+		}
+	}
+}
+
+func TestResolveDemoRootDefault(t *testing.T) {
+	cwd := t.TempDir()
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(original)
+	}()
+
+	root, err := resolveDemoRoot("")
+	if err != nil {
+		t.Fatalf("resolveDemoRoot: %v", err)
+	}
+	expected, err := filepath.Abs(filepath.Join(cwd, ".centian", "demo"))
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	if normalizeDarwinPath(root) != normalizeDarwinPath(expected) {
+		t.Fatalf("expected %s, got %s", expected, root)
+	}
+}
+
+func normalizeDarwinPath(value string) string {
+	return strings.TrimPrefix(value, "/private")
+}
+
+func TestHandleDemoCommandRequiresAgent(t *testing.T) {
+	cmd := &urfavecli.Command{}
+	err := handleDemoCommand(context.Background(), cmd)
+	if err == nil {
+		t.Fatal("expected error for missing agent")
+	}
+}

--- a/internal/proxy/proxy_taskverification_tools.go
+++ b/internal/proxy/proxy_taskverification_tools.go
@@ -13,15 +13,16 @@ import (
 )
 
 const (
-	taskListTemplatesTool      = "centian.task_list_templates"
-	taskRegisterTool           = "centian.task_register"
-	taskCompleteOnboardingTool = "centian.task_complete_onboarding"
-	taskCompletePlanningTool   = "centian.task_complete_planning"
-	taskStartStepTool          = "centian.task_start_step"
-	taskCompleteStepTool       = "centian.task_complete_step"
-	taskResumeTool             = "centian.task_resume"
-	taskRestartTool            = "centian.task_restart"
-	taskFailTool               = "centian.task_fail"
+	taskListTemplatesTool       = "centian.task_list_templates"
+	taskRegisterTool            = "centian.task_register"
+	taskCompleteOnboardingTool  = "centian.task_complete_onboarding"
+	taskCompletePlanningTool    = "centian.task_complete_planning"
+	taskStartStepTool           = "centian.task_start_step"
+	taskCompleteStepTool        = "centian.task_complete_step"
+	taskResumeTool              = "centian.task_resume"
+	taskRestartTool             = "centian.task_restart"
+	taskFailTool                = "centian.task_fail"
+	pathModeRelativeToWorkspace = "relative_to_workspace"
 )
 
 type taskRegisterArgs struct {
@@ -57,7 +58,8 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskListTemplatesTool,
-		Description: "List available task verification templates.",
+		Description: taskToolDescription("List available task verification templates."),
+		Annotations: taskReadOnlyAnnotations(),
 		InputSchema: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -67,7 +69,8 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskRegisterTool,
-		Description: "Register a task verification run from a template.",
+		Description: taskToolDescription("Register a task verification run from a template."),
+		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -81,21 +84,24 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskCompleteOnboardingTool,
-		Description: "Persist onboarding context and advance the task into planning. For compound shell commands or directory changes later in the workflow, use bash -lc '...'.",
+		Description: taskToolDescription("Persist onboarding context and advance the task into planning."),
+		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: taskCompleteOnboardingSchema(),
 	}, p.wrapTaskToolHandler(session, taskCompleteOnboardingTool, p.handleTaskCompleteOnboardingTool))
 	session.registeredStaticTools[taskCompleteOnboardingTool] = struct{}{}
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskCompletePlanningTool,
-		Description: "Persist planning context, freeze the contract, and enter execution.",
+		Description: taskToolDescription("Persist planning context, freeze the contract, and enter execution."),
+		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: taskCompletePlanningSchema(),
 	}, p.wrapTaskToolHandler(session, taskCompletePlanningTool, p.handleTaskCompletePlanningTool))
 	session.registeredStaticTools[taskCompletePlanningTool] = struct{}{}
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskStartStepTool,
-		Description: "Start a task step by running preconditions and capturing invariant baselines.",
+		Description: taskToolDescription("Start a task step by running preconditions and capturing invariant baselines."),
+		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -108,7 +114,8 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskCompleteStepTool,
-		Description: "Complete a task step by running postconditions and invariant checks.",
+		Description: taskToolDescription("Complete a task step by running postconditions and invariant checks."),
+		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -121,7 +128,8 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskResumeTool,
-		Description: "Resume a timed-out task verification run without resetting workflow progress.",
+		Description: taskToolDescription("Resume a timed-out task verification run without resetting workflow progress."),
+		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -131,7 +139,8 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskRestartTool,
-		Description: "Restart the active task verification run and clear step state.",
+		Description: taskToolDescription("Restart the active task verification run and clear step state."),
+		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
@@ -141,7 +150,8 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskFailTool,
-		Description: "Explicitly fail the active task verification run.",
+		Description: taskToolDescription("Explicitly fail the active task verification run."),
+		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -150,6 +160,28 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 		},
 	}, p.wrapTaskToolHandler(session, taskFailTool, p.handleTaskFailTool))
 	session.registeredStaticTools[taskFailTool] = struct{}{}
+}
+
+func taskToolDescription(base string) string {
+	return base + " Use workspaceRoot as the project root, keep file paths relative to it, and treat nextAction as the workflow hint."
+}
+
+func taskReadOnlyAnnotations() *mcp.ToolAnnotations {
+	openWorld := false
+	return &mcp.ToolAnnotations{
+		ReadOnlyHint:   true,
+		IdempotentHint: true,
+		OpenWorldHint:  &openWorld,
+	}
+}
+
+func taskStateTransitionAnnotations() *mcp.ToolAnnotations {
+	destructive := false
+	openWorld := false
+	return &mcp.ToolAnnotations{
+		DestructiveHint: &destructive,
+		OpenWorldHint:   &openWorld,
+	}
 }
 
 func (p *CentianEndpoint) wrapTaskToolHandler(
@@ -172,7 +204,7 @@ func (p *CentianEndpoint) wrapTaskToolHandler(
 			err    error
 		)
 		if invocationSnapshot.RunID == "" && !taskToolAllowedBeforeRegistration(toolName) {
-			result = taskToolRegistrationRequiredResult(toolName)
+			result = taskToolRegistrationRequiredResult(toolName, p.server.TaskVerification.WorkingDir)
 		} else {
 			result, err = handler(ctx, session, req)
 		}
@@ -214,23 +246,26 @@ func taskToolAllowedBeforeRegistration(toolName string) bool {
 	}
 }
 
-func taskToolRegistrationRequiredResult(toolName string) *mcp.CallToolResult {
+func taskToolRegistrationRequiredResult(toolName, workingDir string) *mcp.CallToolResult {
 	message := fmt.Sprintf(
 		"tool %q is not allowed before registering a task; call centian.task_list_templates and centian.task_register first",
 		toolName,
 	)
+	structured := map[string]any{
+		"error":              message,
+		"requestedTool":      toolName,
+		"reason":             governanceDeniedRegistrationNeeded,
+		"allowedBeforeRun":   []string{taskListTemplatesTool, taskRegisterTool},
+		"registrationNeeded": true,
+		"nextAction":         "Call centian.task_list_templates, then centian.task_register.",
+	}
+	addWorkspaceContext(structured, workingDir)
 	return &mcp.CallToolResult{
 		IsError: true,
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: message},
 		},
-		StructuredContent: map[string]any{
-			"error":              message,
-			"requestedTool":      toolName,
-			"reason":             governanceDeniedRegistrationNeeded,
-			"allowedBeforeRun":   []string{taskListTemplatesTool, taskRegisterTool},
-			"registrationNeeded": true,
-		},
+		StructuredContent: structured,
 	}
 }
 
@@ -401,7 +436,12 @@ func (p *CentianEndpoint) handleTaskListTemplatesTool(_ context.Context, _ *Upst
 	if len(lines) == 0 {
 		lines = append(lines, "No task templates available.")
 	}
-	return toolResult(strings.Join(lines, "\n"), map[string]any{"templates": structured}), nil
+	response := map[string]any{
+		"templates":  structured,
+		"nextAction": "Call centian.task_register with one templateId and its parameters.",
+	}
+	addWorkspaceContext(response, p.server.TaskVerification.WorkingDir)
+	return toolResult(strings.Join(lines, "\n"), response), nil
 }
 
 func (p *CentianEndpoint) handleTaskRegisterTool(ctx context.Context, session *UpstreamSession, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -435,7 +475,7 @@ func (p *CentianEndpoint) handleTaskRegisterTool(ctx context.Context, session *U
 		"draftParameters": run.DraftParameters,
 	})
 
-	structured := runStructuredContent(run)
+	structured := runStructuredContent(run, p.server.TaskVerification.WorkingDir)
 	stepCount := len(run.SelectedTemplate.CompiledWorkflow.WorkflowSteps)
 	structured["stepCount"] = stepCount
 	return toolResult(fmt.Sprintf("Registered task %s with %d declared step(s).", run.TemplateID, stepCount), structured), nil
@@ -461,7 +501,7 @@ func (p *CentianEndpoint) handleTaskCompleteOnboardingTool(ctx context.Context, 
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeOnboardingCompleted, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), map[string]any{
 		"taskSummary": args.Onboarding.TaskSummary,
 	})
-	structured := runStructuredContent(session.taskRun)
+	structured := runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)
 	if session.taskRun.Onboarding != nil {
 		structured["onboarding"] = session.taskRun.Onboarding
 	}
@@ -491,7 +531,7 @@ func (p *CentianEndpoint) handleTaskCompletePlanningTool(ctx context.Context, se
 	if node, exists := session.taskRun.CurrentNode(); exists && node.Kind == taskverification.WorkflowNodeKindWaitingForApproval {
 		p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeApprovalWaitEntered, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
 	}
-	structured := runStructuredContent(session.taskRun)
+	structured := runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)
 	if session.taskRun.Planning != nil {
 		structured["planning"] = session.taskRun.Planning
 	}
@@ -522,7 +562,7 @@ func (p *CentianEndpoint) handleTaskStartStepTool(ctx context.Context, session *
 	}
 	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeStepStarted, outcome, taskActionRequestIDFromContext(ctx), stepEventPayload(result))
-	return stepToolResult(result, session.taskRun), nil
+	return stepToolResult(result, session.taskRun, p.server.TaskVerification.WorkingDir, taskStartStepTool), nil
 }
 
 func (p *CentianEndpoint) handleTaskCompleteStepTool(ctx context.Context, session *UpstreamSession, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -554,7 +594,7 @@ func (p *CentianEndpoint) handleTaskCompleteStepTool(ctx context.Context, sessio
 			p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeApprovalWaitEntered, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
 		}
 	}
-	return stepToolResult(result, session.taskRun), nil
+	return stepToolResult(result, session.taskRun, p.server.TaskVerification.WorkingDir, taskCompleteStepTool), nil
 }
 
 func (p *CentianEndpoint) handleTaskResumeTool(ctx context.Context, session *UpstreamSession, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -570,7 +610,7 @@ func (p *CentianEndpoint) handleTaskResumeTool(ctx context.Context, session *Ups
 	}
 	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeResumed, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
-	return toolResult("Task resumed.", runStructuredContent(session.taskRun)), nil
+	return toolResult("Task resumed.", runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
 }
 
 func (p *CentianEndpoint) handleTaskRestartTool(ctx context.Context, session *UpstreamSession, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -586,7 +626,7 @@ func (p *CentianEndpoint) handleTaskRestartTool(ctx context.Context, session *Up
 	}
 	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeRestarted, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
-	return toolResult("Task restarted.", runStructuredContent(session.taskRun)), nil
+	return toolResult("Task restarted.", runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
 }
 
 func (p *CentianEndpoint) handleTaskFailTool(ctx context.Context, session *UpstreamSession, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -614,7 +654,7 @@ func (p *CentianEndpoint) handleTaskFailTool(ctx context.Context, session *Upstr
 	if strings.TrimSpace(args.Reason) != "" {
 		message = fmt.Sprintf("Task failed: %s", strings.TrimSpace(args.Reason))
 	}
-	return toolResult(message, runStructuredContent(session.taskRun)), nil
+	return toolResult(message, runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
 }
 
 func decodeToolArguments(req *mcp.CallToolRequest, target any) error {
@@ -637,8 +677,8 @@ func toolResult(message string, structured map[string]any) *mcp.CallToolResult {
 	}
 }
 
-func stepToolResult(result *taskverification.StepResult, run *taskverification.RunState) *mcp.CallToolResult {
-	structured := runStructuredContent(run)
+func stepToolResult(result *taskverification.StepResult, run *taskverification.RunState, workingDir, actionTool string) *mcp.CallToolResult {
+	structured := runStructuredContent(run, workingDir)
 	structured["passed"] = result.Passed
 	structured["message"] = result.Message
 	structured["step"] = result.Step
@@ -670,12 +710,15 @@ func stepToolResult(result *taskverification.StepResult, run *taskverification.R
 	if result.StderrSnippet != "" {
 		structured["stderrSnippet"] = result.StderrSnippet
 	}
+	structured["nextAction"] = nextActionForStepResult(result, run, actionTool)
 	return toolResult(result.Message, structured)
 }
 
-func runStructuredContent(run *taskverification.RunState) map[string]any {
+func runStructuredContent(run *taskverification.RunState, workingDir string) map[string]any {
 	if run == nil {
-		return map[string]any{}
+		structured := map[string]any{}
+		addWorkspaceContext(structured, workingDir)
+		return structured
 	}
 
 	structured := map[string]any{
@@ -695,10 +738,12 @@ func runStructuredContent(run *taskverification.RunState) map[string]any {
 		"explicitFailReason": run.ExplicitFailReason,
 	}
 	addTaskTimingFields(structured, run)
+	addWorkspaceContext(structured, workingDir)
 	addTaskContracts(structured)
 	addCurrentNodeContext(structured, run)
 	addPlanningNodeContext(structured, run)
 	addArtifactSummaries(structured, run)
+	structured["nextAction"] = nextActionForRun(run)
 
 	if !run.WorkflowReady || run.RunnableTemplate == nil {
 		return structured
@@ -708,10 +753,92 @@ func runStructuredContent(run *taskverification.RunState) map[string]any {
 	return structured
 }
 
+func addWorkspaceContext(structured map[string]any, workingDir string) {
+	if strings.TrimSpace(workingDir) == "" {
+		return
+	}
+	structured["workspaceRoot"] = workingDir
+	structured["pathMode"] = pathModeRelativeToWorkspace
+	structured["commandWorkingDirectory"] = workingDir
+}
+
 func addTaskContracts(structured map[string]any) {
 	structured["onboardingContract"] = onboardingContract()
 	structured["planningContract"] = planningContract()
 	structured["shellCommandHint"] = "For compound shell commands or directory changes, use bash -lc '...'."
+}
+
+func nextActionForRun(run *taskverification.RunState) string {
+	if run == nil {
+		return ""
+	}
+	switch run.Status {
+	case taskverification.TaskStatusCompleted:
+		return "Task is complete; stop task work."
+	case taskverification.TaskStatusFailed:
+		return "Restart the task or register a new task run."
+	case taskverification.TaskStatusTimedOut:
+		return "Call centian.task_resume or centian.task_restart."
+	}
+
+	node, exists := run.CurrentNode()
+	if !exists {
+		if run.Phase == taskverification.TaskPhaseInitialization {
+			return "Call centian.task_list_templates, then centian.task_register."
+		}
+		return ""
+	}
+
+	switch node.Kind {
+	case taskverification.WorkflowNodeKindOnboarding:
+		return "Call centian.task_complete_onboarding to freeze the onboarding context."
+	case taskverification.WorkflowNodeKindPlanning:
+		return "Call centian.task_complete_planning to freeze the execution contract."
+	case taskverification.WorkflowNodeKindWaitingForApproval:
+		return "Wait for approval before continuing task work."
+	case taskverification.WorkflowNodeKindScaffolding, taskverification.WorkflowNodeKindExecution:
+		stepNumber, active := activeOrCurrentStep(run)
+		if stepNumber == 0 {
+			return ""
+		}
+		if active {
+			return fmt.Sprintf("Do the step work in workspaceRoot, then call centian.task_complete_step for step %d.", stepNumber)
+		}
+		return fmt.Sprintf("Call centian.task_start_step for step %d.", stepNumber)
+	default:
+		return ""
+	}
+}
+
+func nextActionForStepResult(result *taskverification.StepResult, run *taskverification.RunState, actionTool string) string {
+	if result == nil {
+		return nextActionForRun(run)
+	}
+	if result.Passed {
+		return nextActionForRun(run)
+	}
+	retryTool := actionTool
+	if retryTool == "" {
+		retryTool = taskCompleteStepTool
+	}
+	return fmt.Sprintf("Fix the failed check in workspaceRoot, then retry %s for step %d.", retryTool, result.Step)
+}
+
+func activeOrCurrentStep(run *taskverification.RunState) (int, bool) {
+	if run == nil || run.RunnableTemplate == nil || run.RunnableTemplate.CompiledWorkflow == nil {
+		return 0, false
+	}
+	for idx := range run.Steps {
+		if run.Steps[idx].Status == taskverification.StepStatusActive {
+			return idx + 1, true
+		}
+	}
+	for idx := range run.RunnableTemplate.CompiledWorkflow.WorkflowSteps {
+		if run.RunnableTemplate.CompiledWorkflow.WorkflowSteps[idx].Path == run.Phase {
+			return idx + 1, false
+		}
+	}
+	return 0, false
 }
 
 func addCurrentNodeContext(structured map[string]any, run *taskverification.RunState) {

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -174,7 +174,7 @@ func TestNewUpstreamServerRegistersTaskVerificationTools(t *testing.T) {
 }
 
 func TestTaskToolFlowAndRestartFail(t *testing.T) {
-	_, session := newTaskToolTestProxy(t, basicTaskTemplate())
+	endpoint, session := newTaskToolTestProxy(t, basicTaskTemplate())
 
 	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
 	defer cleanup()
@@ -199,6 +199,10 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.DeepEqual(t, registerStructured["allowedTools"], []any{"shell__*", "filesystem__*"})
 	assert.Equal(t, registerStructured["executionReady"], false)
 	assert.Equal(t, registerStructured["hasOnboarding"], false)
+	assert.Equal(t, registerStructured["workspaceRoot"], endpoint.server.TaskVerification.WorkingDir)
+	assert.Equal(t, registerStructured["pathMode"], pathModeRelativeToWorkspace)
+	assert.Equal(t, registerStructured["commandWorkingDirectory"], endpoint.server.TaskVerification.WorkingDir)
+	assert.Equal(t, registerStructured["nextAction"], "Call centian.task_complete_onboarding to freeze the onboarding context.")
 	_, hasSteps := registerStructured["steps"]
 	assert.Assert(t, !hasSteps)
 
@@ -240,6 +244,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.DeepEqual(t, completeOnboardingStructured["allowedTools"], []any{"shell__*", "filesystem__*"})
 	assert.Assert(t, completeOnboardingStructured["onboarding"] != nil)
 	assert.Equal(t, completeOnboardingStructured["hasPlanning"], false)
+	assert.Equal(t, completeOnboardingStructured["nextAction"], "Call centian.task_complete_planning to freeze the execution contract.")
 
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskStartStepTool,
@@ -270,6 +275,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, completePlanningStructured["hasPlanning"], true)
 	assert.DeepEqual(t, completePlanningStructured["allowedTools"], []any{"shell__*", "filesystem__*"})
 	assert.Equal(t, completePlanningStructured["executionReady"], true)
+	assert.Equal(t, completePlanningStructured["nextAction"], "Call centian.task_start_step for step 1.")
 	assert.Assert(t, completePlanningStructured["planningSummary"] != nil)
 	assert.DeepEqual(t, completePlanningStructured["frozenContractSummary"], map[string]any{
 		"selectedFiles":        []any{"tests/test_mathlib.py"},
@@ -291,6 +297,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, startStepStructured["phase"], "execution.step_one")
 	assert.Equal(t, startStepStructured["stepStatus"], string(taskverification.StepStatusActive))
 	assert.Equal(t, startStepStructured["summary"], "step 1 (step_one) started")
+	assert.Equal(t, startStepStructured["nextAction"], "Do the step work in workspaceRoot, then call centian.task_complete_step for step 1.")
 	_, hasFailureKind := startStepStructured["failureKind"]
 	assert.Assert(t, !hasFailureKind)
 
@@ -306,6 +313,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, restartStructured["hasOnboarding"], true)
 	assert.Equal(t, restartStructured["hasPlanning"], false)
 	assert.Equal(t, restartStructured["taskSummary"], "Small test task context with one shell validation path.")
+	assert.Equal(t, restartStructured["nextAction"], "Call centian.task_complete_onboarding to freeze the onboarding context.")
 
 	failResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskFailTool,
@@ -318,6 +326,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, failStructured["status"], string(taskverification.TaskStatusFailed))
 	assert.Equal(t, failStructured["explicitFailReason"], "stuck")
 	assert.Equal(t, failStructured["phase"], string(taskverification.TaskPhaseOnboarding))
+	assert.Equal(t, failStructured["nextAction"], "Restart the task or register a new task run.")
 }
 
 func TestTaskToolFlowAllowsNoCheckTemplate(t *testing.T) {
@@ -426,6 +435,34 @@ func TestTaskVerificationToolSchemasExposeNestedArtifacts(t *testing.T) {
 	assert.Assert(t, planningProps["expectedFailure"] != nil)
 	assert.Assert(t, planningProps["implementationTarget"] != nil)
 	assert.Assert(t, planningProps["invariants"] != nil)
+
+	listTool := byName[taskListTemplatesTool]
+	assert.Assert(t, listTool.Annotations != nil)
+	assert.Equal(t, listTool.Annotations.ReadOnlyHint, true)
+	assert.Equal(t, listTool.Annotations.IdempotentHint, true)
+	assert.Assert(t, listTool.Annotations.OpenWorldHint != nil)
+	assert.Equal(t, *listTool.Annotations.OpenWorldHint, false)
+
+	for _, toolName := range []string{
+		taskRegisterTool,
+		taskCompleteOnboardingTool,
+		taskCompletePlanningTool,
+		taskStartStepTool,
+		taskCompleteStepTool,
+		taskResumeTool,
+		taskRestartTool,
+		taskFailTool,
+	} {
+		tool := byName[toolName]
+		assert.Assert(t, tool != nil)
+		assert.Assert(t, tool.Annotations != nil)
+		assert.Assert(t, tool.Annotations.DestructiveHint != nil)
+		assert.Equal(t, *tool.Annotations.DestructiveHint, false)
+		assert.Assert(t, tool.Annotations.OpenWorldHint != nil)
+		assert.Equal(t, *tool.Annotations.OpenWorldHint, false)
+		assert.Equal(t, tool.Annotations.ReadOnlyHint, false)
+		assert.Equal(t, tool.Annotations.IdempotentHint, false)
+	}
 }
 
 func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *testing.T) {
@@ -998,6 +1035,7 @@ workflow:
 	assert.Assert(t, structured["stdoutSnippet"] != nil)
 	assert.Assert(t, structured["summary"] != nil)
 	assert.Assert(t, structured["frozenContractSummary"] != nil)
+	assert.Equal(t, structured["nextAction"], "Fix the failed check in workspaceRoot, then retry centian.task_complete_step for step 1.")
 }
 
 func TestWorkflowNodeToolGovernanceAllowsMatchingTool(t *testing.T) {
@@ -1273,6 +1311,8 @@ func TestTaskLifecycleToolsRequireRegistrationFirst(t *testing.T) {
 	structured := result.StructuredContent.(map[string]any)
 	assert.Equal(t, structured["reason"], governanceDeniedRegistrationNeeded)
 	assert.Equal(t, structured["requestedTool"], taskCompleteOnboardingTool)
+	assert.Equal(t, structured["nextAction"], "Call centian.task_list_templates, then centian.task_register.")
+	assert.Equal(t, structured["pathMode"], pathModeRelativeToWorkspace)
 }
 
 func TestWorkflowNodeToolGovernanceDeniesUnmatchedTool(t *testing.T) {
@@ -1304,6 +1344,7 @@ func TestWorkflowNodeToolGovernanceDeniesUnmatchedTool(t *testing.T) {
 	assert.Equal(t, structured["currentNodeKind"], string(taskverification.WorkflowNodeKindOnboarding))
 	assert.Equal(t, structured["requestedTool"], "database__query")
 	assert.DeepEqual(t, structured["allowedTools"], []any{"shell__*", "filesystem__*"})
+	assert.Equal(t, structured["nextAction"], "Follow the current Centian workflow state before retrying this tool.")
 	assert.Assert(t, downstream.CapturedRequest == nil)
 }
 

--- a/internal/proxy/proxy_tool_governance.go
+++ b/internal/proxy/proxy_tool_governance.go
@@ -30,28 +30,28 @@ func (p *CentianEndpoint) enforceWorkflowNodeToolGovernance(session *UpstreamSes
 	run := session.taskRun
 	if run == nil {
 		if p.server != nil && p.server.Config != nil && p.server.Config.Proxy.TaskVerificationEnabled() {
-			return p.governanceDeniedResult(callCtx, "", "", "", nil, governanceDeniedRegistrationNeeded), true
+			return governanceDeniedResult(callCtx, taskverification.TaskPhaseInitialization, "", "", nil, governanceDeniedRegistrationNeeded), true
 		}
 		return nil, false
 	}
 	if run.Status != taskverification.TaskStatusActive {
-		return p.governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, governanceReasonForTaskStatus(run.Status)), true
+		return governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, governanceReasonForTaskStatus(run.Status)), true
 	}
 
 	node, exists := run.CurrentNode()
 	if !exists {
-		return p.governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, "unknown_workflow_node"), true
+		return governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, "unknown_workflow_node"), true
 	}
 	if node.Kind == taskverification.WorkflowNodeKindWaitingForApproval {
-		return p.governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedWaitingForApproval), true
+		return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedWaitingForApproval), true
 	}
 	if len(node.AllowedTools) == 0 {
-		return p.governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoAllowlist), true
+		return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoAllowlist), true
 	}
 	if matchesAllowedTool(node.AllowedTools, callCtx.GetOriginalToolName(), callCtx.GetToolName()) {
 		return nil, false
 	}
-	return p.governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoPatternMatch), true
+	return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoPatternMatch), true
 }
 
 func matchesAllowedTool(patterns []string, upstreamName, canonicalName string) bool {
@@ -69,7 +69,7 @@ func matchesAllowedTool(patterns []string, upstreamName, canonicalName string) b
 	return false
 }
 
-func (p *CentianEndpoint) governanceDeniedResult(
+func governanceDeniedResult(
 	callCtx CallContext,
 	phase taskverification.TaskPhase,
 	status taskverification.TaskStatus,
@@ -93,7 +93,13 @@ func (p *CentianEndpoint) governanceDeniedResult(
 		nodeKind,
 		reason,
 	)
-	if nodeKind == "" {
+	if phase == taskverification.TaskPhaseInitialization {
+		message = `All actions are blocked until task registration at centian.
+		Use 'centian.task_list_templates' to list all templates, 
+		select one, and call 'centian.task_register' accordingly.
+		Follow the centian workflow as provided to you.
+		`
+	} else if nodeKind == "" {
 		message = fmt.Sprintf(
 			"tool %q is not allowed in workflow phase %q: %s",
 			requestedTool,

--- a/internal/proxy/proxy_tool_governance.go
+++ b/internal/proxy/proxy_tool_governance.go
@@ -30,28 +30,28 @@ func (p *CentianEndpoint) enforceWorkflowNodeToolGovernance(session *UpstreamSes
 	run := session.taskRun
 	if run == nil {
 		if p.server != nil && p.server.Config != nil && p.server.Config.Proxy.TaskVerificationEnabled() {
-			return governanceDeniedResult(callCtx, taskverification.TaskPhaseInitialization, "", "", nil, governanceDeniedRegistrationNeeded), true
+			return governanceDeniedResult(callCtx, taskverification.TaskPhaseInitialization, "", "", nil, governanceDeniedRegistrationNeeded, p.server.TaskVerification.WorkingDir), true
 		}
 		return nil, false
 	}
 	if run.Status != taskverification.TaskStatusActive {
-		return governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, governanceReasonForTaskStatus(run.Status)), true
+		return governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, governanceReasonForTaskStatus(run.Status), p.server.TaskVerification.WorkingDir), true
 	}
 
 	node, exists := run.CurrentNode()
 	if !exists {
-		return governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, "unknown_workflow_node"), true
+		return governanceDeniedResult(callCtx, run.Phase, run.Status, "", nil, "unknown_workflow_node", p.server.TaskVerification.WorkingDir), true
 	}
 	if node.Kind == taskverification.WorkflowNodeKindWaitingForApproval {
-		return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedWaitingForApproval), true
+		return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedWaitingForApproval, p.server.TaskVerification.WorkingDir), true
 	}
 	if len(node.AllowedTools) == 0 {
-		return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoAllowlist), true
+		return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoAllowlist, p.server.TaskVerification.WorkingDir), true
 	}
 	if matchesAllowedTool(node.AllowedTools, callCtx.GetOriginalToolName(), callCtx.GetToolName()) {
 		return nil, false
 	}
-	return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoPatternMatch), true
+	return governanceDeniedResult(callCtx, run.Phase, run.Status, node.Kind, node.AllowedTools, governanceDeniedNoPatternMatch, p.server.TaskVerification.WorkingDir), true
 }
 
 func matchesAllowedTool(patterns []string, upstreamName, canonicalName string) bool {
@@ -76,6 +76,7 @@ func governanceDeniedResult(
 	nodeKind taskverification.WorkflowNodeKind,
 	allowedTools []string,
 	reason string,
+	workingDir string,
 ) *mcp.CallToolResult {
 	allowedToolCopy := append([]string{}, allowedTools...)
 	requestedTool := ""
@@ -121,7 +122,11 @@ func governanceDeniedResult(
 			"currentNodeKind": string(nodeKind),
 			"reason":          reason,
 			"allowedTools":    allowedToolCopy,
+			"nextAction":      governanceNextAction(reason),
 		},
+	}
+	if structured, ok := result.StructuredContent.(map[string]any); ok {
+		addWorkspaceContext(structured, workingDir)
 	}
 
 	if callCtx != nil {
@@ -136,6 +141,23 @@ func governanceDeniedResult(
 	}
 
 	return result
+}
+
+func governanceNextAction(reason string) string {
+	switch reason {
+	case governanceDeniedRegistrationNeeded:
+		return "Call centian.task_list_templates, then centian.task_register."
+	case governanceDeniedTaskCompleted:
+		return "Task is complete; stop task work."
+	case governanceDeniedTaskFailed:
+		return "Restart the task or register a new task run."
+	case governanceDeniedTaskTimedOut:
+		return "Call centian.task_resume or centian.task_restart."
+	case governanceDeniedWaitingForApproval:
+		return "Wait for approval before continuing task work."
+	default:
+		return "Follow the current Centian workflow state before retrying this tool."
+	}
 }
 
 func governanceReasonForTaskStatus(status taskverification.TaskStatus) string {

--- a/internal/taskverification/conditions.go
+++ b/internal/taskverification/conditions.go
@@ -29,6 +29,14 @@ var conditionRegistry = map[string]conditionHandler{
 		validate: validateStringValueCondition,
 		evaluate: evaluateStdoutNotContainsCondition,
 	},
+	"output_contains": {
+		validate: validateStringValueCondition,
+		evaluate: evaluateOutputContainsCondition,
+	},
+	"output_not_contains": {
+		validate: validateStringValueCondition,
+		evaluate: evaluateOutputNotContainsCondition,
+	},
 	"file_exists": {
 		validate: validatePathCondition,
 		evaluate: evaluateFileExistsCondition,
@@ -133,6 +141,22 @@ func evaluateStdoutNotContainsCondition(condition Condition, result *commandResu
 	return evaluateStdoutNotContains(value, result.Stdout)
 }
 
+func evaluateOutputContainsCondition(condition Condition, result *commandResult, _ string) error {
+	value, ok := condition.Value.(string)
+	if !ok {
+		return fmt.Errorf("output_contains condition requires a string value, got %T", condition.Value)
+	}
+	return evaluateOutputContains(value, result)
+}
+
+func evaluateOutputNotContainsCondition(condition Condition, result *commandResult, _ string) error {
+	value, ok := condition.Value.(string)
+	if !ok {
+		return fmt.Errorf("output_not_contains condition requires a string value, got %T", condition.Value)
+	}
+	return evaluateOutputNotContains(value, result)
+}
+
 func evaluateFileExistsCondition(condition Condition, _ *commandResult, workingDir string) error {
 	return evaluateFileExists(condition.Path, workingDir)
 }
@@ -169,6 +193,33 @@ func evaluateStdoutNotContains(unexpected, stdout string) error {
 		return fmt.Errorf("expected stdout not to contain %q", unexpected)
 	}
 	return nil
+}
+
+func evaluateOutputContains(expected string, result *commandResult) error {
+	if !strings.Contains(combinedCommandOutput(result), expected) {
+		return fmt.Errorf("expected output to contain %q", expected)
+	}
+	return nil
+}
+
+func evaluateOutputNotContains(unexpected string, result *commandResult) error {
+	if strings.Contains(combinedCommandOutput(result), unexpected) {
+		return fmt.Errorf("expected output not to contain %q", unexpected)
+	}
+	return nil
+}
+
+func combinedCommandOutput(result *commandResult) string {
+	if result == nil {
+		return ""
+	}
+	if result.Stdout == "" {
+		return result.Stderr
+	}
+	if result.Stderr == "" {
+		return result.Stdout
+	}
+	return result.Stdout + "\n" + result.Stderr
 }
 
 func evaluateFileExists(path, workingDir string) error {

--- a/internal/taskverification/conditions_test.go
+++ b/internal/taskverification/conditions_test.go
@@ -63,6 +63,28 @@ func TestEvaluateStdoutNotContainsCondition_ValidString(t *testing.T) {
 	}
 }
 
+func TestEvaluateOutputContainsCondition_MatchesStderr(t *testing.T) {
+	condition := Condition{Type: "output_contains", Value: "FAIL"}
+	result := &commandResult{Stdout: "", Stderr: "FAIL: test case"}
+
+	err := evaluateOutputContainsCondition(condition, result, "")
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestEvaluateOutputNotContainsCondition_UsesCombinedStreams(t *testing.T) {
+	condition := Condition{Type: "output_not_contains", Value: "panic"}
+	result := &commandResult{Stdout: "ok", Stderr: "still ok"}
+
+	err := evaluateOutputNotContainsCondition(condition, result, "")
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
 func TestEvaluateFileContainsCondition_NonStringValue(t *testing.T) {
 	// Given: a condition with a non-string value and a temp file
 	tmpDir := t.TempDir()

--- a/internal/taskverification/types.go
+++ b/internal/taskverification/types.go
@@ -220,6 +220,8 @@ const (
 type TaskPhase string
 
 const (
+	// TaskPhaseInitialization is the workflow path before registering a task.
+	TaskPhaseInitialization TaskPhase = "initialization"
 	// TaskPhaseOnboarding is the onboarding workflow path.
 	TaskPhaseOnboarding TaskPhase = "onboarding"
 	// TaskPhasePlanning is the planning workflow path.

--- a/task-templates/python_tdd_workflow.yaml
+++ b/task-templates/python_tdd_workflow.yaml
@@ -108,12 +108,12 @@ workflow:
           pre_conditions:
             - type: exit_code
               value: 1
-            - type: stdout_contains
+            - type: output_contains
               value: "${expectedError}"
           post_conditions:
             - type: exit_code
               value: 1
-            - type: stdout_contains
+            - type: output_contains
               value: "${expectedError}"
     - id: "implement_solution"
       name: "Implement solution"

--- a/tests/integrationtests/demo/demo_integration_test.go
+++ b/tests/integrationtests/demo/demo_integration_test.go
@@ -1,0 +1,132 @@
+//go:build !windows
+
+package demo
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const runDemoIntegrationEnv = "CENTIAN_RUN_DEMO_INTEGRATION"
+
+func TestCentianDemoClaude(t *testing.T) {
+	if os.Getenv(runDemoIntegrationEnv) != "1" {
+		t.Skipf("set %s=1 to run demo integration tests", runDemoIntegrationEnv)
+	}
+	if _, err := exec.LookPath("claude"); err != nil {
+		t.Fatalf("claude is not available: %v", err)
+	}
+	if _, err := exec.LookPath("npx"); err != nil {
+		t.Fatalf("npx is not available: %v", err)
+	}
+
+	root := t.TempDir()
+	binary := filepath.Join(root, "centian")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/main.go")
+	build.Dir = repoRoot(t)
+	build.Env = append(os.Environ(), "GOCACHE=/tmp/centian-gocache")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build centian binary: %v\n%s", err, strings.TrimSpace(string(output)))
+	}
+
+	demoRoot := filepath.Join(root, "demo")
+	cmd := exec.Command(binary, "demo", "--agent", "claude", "--path", demoRoot)
+	cmd.Dir = repoRoot(t)
+	cmd.Env = os.Environ()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run centian demo: %v\n%s", err, strings.TrimSpace(string(output)))
+	}
+
+	for _, path := range []string{
+		filepath.Join(demoRoot, "workspace"),
+		filepath.Join(demoRoot, "templates", "python_tdd_workflow.yaml"),
+		filepath.Join(demoRoot, "logs"),
+		filepath.Join(demoRoot, "config.json"),
+		filepath.Join(demoRoot, "prompt.md"),
+		filepath.Join(demoRoot, "claude_mcp_config.json"),
+		filepath.Join(demoRoot, "centian.pid"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected demo artifact %s: %v", path, err)
+		}
+	}
+
+	pidBytes, err := os.ReadFile(filepath.Join(demoRoot, "centian.pid"))
+	if err != nil {
+		t.Fatalf("read centian.pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("parse centian pid: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGTERM)
+	})
+
+	port := readPort(t, filepath.Join(demoRoot, "config.json"))
+	baseURL := "http://127.0.0.1:" + port
+	waitForHTTP(t, baseURL+"/api/task-runs")
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("failed to locate repo root")
+		}
+		dir = parent
+	}
+}
+
+func readPort(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var payload struct {
+		Proxy struct {
+			Port string `json:"port"`
+		} `json:"proxy"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if payload.Proxy.Port == "" {
+		t.Fatal("config port is empty")
+	}
+	return payload.Proxy.Port
+}
+
+func waitForHTTP(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", url)
+}

--- a/tests/integrationtests/taskverification/README.md
+++ b/tests/integrationtests/taskverification/README.md
@@ -1,0 +1,200 @@
+# Taskverification Black-Box Integration Test
+
+This directory contains the host-native black-box integration harness for Centian taskverification.
+
+The goal of this test is to run real local coding agents against a real Centian process and assert the result from Centian's own task runs, events, and request logs, not from the agent's prose.
+
+## What This Test Covers
+
+The harness starts a fresh local Centian instance, points a headless agent at that instance over MCP, gives the agent a clean user-style prompt, and then checks whether Centian observed a valid taskverification lifecycle.
+
+Today the suite supports:
+
+- `codex`
+- `claude`
+
+The same prompt and task template are used for both agents.
+
+This is intentionally a black-box test:
+
+- the agent sees only the configured Centian MCP server
+- the prompt does not teach the agent Centian internals
+- success is asserted from Centian task state and project output
+
+## Fixture Files
+
+This directory contains the versioned fixtures used by the harness:
+
+- [blackbox_test.go](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/blackbox_test.go): test harness and strict assertions
+- [centian_config.json](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/centian_config.json): Centian config template resolved into a temp run directory
+- [prompt.yaml](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/prompt.yaml): shared user-style prompt
+- [python_tdd_workflow.yaml](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/python_tdd_workflow.yaml): taskverification template fixture
+- [codex_config.toml](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/codex_config.toml): Codex config template
+- [claude_mcp_config.json](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/claude_mcp_config.json): Claude MCP config template
+
+The harness creates one preserved run directory per agent under [`.tmp`](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/.tmp), for example:
+
+```text
+tests/integrationtests/taskverification/.tmp/20260330145635_run_codex
+```
+
+Each run directory contains:
+
+- `project/`: the empty project root the agent must populate
+- `templates/`: localized taskverification templates used by Centian
+- `logs/`: request logs and SQLite event store
+- `centian.config.json`: resolved Centian config for the run
+- `centian.stdout.log` and `centian.stderr.log`
+- `codex/` or `claude/`: agent-specific config, stdout, stderr, and captured final output
+
+Artifacts are intentionally preserved after the test finishes.
+
+## Runtime Flow
+
+For each selected agent, the harness does the following:
+
+1. Creates a fresh temp run directory under [`.tmp`](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/.tmp).
+2. Creates an empty `project/` directory.
+3. Copies the versioned task template fixture into `templates/`.
+4. Resolves [centian_config.json](/Users/brb/_devspace/centian-cli/tests/integrationtests/taskverification/centian_config.json) into a run-local config.
+5. Starts `centian start --config-path <run-config>` with its process working directory set to the run-local project root.
+6. Waits for:
+   - the MCP endpoint `/mcp/taskverification`
+   - the HTTP API `/api/task-runs`
+7. Prints the UI URL:
+   - `http://127.0.0.1:<port>/ui/tasks`
+8. Creates agent-specific config in the run directory and starts the agent headlessly.
+9. After the agent exits or times out, fetches:
+   - `/api/task-runs`
+   - `/api/task-runs/{runID}/events`
+   - the latest `requests_*.jsonl`
+10. Verifies both Centian lifecycle behavior and the produced Python files in `project/`.
+
+## Strict Success Criteria
+
+The black-box test currently requires all of the following:
+
+- at least one task run was created
+- the latest task run finished with `completed`
+- the observed task tool call order includes:
+  - `centian.task_list_templates`
+  - `centian.task_register`
+  - `centian.task_complete_onboarding`
+  - `centian.task_complete_planning`
+  - `centian.task_start_step`
+  - `centian.task_complete_step`
+- `centian.task_fail` was not used
+- no terminal failure or timeout event was recorded
+- the agent created:
+  - `score_parentheses.py`
+  - `test_score_parentheses.py`
+- the final project passes:
+  - `python test_score_parentheses.py`
+  - `python -m py_compile score_parentheses.py test_score_parentheses.py`
+
+## Running The Test
+
+Preferred command:
+
+```bash
+make test-taskverification-blackbox
+```
+
+Direct `go test` command:
+
+```bash
+CENTIAN_RUN_TASKVERIFICATION_BLACKBOX=1 \
+go test -v ./tests/integrationtests/taskverification -run TestTaskVerificationBlackBox
+```
+
+Useful environment variables:
+
+- `CENTIAN_RUN_TASKVERIFICATION_BLACKBOX=1`: required opt-in gate
+- `CENTIAN_TASKVERIFICATION_AGENTS=codex,claude`: agent selection
+- `CENTIAN_TASKVERIFICATION_AGENT_TIMEOUT=15m`: per-agent timeout
+- `CENTIAN_TASKVERIFICATION_BINARY=/path/to/centian`: Centian binary override
+- `CODEX_MODEL=<model>`: optional Codex model override
+- `CLAUDE_MODEL=<model>`: optional Claude model override
+
+Prerequisites:
+
+- `centian` available on `PATH`, or set via `CENTIAN_TASKVERIFICATION_BINARY`
+- `python`
+- `npx`
+- `codex` and/or `claude`
+
+The test fixture assumes only standard-library Python is available. It does not require `pytest` or `ruff`.
+
+## Debugging
+
+The printed UI URL can be opened while the test is running to observe task runs in real time.
+
+The most useful artifacts after a failure are:
+
+- `centian.stderr.log`: Centian startup and proxy errors
+- `logs/requests_*.jsonl`: exact MCP request log as seen by Centian
+- `logs/events.sqlite`: persisted task and action events
+- `codex/stdout.jsonl` or `claude/stdout.json`: agent transcript output
+- `codex/stderr.log` or `claude/stderr.log`
+
+If an agent created no task run at all, start with:
+
+- the agent stderr log
+- the run-local config files
+- `centian.stderr.log`
+
+If a task run exists but did not complete, inspect:
+
+- the task events from the UI or API
+- `requests_*.jsonl`
+- the project files under `project/`
+
+## Known Limitation
+
+This harness is a strong black-box test of Centian taskverification, but it is **not yet a strict MCP-only confinement test**, especially for Codex.
+
+Current limitation:
+
+- Codex can still use native workspace capabilities that are not mediated by Centian.
+- Proxied tool annotations are preserved from the downstream tools, so approval behavior is still partly determined outside Centian.
+- Changing annotations only for Centian-owned tools is not enough, because proxied tools can still present approval-triggering metadata to the client.
+
+In practice this means:
+
+- a run can succeed through Centian while still involving agent-native file access
+- approval or tool-safety behavior may differ across clients even when the Centian task flow is identical
+
+This does not make the test useless, but it does mean the result should be interpreted as:
+
+- "did the agent complete a real task through Centian?"
+
+not as:
+
+- "was every action forced through Centian and only through Centian?"
+
+## Potential Future Mitigation
+
+A likely future mitigation is a **configurable, client-specific tool annotation override** at the gateway level.
+
+High-level idea:
+
+- configure a gateway policy that targets specific clients such as Codex
+- when a matching client connects, Centian rewrites annotations for **all tools exposed by that gateway**
+- this includes both:
+  - Centian-owned task tools
+  - proxied downstream tools
+
+The most likely first policy mode is:
+
+- `force_read_only`
+
+That mode would present all tools on that gateway as:
+
+- `readOnlyHint = true`
+- `idempotentHint = true`
+- `destructiveHint = false`
+- `openWorldHint = false`
+
+This would not change actual tool behavior or governance. It would only change how the client interprets tool safety and approval requirements.
+
+That mitigation is intentionally deferred. The current priority of this directory is to keep the black-box taskverification test understandable, inspectable, and stable enough to expose real agent-integration issues.

--- a/tests/integrationtests/taskverification/blackbox_test.go
+++ b/tests/integrationtests/taskverification/blackbox_test.go
@@ -222,11 +222,7 @@ func newArtifactDir(t *testing.T, assetsDir, agentName string) (string, func()) 
 		dir = filepath.Join(root, fmt.Sprintf("%s_%02d", baseName, i))
 	}
 	return dir, func() {
-		if t.Failed() {
-			t.Logf("preserving taskverification black-box artifacts at %s", dir)
-			return
-		}
-		_ = os.RemoveAll(dir)
+		t.Logf("preserving taskverification black-box artifacts at %s", dir)
 	}
 }
 
@@ -571,6 +567,7 @@ func waitForCentian(t *testing.T, h *blackboxHarness) {
 		mcpReady := isEndpointReachable(client, h.mcpURL)
 		apiReady := isJSONEndpointReady(client, apiURL)
 		if mcpReady && apiReady {
+			fmt.Printf("Task UI: %s/ui/tasks\n", h.baseURL)
 			return
 		}
 		time.Sleep(500 * time.Millisecond)

--- a/tests/integrationtests/taskverification/blackbox_test.go
+++ b/tests/integrationtests/taskverification/blackbox_test.go
@@ -50,7 +50,7 @@ type agentAdapter interface {
 	Name() string
 	IsAvailable() error
 	PrepareConfig(*testing.T, *blackboxHarness) (agentLaunchConfig, error)
-	Run(context.Context, *testing.T, *blackboxHarness, agentLaunchConfig, string) error
+	Run(context.Context, *testing.T, *blackboxHarness, *agentLaunchConfig, string) error
 }
 
 type agentLaunchConfig struct {
@@ -86,7 +86,6 @@ func TestTaskVerificationBlackBox(t *testing.T) {
 		t.Fatalf("no agents selected via %s", agentsEnv)
 	}
 	for _, adapter := range adapters {
-		adapter := adapter
 		t.Run(adapter.Name(), func(t *testing.T) {
 			harness := newBlackboxHarness(t, adapter.Name())
 			prompt := loadUserPrompt(t, harness.assetsDir)
@@ -111,13 +110,13 @@ func TestTaskVerificationBlackBox(t *testing.T) {
 				t.Fatalf("failed to prepare %s config: %v", adapter.Name(), err)
 			}
 
-			err = adapter.Run(runCtx, t, harness, cfg, prompt)
+			err = adapter.Run(runCtx, t, harness, &cfg, prompt)
 			runs := fetchTaskRuns(t, harness)
 			if len(runs) == 0 {
 				t.Fatalf("%s created no task run; run error: %v; artifacts: %s", adapter.Name(), err, cfg.ArtifactRoot)
 			}
 
-			latest := runs[0]
+			latest := &runs[0]
 			events := fetchTaskRunEvents(t, harness, latest.RunID)
 			requests := loadRequestLogs(t, harness)
 
@@ -401,8 +400,9 @@ func (codexAdapter) PrepareConfig(t *testing.T, h *blackboxHarness) (agentLaunch
 			"codex",
 			"exec",
 			"--skip-git-repo-check",
-			"--dangerously-bypass-approvals-and-sandbox",
 			"--json",
+			// "--full-auto",
+			// "--dangerously-bypass-approvals-and-sandbox",
 			"-C", workDir,
 			"-o", filepath.Join(artifactRoot, "final.txt"),
 			"-",
@@ -410,7 +410,7 @@ func (codexAdapter) PrepareConfig(t *testing.T, h *blackboxHarness) (agentLaunch
 	}, nil
 }
 
-func (codexAdapter) Run(ctx context.Context, t *testing.T, _ *blackboxHarness, cfg agentLaunchConfig, prompt string) error {
+func (codexAdapter) Run(ctx context.Context, t *testing.T, _ *blackboxHarness, cfg *agentLaunchConfig, prompt string) error {
 	t.Helper()
 	return runAgentCommand(ctx, cfg, prompt)
 }
@@ -474,12 +474,12 @@ func (claudeAdapter) PrepareConfig(t *testing.T, h *blackboxHarness) (agentLaunc
 	}, nil
 }
 
-func (claudeAdapter) Run(ctx context.Context, t *testing.T, _ *blackboxHarness, cfg agentLaunchConfig, prompt string) error {
+func (claudeAdapter) Run(ctx context.Context, t *testing.T, _ *blackboxHarness, cfg *agentLaunchConfig, prompt string) error {
 	t.Helper()
 	return runAgentCommand(ctx, cfg, prompt)
 }
 
-func runAgentCommand(ctx context.Context, cfg agentLaunchConfig, prompt string) error {
+func runAgentCommand(ctx context.Context, cfg *agentLaunchConfig, prompt string) error {
 	stdoutFile, err := os.Create(cfg.StdoutPath)
 	if err != nil {
 		return err
@@ -654,7 +654,7 @@ func loadRequestLogs(t *testing.T, h *blackboxHarness) []requestLogEntry {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Bytes()
-		if len(strings.TrimSpace(string(line))) == 0 {
+		if strings.TrimSpace(string(line)) == "" {
 			continue
 		}
 		var entry requestLogEntry
@@ -673,7 +673,7 @@ func assertStrictSuccess(
 	t *testing.T,
 	agentName string,
 	h *blackboxHarness,
-	latest persistence.TaskRunSummary,
+	latest *persistence.TaskRunSummary,
 	events []persistence.TaskRunEvent,
 	requests []requestLogEntry,
 ) {
@@ -716,7 +716,8 @@ func assertStrictSuccess(
 	}
 
 	eventTypes := make([]string, 0)
-	for _, event := range events {
+	for idx := range events {
+		event := &events[idx]
 		if event.Source != persistence.TaskRunEventSourceTask || event.EventType == "" {
 			continue
 		}
@@ -748,7 +749,7 @@ func assertStrictSuccess(
 	runProjectCommand(t, h.projectDir, "python", "-m", "py_compile", "score_parentheses.py", "test_score_parentheses.py")
 }
 
-func runProjectCommand(t *testing.T, dir string, name string, args ...string) {
+func runProjectCommand(t *testing.T, dir, name string, args ...string) {
 	t.Helper()
 
 	cmd := exec.Command(name, args...)

--- a/tests/integrationtests/taskverification/blackbox_test.go
+++ b/tests/integrationtests/taskverification/blackbox_test.go
@@ -1,0 +1,831 @@
+package taskverification
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/T4cceptor/centian/internal/persistence"
+	tv "github.com/T4cceptor/centian/internal/taskverification"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	runBlackboxEnv      = "CENTIAN_RUN_TASKVERIFICATION_BLACKBOX"
+	agentsEnv           = "CENTIAN_TASKVERIFICATION_AGENTS"
+	agentTimeoutEnv     = "CENTIAN_TASKVERIFICATION_AGENT_TIMEOUT"
+	centianBinaryEnv    = "CENTIAN_TASKVERIFICATION_BINARY"
+	defaultAgentTimeout = 15 * time.Minute
+)
+
+type blackboxHarness struct {
+	t              *testing.T
+	assetsDir      string
+	artifactsDir   string
+	projectDir     string
+	templatesDir   string
+	configPath     string
+	baseURL        string
+	mcpURL         string
+	logDir         string
+	internalLog    string
+	eventStorePath string
+	requestLogDir  string
+}
+
+type agentAdapter interface {
+	Name() string
+	IsAvailable() error
+	PrepareConfig(*testing.T, *blackboxHarness) (agentLaunchConfig, error)
+	Run(context.Context, *testing.T, *blackboxHarness, agentLaunchConfig, string) error
+}
+
+type agentLaunchConfig struct {
+	WorkDir      string
+	StdoutPath   string
+	StderrPath   string
+	FinalPath    string
+	Env          []string
+	Command      []string
+	ConfigPath   string
+	ArtifactRoot string
+}
+
+type requestLogEntry struct {
+	ToolCall *struct {
+		Name         string `json:"name"`
+		OriginalName string `json:"original_name"`
+		IsError      bool   `json:"is_error"`
+	} `json:"tool_call"`
+}
+
+type promptFile struct {
+	Prompt string `yaml:"prompt"`
+}
+
+func TestTaskVerificationBlackBox(t *testing.T) {
+	if os.Getenv(runBlackboxEnv) != "1" {
+		t.Skipf("set %s=1 to run taskverification black-box tests", runBlackboxEnv)
+	}
+
+	adapters := selectedAgentAdapters()
+	if len(adapters) == 0 {
+		t.Fatalf("no agents selected via %s", agentsEnv)
+	}
+	for _, adapter := range adapters {
+		adapter := adapter
+		t.Run(adapter.Name(), func(t *testing.T) {
+			harness := newBlackboxHarness(t, adapter.Name())
+			prompt := loadUserPrompt(t, harness.assetsDir)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			centianCmd := startCentian(t, ctx, harness)
+			defer stopCommand(t, centianCmd)
+
+			waitForCentian(t, harness)
+
+			if err := adapter.IsAvailable(); err != nil {
+				t.Fatalf("%s adapter is not available: %v", adapter.Name(), err)
+			}
+
+			agentTimeout := loadAgentTimeout(t)
+			runCtx, runCancel := context.WithTimeout(context.Background(), agentTimeout)
+			defer runCancel()
+
+			cfg, err := adapter.PrepareConfig(t, harness)
+			if err != nil {
+				t.Fatalf("failed to prepare %s config: %v", adapter.Name(), err)
+			}
+
+			err = adapter.Run(runCtx, t, harness, cfg, prompt)
+			runs := fetchTaskRuns(t, harness)
+			if len(runs) == 0 {
+				t.Fatalf("%s created no task run; run error: %v; artifacts: %s", adapter.Name(), err, cfg.ArtifactRoot)
+			}
+
+			latest := runs[0]
+			events := fetchTaskRunEvents(t, harness, latest.RunID)
+			requests := loadRequestLogs(t, harness)
+
+			assertStrictSuccess(t, adapter.Name(), harness, latest, events, requests)
+			if err != nil {
+				t.Fatalf("%s run failed despite successful task assertions: %v; artifacts: %s", adapter.Name(), err, cfg.ArtifactRoot)
+			}
+		})
+	}
+}
+
+func newBlackboxHarness(t *testing.T, agentName string) *blackboxHarness {
+	t.Helper()
+
+	assetsDir := assetDir(t)
+	artifactsDir, cleanup := newArtifactDir(t, assetsDir, agentName)
+	t.Cleanup(cleanup)
+
+	projectDir := filepath.Join(artifactsDir, "project")
+	templatesDir := filepath.Join(artifactsDir, "templates")
+	logDir := filepath.Join(artifactsDir, "logs")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("failed to create project dir: %v", err)
+	}
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+		t.Fatalf("failed to create templates dir: %v", err)
+	}
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+
+	writeEmptyProject(t, projectDir)
+	writeLocalTemplates(t, assetsDir, templatesDir)
+
+	port := allocateFreePort(t)
+	baseURL := "http://127.0.0.1:" + port
+	configPath := filepath.Join(artifactsDir, "centian.config.json")
+	eventStorePath := filepath.Join(logDir, "events.sqlite")
+	internalLog := filepath.Join(artifactsDir, "centian_internal.log")
+	writeCentianConfig(t, assetsDir, configPath, templatesDir, projectDir, internalLog, eventStorePath, port)
+
+	return &blackboxHarness{
+		t:              t,
+		assetsDir:      assetsDir,
+		artifactsDir:   artifactsDir,
+		projectDir:     projectDir,
+		templatesDir:   templatesDir,
+		configPath:     configPath,
+		baseURL:        baseURL,
+		mcpURL:         baseURL + "/mcp/taskverification",
+		logDir:         logDir,
+		internalLog:    internalLog,
+		eventStorePath: eventStorePath,
+		requestLogDir:  logDir,
+	}
+}
+
+func assetDir(t *testing.T) string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Dir("tests/integrationtests/taskverification/blackbox_test.go"))
+	if err == nil {
+		if _, statErr := os.Stat(path); statErr == nil {
+			return path
+		}
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to resolve working directory: %v", err)
+	}
+	for {
+		candidate := filepath.Join(dir, "tests", "integrationtests", "taskverification")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("failed to locate taskverification test asset directory from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+func newArtifactDir(t *testing.T, assetsDir, agentName string) (string, func()) {
+	t.Helper()
+
+	root := filepath.Join(assetsDir, ".tmp")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("failed to create taskverification tmp dir: %v", err)
+	}
+	baseName := time.Now().Format("20060102150405") + "_run_" + sanitizeName(agentName)
+	dir := filepath.Join(root, baseName)
+	for i := 1; ; i++ {
+		err := os.Mkdir(dir, 0o755)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrExist) {
+			t.Fatalf("failed to create artifact dir: %v", err)
+		}
+		dir = filepath.Join(root, fmt.Sprintf("%s_%02d", baseName, i))
+	}
+	return dir, func() {
+		if t.Failed() {
+			t.Logf("preserving taskverification black-box artifacts at %s", dir)
+			return
+		}
+		_ = os.RemoveAll(dir)
+	}
+}
+
+func sanitizeName(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return "agent"
+	}
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	result := strings.Trim(b.String(), "_")
+	if result == "" {
+		return "agent"
+	}
+	return result
+}
+
+func writeEmptyProject(t *testing.T, projectDir string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(projectDir, ".gitkeep"), []byte(""), 0o644); err != nil {
+		t.Fatalf("failed to initialize empty project dir: %v", err)
+	}
+}
+
+func writeLocalTemplates(t *testing.T, assetsDir, templatesDir string) {
+	t.Helper()
+
+	data := []byte(loadAsset(t, assetsDir, "python_tdd_workflow.yaml"))
+	var template tv.Template
+	if err := yaml.Unmarshal(data, &template); err != nil {
+		t.Fatalf("failed to parse python_tdd_workflow.yaml fixture: %v", err)
+	}
+	if err := template.Validate(); err != nil {
+		t.Fatalf("python_tdd_workflow.yaml fixture is invalid: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templatesDir, "python_tdd_workflow.yaml"), data, 0o644); err != nil {
+		t.Fatalf("failed to write template fixture: %v", err)
+	}
+}
+
+func writeCentianConfig(
+	t *testing.T,
+	assetsDir string,
+	configPath, templatesDir, projectDir, internalLog, eventStorePath, port string,
+) {
+	t.Helper()
+
+	configTemplate := loadAsset(t, assetsDir, "centian_config.json")
+	replacer := strings.NewReplacer(
+		"__PORT__", port,
+		"__TEMPLATES_DIR__", templatesDir,
+		"__PROJECT_DIR__", projectDir,
+		"__INTERNAL_LOG__", internalLog,
+		"__EVENT_STORE_PATH__", eventStorePath,
+	)
+	resolved := replacer.Replace(configTemplate)
+	var payload any
+	if err := json.Unmarshal([]byte(resolved), &payload); err != nil {
+		t.Fatalf("failed to parse resolved centian config template: %v", err)
+	}
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal resolved centian config: %v", err)
+	}
+	if err := os.WriteFile(configPath, encoded, 0o644); err != nil {
+		t.Fatalf("failed to write centian config: %v", err)
+	}
+}
+
+func loadUserPrompt(t *testing.T, assetsDir string) string {
+	t.Helper()
+
+	content := loadAsset(t, assetsDir, "prompt.yaml")
+	var file promptFile
+	if err := yaml.Unmarshal([]byte(content), &file); err != nil {
+		t.Fatalf("failed to parse prompt.yaml: %v", err)
+	}
+	if strings.TrimSpace(file.Prompt) == "" {
+		t.Fatalf("prompt.yaml does not contain a prompt")
+	}
+	return strings.TrimSpace(file.Prompt)
+}
+
+func selectedAgentAdapters() []agentAdapter {
+	selected := strings.TrimSpace(os.Getenv(agentsEnv))
+	if selected == "" {
+		selected = "codex,claude"
+	}
+
+	available := map[string]agentAdapter{
+		"codex":  codexAdapter{},
+		"claude": claudeAdapter{},
+	}
+	result := make([]agentAdapter, 0, 2)
+	for _, raw := range strings.Split(selected, ",") {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		if name == "" {
+			continue
+		}
+		adapter, ok := available[name]
+		if !ok {
+			continue
+		}
+		result = append(result, adapter)
+	}
+	return result
+}
+
+type codexAdapter struct{}
+
+func (codexAdapter) Name() string { return "codex" }
+
+func (codexAdapter) IsAvailable() error {
+	_, err := exec.LookPath("codex")
+	return err
+}
+
+func (codexAdapter) PrepareConfig(t *testing.T, h *blackboxHarness) (agentLaunchConfig, error) {
+	t.Helper()
+
+	artifactRoot := filepath.Join(h.artifactsDir, "codex")
+	if err := os.MkdirAll(artifactRoot, 0o755); err != nil {
+		return agentLaunchConfig{}, err
+	}
+	homeDir := filepath.Join(artifactRoot, "codex-home")
+	workDir := filepath.Join(artifactRoot, "workdir")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		return agentLaunchConfig{}, err
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return agentLaunchConfig{}, err
+	}
+
+	if err := copyIfExists(filepath.Join(os.Getenv("HOME"), ".codex", "auth.json"), filepath.Join(homeDir, "auth.json")); err != nil {
+		return agentLaunchConfig{}, err
+	}
+
+	configPath := filepath.Join(homeDir, "config.toml")
+	content := loadAsset(t, h.assetsDir, "codex_config.toml")
+	modelBlock := ""
+	if model := strings.TrimSpace(os.Getenv("CODEX_MODEL")); model != "" {
+		modelBlock = `model = ` + strconv.Quote(model)
+	}
+	content = strings.NewReplacer(
+		"__MODEL_BLOCK__", modelBlock,
+		"__MCP_URL__", h.mcpURL,
+		"__WORK_DIR__", workDir,
+	).Replace(content)
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		return agentLaunchConfig{}, err
+	}
+
+	return agentLaunchConfig{
+		WorkDir:      workDir,
+		StdoutPath:   filepath.Join(artifactRoot, "stdout.jsonl"),
+		StderrPath:   filepath.Join(artifactRoot, "stderr.log"),
+		FinalPath:    filepath.Join(artifactRoot, "final.txt"),
+		ConfigPath:   configPath,
+		ArtifactRoot: artifactRoot,
+		Env: append(os.Environ(),
+			"CODEX_HOME="+homeDir,
+		),
+		Command: []string{
+			"codex",
+			"exec",
+			"--skip-git-repo-check",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--json",
+			"-C", workDir,
+			"-o", filepath.Join(artifactRoot, "final.txt"),
+			"-",
+		},
+	}, nil
+}
+
+func (codexAdapter) Run(ctx context.Context, t *testing.T, _ *blackboxHarness, cfg agentLaunchConfig, prompt string) error {
+	t.Helper()
+	return runAgentCommand(ctx, cfg, prompt)
+}
+
+type claudeAdapter struct{}
+
+func (claudeAdapter) Name() string { return "claude" }
+
+func (claudeAdapter) IsAvailable() error {
+	_, err := exec.LookPath("claude")
+	return err
+}
+
+func (claudeAdapter) PrepareConfig(t *testing.T, h *blackboxHarness) (agentLaunchConfig, error) {
+	t.Helper()
+
+	artifactRoot := filepath.Join(h.artifactsDir, "claude")
+	if err := os.MkdirAll(artifactRoot, 0o755); err != nil {
+		return agentLaunchConfig{}, err
+	}
+	workDir := filepath.Join(artifactRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return agentLaunchConfig{}, err
+	}
+	configPath := filepath.Join(workDir, ".mcp.json")
+	config := strings.ReplaceAll(loadAsset(t, h.assetsDir, "claude_mcp_config.json"), "__MCP_URL__", h.mcpURL)
+	var payload any
+	if err := json.Unmarshal([]byte(config), &payload); err != nil {
+		return agentLaunchConfig{}, err
+	}
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return agentLaunchConfig{}, err
+	}
+	if err := os.WriteFile(configPath, encoded, 0o644); err != nil {
+		return agentLaunchConfig{}, err
+	}
+
+	command := []string{
+		"claude",
+		"-p",
+		"--output-format", "json",
+		"--no-session-persistence",
+		"--permission-mode", "bypassPermissions",
+		"--mcp-config", configPath,
+		"--strict-mcp-config",
+	}
+	if model := strings.TrimSpace(os.Getenv("CLAUDE_MODEL")); model != "" {
+		command = append(command, "--model", model)
+	}
+
+	return agentLaunchConfig{
+		WorkDir:      workDir,
+		StdoutPath:   filepath.Join(artifactRoot, "stdout.json"),
+		StderrPath:   filepath.Join(artifactRoot, "stderr.log"),
+		FinalPath:    filepath.Join(artifactRoot, "final.txt"),
+		ConfigPath:   configPath,
+		ArtifactRoot: artifactRoot,
+		Env:          os.Environ(),
+		Command:      command,
+	}, nil
+}
+
+func (claudeAdapter) Run(ctx context.Context, t *testing.T, _ *blackboxHarness, cfg agentLaunchConfig, prompt string) error {
+	t.Helper()
+	return runAgentCommand(ctx, cfg, prompt)
+}
+
+func runAgentCommand(ctx context.Context, cfg agentLaunchConfig, prompt string) error {
+	stdoutFile, err := os.Create(cfg.StdoutPath)
+	if err != nil {
+		return err
+	}
+	defer stdoutFile.Close()
+
+	stderrFile, err := os.Create(cfg.StderrPath)
+	if err != nil {
+		return err
+	}
+	defer stderrFile.Close()
+
+	cmd := exec.CommandContext(ctx, cfg.Command[0], cfg.Command[1:]...)
+	cmd.Dir = cfg.WorkDir
+	cmd.Env = cfg.Env
+	cmd.Stdout = stdoutFile
+	cmd.Stderr = stderrFile
+	cmd.Stdin = strings.NewReader(prompt)
+
+	err = cmd.Run()
+	if finalBytes, readErr := os.ReadFile(cfg.StdoutPath); readErr == nil {
+		_ = os.WriteFile(cfg.FinalPath, finalBytes, 0o644)
+	}
+	if ctx.Err() != nil {
+		return fmt.Errorf("agent timed out: %w", ctx.Err())
+	}
+	return err
+}
+
+func startCentian(t *testing.T, ctx context.Context, h *blackboxHarness) *exec.Cmd {
+	t.Helper()
+
+	binary := strings.TrimSpace(os.Getenv(centianBinaryEnv))
+	if binary == "" {
+		binary = "centian"
+	}
+	resolved, err := exec.LookPath(binary)
+	if err != nil {
+		t.Fatalf("failed to resolve centian binary %q: %v", binary, err)
+	}
+
+	stdoutPath := filepath.Join(h.artifactsDir, "centian.stdout.log")
+	stderrPath := filepath.Join(h.artifactsDir, "centian.stderr.log")
+	stdoutFile, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("failed to create centian stdout log: %v", err)
+	}
+	stderrFile, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatalf("failed to create centian stderr log: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = stdoutFile.Close()
+		_ = stderrFile.Close()
+	})
+
+	cmd := exec.CommandContext(ctx, resolved, "start", "--config-path", h.configPath)
+	cmd.Dir = h.projectDir
+	cmd.Env = append(os.Environ(), "CENTIAN_LOG_DIR="+h.logDir)
+	cmd.Stdout = stdoutFile
+	cmd.Stderr = stderrFile
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start centian: %v", err)
+	}
+	return cmd
+}
+
+func stopCommand(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+}
+
+func waitForCentian(t *testing.T, h *blackboxHarness) {
+	t.Helper()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(45 * time.Second)
+	apiURL := h.baseURL + "/api/task-runs"
+
+	for time.Now().Before(deadline) {
+		mcpReady := isEndpointReachable(client, h.mcpURL)
+		apiReady := isJSONEndpointReady(client, apiURL)
+		if mcpReady && apiReady {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("centian did not become ready in time; artifacts: %s", h.artifactsDir)
+}
+
+func isEndpointReachable(client *http.Client, endpoint string) bool {
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 500
+}
+
+func isJSONEndpointReady(client *http.Client, endpoint string) bool {
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func fetchTaskRuns(t *testing.T, h *blackboxHarness) []persistence.TaskRunSummary {
+	t.Helper()
+
+	resp, err := http.Get(h.baseURL + "/api/task-runs")
+	if err != nil {
+		t.Fatalf("failed to fetch task runs: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("task runs endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var runs []persistence.TaskRunSummary
+	if err := json.NewDecoder(resp.Body).Decode(&runs); err != nil {
+		t.Fatalf("failed to decode task runs: %v", err)
+	}
+	return runs
+}
+
+func fetchTaskRunEvents(t *testing.T, h *blackboxHarness, runID string) []persistence.TaskRunEvent {
+	t.Helper()
+
+	resp, err := http.Get(h.baseURL + "/api/task-runs/" + runID + "/events")
+	if err != nil {
+		t.Fatalf("failed to fetch task run events: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("task run events endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var events []persistence.TaskRunEvent
+	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
+		t.Fatalf("failed to decode task run events: %v", err)
+	}
+	return events
+}
+
+func loadRequestLogs(t *testing.T, h *blackboxHarness) []requestLogEntry {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(h.requestLogDir, "requests_*.jsonl"))
+	if err != nil {
+		t.Fatalf("failed to glob request logs: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("no request logs found in %s", h.requestLogDir)
+	}
+	slices.Sort(matches)
+	path := matches[len(matches)-1]
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open request log %s: %v", path, err)
+	}
+	defer file.Close()
+
+	result := make([]requestLogEntry, 0)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+		var entry requestLogEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("failed to parse request log %s: %v", path, err)
+		}
+		result = append(result, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("failed to scan request log %s: %v", path, err)
+	}
+	return result
+}
+
+func assertStrictSuccess(
+	t *testing.T,
+	agentName string,
+	h *blackboxHarness,
+	latest persistence.TaskRunSummary,
+	events []persistence.TaskRunEvent,
+	requests []requestLogEntry,
+) {
+	t.Helper()
+
+	if latest.Status != string(tv.TaskStatusCompleted) {
+		t.Fatalf("%s latest task run did not complete: status=%s phase=%s artifacts=%s", agentName, latest.Status, latest.CurrentPhase, h.artifactsDir)
+	}
+
+	taskToolNames := make([]string, 0)
+	for _, entry := range requests {
+		if entry.ToolCall == nil {
+			continue
+		}
+		taskToolNames = append(taskToolNames, entry.ToolCall.Name)
+	}
+
+	if !containsSubsequence(taskToolNames, []string{
+		"centian.task_list_templates",
+		"centian.task_register",
+		"centian.task_complete_onboarding",
+		"centian.task_complete_planning",
+		"centian.task_start_step",
+		"centian.task_complete_step",
+	}) {
+		t.Fatalf("%s did not produce the expected task tool call order: %v", agentName, taskToolNames)
+	}
+
+	taskToolCalls := 0
+	for _, name := range taskToolNames {
+		if strings.HasPrefix(name, "centian.task_") {
+			taskToolCalls++
+		}
+		if name == "centian.task_fail" {
+			t.Fatalf("%s used centian.task_fail unexpectedly", agentName)
+		}
+	}
+	if taskToolCalls < 5 {
+		t.Fatalf("%s produced too few centian task tool calls: %d", agentName, taskToolCalls)
+	}
+
+	eventTypes := make([]string, 0)
+	for _, event := range events {
+		if event.Source != persistence.TaskRunEventSourceTask || event.EventType == "" {
+			continue
+		}
+		if event.EventType == string(tv.TaskEventTypeFailed) || event.EventType == string(tv.TaskEventTypeTimedOut) {
+			t.Fatalf("%s task run contained terminal failure event %s", agentName, event.EventType)
+		}
+		eventTypes = append(eventTypes, event.EventType)
+	}
+	if !containsSubsequence(eventTypes, []string{
+		string(tv.TaskEventTypeRegistered),
+		string(tv.TaskEventTypeOnboardingCompleted),
+		string(tv.TaskEventTypePlanningCompleted),
+		string(tv.TaskEventTypeStepStarted),
+		string(tv.TaskEventTypeStepCompleted),
+	}) {
+		t.Fatalf("%s task run lifecycle events are incomplete: %v", agentName, eventTypes)
+	}
+
+	scorePath := filepath.Join(h.projectDir, "score_parentheses.py")
+	if _, err := os.Stat(scorePath); err != nil {
+		t.Fatalf("%s did not create %s: %v", agentName, scorePath, err)
+	}
+	testPath := filepath.Join(h.projectDir, "test_score_parentheses.py")
+	if _, err := os.Stat(testPath); err != nil {
+		t.Fatalf("%s did not create %s: %v", agentName, testPath, err)
+	}
+
+	runProjectCommand(t, h.projectDir, "python", "test_score_parentheses.py")
+	runProjectCommand(t, h.projectDir, "python", "-m", "py_compile", "score_parentheses.py", "test_score_parentheses.py")
+}
+
+func runProjectCommand(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command %s %s failed in %s: %v\n%s", name, strings.Join(args, " "), dir, err, strings.TrimSpace(string(output)))
+	}
+}
+
+func containsSubsequence(haystack, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	index := 0
+	for _, item := range haystack {
+		if item == needle[index] {
+			index++
+			if index == len(needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func loadAgentTimeout(t *testing.T) time.Duration {
+	t.Helper()
+
+	raw := strings.TrimSpace(os.Getenv(agentTimeoutEnv))
+	if raw == "" {
+		return defaultAgentTimeout
+	}
+	duration, err := time.ParseDuration(raw)
+	if err != nil {
+		t.Fatalf("failed to parse %s=%q: %v", agentTimeoutEnv, raw, err)
+	}
+	return duration
+}
+
+func loadAsset(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func allocateFreePort(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate free port: %v", err)
+	}
+	defer listener.Close()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("failed to resolve allocated tcp port")
+	}
+	return fmt.Sprintf("%d", addr.Port)
+}
+
+func copyIfExists(src, dst string) error {
+	data, err := os.ReadFile(src)
+	switch {
+	case err == nil:
+		return os.WriteFile(dst, data, 0o600)
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	default:
+		return err
+	}
+}

--- a/tests/integrationtests/taskverification/centian_config.json
+++ b/tests/integrationtests/taskverification/centian_config.json
@@ -1,0 +1,53 @@
+{
+  "name": "Task Verification Blackbox",
+  "version": "1.0.0",
+  "auth": false,
+  "proxy": {
+    "host": "127.0.0.1",
+    "port": "__PORT__",
+    "timeout": 30,
+    "logLevel": "debug",
+    "logOutput": "both",
+    "logFile": "__INTERNAL_LOG__",
+    "capabilities": {
+      "taskVerification": {
+        "enabled": true,
+        "templatesPath": "__TEMPLATES_DIR__"
+      },
+      "eventStorage": {
+        "enabled": true,
+        "driver": "sqlite",
+        "path": "__EVENT_STORE_PATH__"
+      }
+    }
+  },
+  "gateways": {
+    "taskverification": {
+      "setupGateway": true,
+      "mcpServers": {
+        "filesystem": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "@modelcontextprotocol/server-filesystem",
+            "__PROJECT_DIR__"
+          ],
+          "enabled": true,
+          "description": "Filesystem access to the test project."
+        },
+        "shell": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "shell-command-mcp"
+          ],
+          "env": {
+            "ALLOWED_COMMANDS": "*"
+          },
+          "enabled": true,
+          "description": "Shell access for the black-box taskverification test."
+        }
+      }
+    }
+  }
+}

--- a/tests/integrationtests/taskverification/centian_config.json
+++ b/tests/integrationtests/taskverification/centian_config.json
@@ -18,6 +18,9 @@
         "enabled": true,
         "driver": "sqlite",
         "path": "__EVENT_STORE_PATH__"
+      },
+      "ui": {
+        "enabled": true
       }
     }
   },

--- a/tests/integrationtests/taskverification/claude_mcp_config.json
+++ b/tests/integrationtests/taskverification/claude_mcp_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "centian": {
+      "type": "http",
+      "url": "__MCP_URL__"
+    }
+  }
+}

--- a/tests/integrationtests/taskverification/codex_config.toml
+++ b/tests/integrationtests/taskverification/codex_config.toml
@@ -1,0 +1,7 @@
+__MODEL_BLOCK__
+[mcp_servers.centian]
+url = "__MCP_URL__"
+enabled = true
+
+[projects."__WORK_DIR__"]
+trust_level = "trusted"

--- a/tests/integrationtests/taskverification/codex_config.toml
+++ b/tests/integrationtests/taskverification/codex_config.toml
@@ -1,7 +1,21 @@
 __MODEL_BLOCK__
+sandbox_mode = "workspace-write"
+
 [mcp_servers.centian]
 url = "__MCP_URL__"
 enabled = true
+destructive_enabled = true
+open_world_enabled = true
+default_tools_approval_mode = "auto"
 
 [projects."__WORK_DIR__"]
 trust_level = "trusted"
+destructive_enabled = true
+open_world_enabled = true
+default_tools_approval_mode = "auto"
+
+[apps._default]
+enabled = true
+destructive_enabled = true
+open_world_enabled = true
+default_tools_approval_mode = "auto"

--- a/tests/integrationtests/taskverification/prompt copy 2.yaml
+++ b/tests/integrationtests/taskverification/prompt copy 2.yaml
@@ -1,0 +1,24 @@
+prompt: |
+  Connect to the MCP server named `centian` and solve this Python TDD task through the Centian workflow.
+
+  Problem:
+
+  Implement a Python function named `score_parentheses(text: str) -> int`.
+
+  The input string is guaranteed to be balanced and consists only of `(` and `)`.
+
+  Scoring rules:
+
+  - `()` has score `1`
+  - `AB` has score `A + B`, where `A` and `B` are balanced parentheses strings
+  - `(A)` has score `2 * A`
+
+  Requirements:
+
+  - Start from the problem statement only. There is no provided implementation or test for this exercise.
+  - Create `score_parentheses.py` and `test_score_parentheses.py` in the same directory.
+  - Treat the Centian project root as the working directory and use project-relative paths.
+  - The environment only guarantees `python`; do not assume any third-party packages are installed.
+  - Establish a failing test first, then implement the solution.
+
+  Use Centian lifecycle tools as the source of truth, rely only on Centian-exposed project tools, and stop after the task is completed.

--- a/tests/integrationtests/taskverification/prompt copy.yaml
+++ b/tests/integrationtests/taskverification/prompt copy.yaml
@@ -1,0 +1,15 @@
+prompt: |
+  Implement a Python function named `score_parentheses(text: str) -> int`.
+
+  The input string is guaranteed to be balanced and consists only of `(` and `)`.
+
+  Scoring rules:
+  - `()` has score `1`
+  - `AB` has score `A + B`
+  - `(A)` has score `2 * A`
+
+  Start from an empty project workspace.
+
+  Create 2 files: one for the code, one for the tests
+
+  Provide a short summary when you are done.

--- a/tests/integrationtests/taskverification/prompt.yaml
+++ b/tests/integrationtests/taskverification/prompt.yaml
@@ -1,0 +1,24 @@
+prompt: |
+  Connect to the MCP server named `centian` and solve this Python TDD task through the Centian workflow.
+
+  Problem:
+
+  Implement a Python function named `score_parentheses(text: str) -> int`.
+
+  The input string is guaranteed to be balanced and consists only of `(` and `)`.
+
+  Scoring rules:
+
+  - `()` has score `1`
+  - `AB` has score `A + B`, where `A` and `B` are balanced parentheses strings
+  - `(A)` has score `2 * A`
+
+  Requirements:
+
+  - Start from the problem statement only. There is no provided implementation or test for this exercise.
+  - Create `score_parentheses.py` and `test_score_parentheses.py` in the same directory.
+  - Treat the Centian project root as the working directory and use project-relative paths.
+  - The environment only guarantees `python`; do not assume any third-party packages are installed.
+  - Establish a failing test first, then implement the solution.
+
+  Use Centian lifecycle tools as the source of truth, rely only on Centian-exposed project tools, and stop after the task is completed.

--- a/tests/integrationtests/taskverification/python_tdd_workflow.yaml
+++ b/tests/integrationtests/taskverification/python_tdd_workflow.yaml
@@ -1,0 +1,144 @@
+version: "0.1"
+task:
+  id: "python_tdd_workflow"
+  name: "Python TDD Workflow"
+  description: "Use Centian to drive a Python TDD loop with explicit scaffolding, a failing-baseline step, and an implementation step."
+  instructions: |
+    Use Centian task verification as the authoritative process for this task.
+
+    Expectations:
+    - Register the task before using any project-access MCP tool, then follow the step boundaries in order.
+    - Prefer `centian.task_start_step` and `centian.task_complete_step` over manually rebuilding the full validation flow.
+    - Treat `centian.task_complete_step` as the source of truth for whether a step passes.
+    - The Centian taskverification working directory is the project root.
+    - Use paths relative to the project root when filling template parameters.
+    - This workflow runs in a host-native test environment with only `python` guaranteed to exist.
+    - Do not assume `pytest` or `ruff` are installed; choose commands that work with plain `python`.
+    - Once the implementation step has started, keep the selected test file stable.
+parameters:
+  - name: "testCommand"
+    description: "The command prefix used to run the selected test target with standard-library-only Python, for example `python`."
+  - name: "testTarget"
+    description: "The test target to execute with the selected command. Use a plain file path such as `test_x.py`."
+  - name: "testFile"
+    description: "The concrete path to the test file used for invariants, for example `test_x.py`."
+  - name: "testName"
+    description: "The test entrypoint name that scaffolding should create inside the selected test file."
+  - name: "lintCommand"
+    description: "The command used to run a dependency-free syntax check for the project, for example `python -m py_compile score_parentheses.py test_score_parentheses.py`."
+  - name: "expectedError"
+    description: "A stable substring expected in stdout for the initial failing baseline, for example `FAIL`."
+  - name: "implementationTarget"
+    description: "The concrete implementation file path that scaffolding and execution will operate on. Use a path relative to the project root, for example `score_parentheses.py`."
+workflow:
+  onboarding:
+    instructions: |
+      Identify the concrete test target, relevant source files, and project commands before planning.
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+  planning:
+    tools_allowed:
+      - "shell__*"
+      - "filesystem__*"
+    editable_fields:
+      - "parameters.testCommand"
+      - "parameters.testTarget"
+      - "parameters.testFile"
+      - "parameters.testName"
+      - "parameters.lintCommand"
+      - "parameters.expectedError"
+      - "parameters.implementationTarget"
+    required_outputs:
+      - "selectedFiles"
+      - "testTarget"
+      - "lintCommand"
+      - "expectedFailure"
+      - "implementationTarget"
+  scaffolding:
+    - id: "setup_test_file"
+      name: "Setup test file"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      instructions: |
+        Create the planned test file as a new artifact. Keep this step additive.
+      checks:
+        - id: "test_file_created"
+          command: "printf 'scaffold-test-file'"
+          pre_conditions:
+            - type: file_not_exists
+              path: "${testFile}"
+          post_conditions:
+            - type: file_exists
+              path: "${testFile}"
+    - id: "setup_test_scaffolding"
+      name: "Setup test scaffolding"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      instructions: |
+        Add the planned test scaffold and make sure the implementation target exists. If the implementation file does not exist yet, create a minimal stub that preserves the planned failing baseline.
+      checks:
+        - id: "test_scaffold_created"
+          command: "printf 'scaffold-test-content'"
+          pre_conditions:
+            - type: file_exists
+              path: "${testFile}"
+            - type: file_not_contains
+              path: "${testFile}"
+              value: "${testName}"
+          post_conditions:
+            - type: file_contains
+              path: "${testFile}"
+              value: "${testName}"
+            - type: file_exists
+              path: "${implementationTarget}"
+  execution:
+    - id: "establish_failing_baseline"
+      name: "Establish failing baseline"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      instructions: |
+        Verify the planned test target already fails for the intended reason. No additional file edits should be required in this step.
+        The pass/fail decision for this step comes from `centian.task_complete_step`.
+      checks:
+        - id: "selected_test_fails"
+          command: "${testCommand} ${testTarget}"
+          pre_conditions:
+            - type: exit_code
+              value: 1
+            - type: stdout_contains
+              value: "${expectedError}"
+          post_conditions:
+            - type: exit_code
+              value: 1
+            - type: stdout_contains
+              value: "${expectedError}"
+    - id: "implement_solution"
+      name: "Implement solution"
+      tools_allowed:
+        - "shell__*"
+        - "filesystem__*"
+      instructions: |
+        Start this step before changing production code.
+        Make the implementation pass the selected test, then let Centian verify the step.
+        Once this step is active, keep the selected test file stable.
+      checks:
+        - id: "selected_test_passes"
+          command: "${testCommand} ${testTarget}"
+          pre_conditions:
+            - type: exit_code
+              value: 1
+          post_conditions:
+            - type: exit_code
+              value: 0
+        - id: "project_lint_passes"
+          command: "${lintCommand}"
+          post_conditions:
+            - type: exit_code
+              value: 0
+      invariants:
+        - id: "test_file_stable"
+          command: "cat ${testFile}"

--- a/tests/integrationtests/taskverification/python_tdd_workflow.yaml
+++ b/tests/integrationtests/taskverification/python_tdd_workflow.yaml
@@ -27,7 +27,7 @@ parameters:
   - name: "lintCommand"
     description: "The command used to run a dependency-free syntax check for the project, for example `python -m py_compile score_parentheses.py test_score_parentheses.py`."
   - name: "expectedError"
-    description: "A stable substring expected in stdout for the initial failing baseline, for example `FAIL`."
+    description: "A stable substring expected in the combined test output for the initial failing baseline, for example `FAIL`."
   - name: "implementationTarget"
     description: "The concrete implementation file path that scaffolding and execution will operate on. Use a path relative to the project root, for example `score_parentheses.py`."
 workflow:
@@ -109,12 +109,12 @@ workflow:
           pre_conditions:
             - type: exit_code
               value: 1
-            - type: stdout_contains
+            - type: output_contains
               value: "${expectedError}"
           post_conditions:
             - type: exit_code
               value: 1
-            - type: stdout_contains
+            - type: output_contains
               value: "${expectedError}"
     - id: "implement_solution"
       name: "Implement solution"

--- a/web/src/routes.test.tsx
+++ b/web/src/routes.test.tsx
@@ -112,6 +112,36 @@ describe("task run list", () => {
     expect(await screen.findByText("No task runs yet")).toBeInTheDocument();
   });
 
+  it("polls the task run list and refreshes new runs in place", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(createFetchResponse([]))
+      .mockResolvedValueOnce(
+        createFetchResponse([
+          {
+            runId: "tr_1742947200123_0000000001",
+            templateId: "python_tdd_demo",
+            startedAt: 1742947200123,
+            status: "active",
+            currentPhase: "planning.review",
+            taskEventCount: 2,
+            actionEventCount: 3,
+            eventCount: 5,
+          },
+        ]),
+      ) as typeof fetch;
+
+    renderApp();
+
+    expect(await screen.findByText("No task runs yet")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    }, { timeout: 3500 });
+
+    expect(await screen.findByText("python_tdd_demo")).toBeInTheDocument();
+  }, 8000);
+
   it("shows an error state when the api request fails", async () => {
     globalThis.fetch = vi.fn(() => Promise.reject(new Error("network down"))) as typeof fetch;
 
@@ -402,6 +432,58 @@ describe("task run detail", () => {
     await new Promise((resolve) => window.setTimeout(resolve, 2200));
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  }, 8000);
+
+  it("keeps polling after a failed step event while the task run remains active", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createFetchResponse([
+          {
+            source: "task",
+            id: "te_1742947200123_0000000001",
+            createdAtUnixMilli: 1742947200123,
+            eventType: "step_completed",
+            outcome: "failed",
+            phasePath: "execution.establish_failing_baseline",
+            resultingPhasePath: "execution.establish_failing_baseline",
+            payloadJson: { status: "active", step: 3, passed: false },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        createFetchResponse([
+          {
+            source: "task",
+            id: "te_1742947200123_0000000001",
+            createdAtUnixMilli: 1742947200123,
+            eventType: "step_completed",
+            outcome: "failed",
+            phasePath: "execution.establish_failing_baseline",
+            resultingPhasePath: "execution.establish_failing_baseline",
+            payloadJson: { status: "active", step: 3, passed: false },
+          },
+          {
+            source: "task",
+            id: "te_1742947201123_0000000002",
+            createdAtUnixMilli: 1742947201123,
+            eventType: "step_started",
+            outcome: "succeeded",
+            phasePath: "execution.establish_failing_baseline",
+            resultingPhasePath: "execution.implement_solution",
+            payloadJson: { status: "active", step: 4 },
+          },
+        ]),
+      ) as typeof fetch;
+
+    renderApp(["/tasks/tr_1742947200123_0000000001"]);
+
+    expect(await screen.findByText("Run Detail")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    }, { timeout: 2500 });
   }, 8000);
 
   it("prompts for an api key on unauthorized detail access", async () => {

--- a/web/src/routes.test.tsx
+++ b/web/src/routes.test.tsx
@@ -40,6 +40,7 @@ function renderApp(initialEntries: string[] = ["/tasks"]) {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   globalThis.fetch = originalFetch;
   clearStoredApiAuth();
@@ -320,6 +321,88 @@ describe("task run detail", () => {
       expect(screen.getByText("Run Detail")).toBeInTheDocument();
     });
   });
+
+  it("polls the detail timeline once per second while the run is active", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createFetchResponse([
+          {
+            source: "task",
+            id: "te_1742947200123_0000000001",
+            createdAtUnixMilli: 1742947200123,
+            eventType: "task_registered",
+            outcome: "succeeded",
+            phasePath: "onboarding",
+            resultingPhasePath: "onboarding",
+            payloadJson: { status: "active" },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        createFetchResponse([
+          {
+            source: "task",
+            id: "te_1742947200123_0000000001",
+            createdAtUnixMilli: 1742947200123,
+            eventType: "task_registered",
+            outcome: "succeeded",
+            phasePath: "onboarding",
+            resultingPhasePath: "onboarding",
+            payloadJson: { status: "active" },
+          },
+          {
+            source: "task",
+            id: "te_1742947201123_0000000002",
+            createdAtUnixMilli: 1742947201123,
+            eventType: "step_completed",
+            outcome: "succeeded",
+            phasePath: "scaffolding.step_1",
+            resultingPhasePath: "scaffolding.step_1",
+            payloadJson: { status: "active", step: 1 },
+          },
+        ]),
+      ) as typeof fetch;
+
+    renderApp(["/tasks/tr_1742947200123_0000000001"]);
+
+    expect(await screen.findByText("Run Detail")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    }, { timeout: 2500 });
+    await waitFor(() => {
+      const titles = screen.getAllByTestId("timeline-event-title").map((element) => element.textContent ?? "");
+      expect(titles.some((title) => title.includes("Step Completed"))).toBe(true);
+    });
+  }, 8000);
+
+  it("stops polling the detail timeline after the run reaches a terminal state", async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        createFetchResponse([
+          {
+            source: "task",
+            id: "te_1742947200123_0000000001",
+            createdAtUnixMilli: 1742947200123,
+            eventType: "task_completed",
+            outcome: "succeeded",
+            phasePath: "execution.implement_solution",
+            resultingPhasePath: "execution.implement_solution",
+            payloadJson: { status: "completed" },
+          },
+        ]),
+      ),
+    ) as typeof fetch;
+
+    renderApp(["/tasks/tr_1742947200123_0000000001"]);
+
+    expect(await screen.findByText("Run Detail")).toBeInTheDocument();
+
+    await new Promise((resolve) => window.setTimeout(resolve, 2200));
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  }, 8000);
 
   it("prompts for an api key on unauthorized detail access", async () => {
     globalThis.fetch = vi.fn(() =>

--- a/web/src/ui/task-run-detail-page.tsx
+++ b/web/src/ui/task-run-detail-page.tsx
@@ -857,7 +857,7 @@ function deriveTaskRunDetailStatus(events: TaskRunEvent[]): TaskRunUIStatus {
     if (payloadStatus === "timed_out" || event.eventType === "task_timed_out") {
       return "timed_out";
     }
-    if (payloadStatus === "failed" || event.eventType === "task_failed" || event.outcome === "failed") {
+    if (payloadStatus === "failed" || event.eventType === "task_failed") {
       return "failed";
     }
     if (payloadStatus === "completed") {

--- a/web/src/ui/task-run-detail-page.tsx
+++ b/web/src/ui/task-run-detail-page.tsx
@@ -50,6 +50,7 @@ export function TaskRunDetailPage() {
   const [authHeaderName, setAuthHeaderName] = useState<string>();
   const [reloadToken, setReloadToken] = useState(0);
   const previousExpandedWidthRef = useRef(getDefaultDetailsWidth());
+  const detailStatus = useMemo(() => deriveTaskRunDetailStatus(events), [events]);
 
   useEffect(() => {
     if (!runID) {
@@ -94,9 +95,53 @@ export function TaskRunDetailPage() {
     return () => controller.abort();
   }, [reloadToken, runID]);
 
+  useEffect(() => {
+    if (!runID || loadState !== "ready" || detailStatus !== "active") {
+      return;
+    }
+
+    let inFlight = false;
+    let controller: AbortController | null = null;
+
+    const poll = () => {
+      if (inFlight) {
+        return;
+      }
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+
+      inFlight = true;
+      controller = new AbortController();
+
+      void fetchTaskRunEvents(runID, controller.signal)
+        .then((result) => {
+          setEvents(result);
+        })
+        .catch((error: unknown) => {
+          if ((error as Error)?.name === "AbortError") {
+            return;
+          }
+          if (error instanceof ApiError && error.status === 401) {
+            setAuthHeaderName(error.authHeaderName);
+            setLoadState("unauthorized");
+          }
+        })
+        .finally(() => {
+          inFlight = false;
+          controller = null;
+        });
+    };
+
+    const timer = window.setInterval(poll, 1000);
+    return () => {
+      window.clearInterval(timer);
+      controller?.abort();
+    };
+  }, [detailStatus, loadState, runID]);
+
   const timelineItems = useMemo(() => buildTimelineItems(events), [events]);
   const groupedEvents = useMemo(() => groupEventsByPhase(timelineItems), [timelineItems]);
-  const detailStatus = useMemo(() => deriveTaskRunDetailStatus(events), [events]);
   const flatTimelineItems = useMemo(
     () => groupedEvents.flatMap((group) => group.items),
     [groupedEvents],

--- a/web/src/ui/task-run-list-page.tsx
+++ b/web/src/ui/task-run-list-page.tsx
@@ -60,6 +60,52 @@ export function TaskRunListPage() {
   }, [reloadToken]);
 
   useEffect(() => {
+    if (loadState !== "ready") {
+      return;
+    }
+
+    let inFlight = false;
+    let controller: AbortController | null = null;
+
+    const poll = () => {
+      if (inFlight) {
+        return;
+      }
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+
+      inFlight = true;
+      controller = new AbortController();
+
+      void fetchTaskRuns(controller.signal)
+        .then((result) => {
+          setRuns(result);
+        })
+        .catch((error: unknown) => {
+          if ((error as Error)?.name === "AbortError") {
+            return;
+          }
+          if (error instanceof ApiError && error.status === 401) {
+            setAuthHeaderName(error.authHeaderName);
+            setErrorMessage("Enter a Centian API key to read persisted task runs.");
+            setLoadState("unauthorized");
+          }
+        })
+        .finally(() => {
+          inFlight = false;
+          controller = null;
+        });
+    };
+
+    const timer = window.setInterval(poll, 2000);
+    return () => {
+      window.clearInterval(timer);
+      controller?.abort();
+    };
+  }, [loadState]);
+
+  useEffect(() => {
     const activeRunExists = runs.some((run) => getTaskRunUIStatus(run.status, run.endedAt) === "active");
     if (!activeRunExists) {
       return;


### PR DESCRIPTION
## Summary

This PR adds two product-facing pieces for taskverification workflows:

- a host-native black-box integration harness that runs real local coding agents against a real Centian instance and validates the workflow from Centian’s own task/event/log state
- a new `centian demo` command that creates a self-contained demo workspace, starts Centian, launches Claude headlessly against it, opens or prints the live UI, and preserves demo artifacts including agent stdout/stderr logs

It also tightens the taskverification agent experience with better task-tool metadata and fixes task UI polling/runtime checks that showed up while iterating on the agent flows.

## What Changed

- Added `tests/integrationtests/taskverification` host-native black-box coverage for Claude/Codex-oriented taskverification runs, with preserved `.tmp` artifacts and a dedicated README
- Added `internal/agentrunner` and `centian demo` for a self-contained local demo flow with embedded assets and a Claude adapter
- Added explicit task-tool annotations plus richer structured workflow hints such as `workspaceRoot`, `pathMode`, `commandWorkingDirectory`, and `nextAction`
- Added `output_contains` / `output_not_contains` taskverification conditions so failing Python baselines work without stdout-only assumptions
- Added polling to the task list and task detail UI so runs update in place while active
- Added agent/demo docs in `README.md` and black-box integration docs under the taskverification test package

## Why

The main goal is to make Centian easier to demonstrate and easier to validate against real coding agents.

The black-box harness gives us a realistic way to inspect how agents behave with Centian’s task lifecycle. The new demo command gives users a low-friction way to see the product working locally. The task-tool metadata and UI polling fixes address concrete issues uncovered while building those flows.
