### PR TITLE
Taskverification planning contract hardening and Gemini demo support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.2.3 - 2026-04-01
+
+### Major
+- Refactored taskverification registration and planning so `centian.task_register` only selects a template and all template parameters are frozen later through `planning.parameters`, removing the earlier draft-parameter shell and making onboarding/planning decisions the source of truth for execution.
+- Added stronger agent-facing taskverification workflow metadata and validation, including required planning parameter exposure, enforced `planning.parameters` schema requirements, structured planning-contract failures, and richer current-step contracts with check and invariant explanations.
+- Added initial Gemini support to `centian demo`, including embedded Gemini settings, demo wiring, and supporting test coverage for the new demo agent option.
+
+### Minor
+- Updated built-in taskverification templates, demo prompts, integration fixtures, and authoring documentation to use planning-time parameters and `required_inputs` consistently.
+- Expanded proxy and taskverification tests to cover the new planning contract, structured task-tool payloads, step metadata, and demo/taskverification integration flows.
+- Updated the task run UI/task state payloads to surface the newer planning metadata without relying on the removed draft-parameter model.
+
+### Bugfixes
+- Fixed brittle taskverification planning behavior where parameters were effectively decided too early and could diverge from onboarding/planning context.
+- Fixed agent-facing failure responses so planning-contract problems return actionable structured details instead of only plain string errors.
+- Fixed taskverification step metadata gaps by preserving authored check/invariant descriptions and exposing concise technical meanings for built-in file/output checks and invariants.
+
 ## v0.2.2 - 2026-04-01
 
 ### Major

--- a/README.md
+++ b/README.md
@@ -91,11 +91,16 @@ For the fastest end-to-end product demo, use the built-in `centian demo` command
 Current v1 support:
 
 - `claude`
+- `gemini`
 
 Example:
 
 ```bash
 centian demo --agent claude
+```
+
+```bash
+centian demo --agent gemini
 ```
 
 Optional path override:
@@ -116,6 +121,7 @@ The command creates:
 - `templates/` with the taskverification workflow
 - `logs/` with Centian-generated logs and event storage
 - `config.json`, `prompt.md`, `claude_mcp_config.json`, and `centian.pid`
+- `workspace/.gemini/settings.json` when using the Gemini demo
 - `agent.stdout.log` and `agent.stderr.log` for the headless agent process output
 
 Behavior:
@@ -132,7 +138,9 @@ To stop the demo server later:
 kill $(cat ./.centian/demo/centian.pid)
 ```
 
-This is a safe, isolated demo flow intended to showcase Centian taskverification. It is not yet a hardened sandbox boundary and does not currently support Codex or Gemini in the public command.
+This is a safe, isolated demo flow intended to showcase Centian taskverification. It is not yet a hardened sandbox boundary and does not currently support Codex in the public command.
+
+When using Gemini, note that the CLI may still maintain some of its own local state outside the demo directory. Centian only controls the generated demo workspace and project-level Gemini settings.
 
 ### `demo/` walkthroughs
 

--- a/demo/taskverification/agent/prompts/existing_bug_mathlib.md
+++ b/demo/taskverification/agent/prompts/existing_bug_mathlib.md
@@ -25,22 +25,18 @@ Bootstrap the task like this:
 
 1. Call `centian.task_list_templates`.
 2. Choose the generic Python TDD workflow template.
-3. Call `centian.task_register` immediately with these parameters:
+3. Call `centian.task_register` immediately with:
    - `templateId`: `python_tdd_workflow`
-   - `testCommand`: `python -m pytest -q`
-   - `testFile`: `tests/test_mathlib_addition.py`
-   - `testName`: `test_add_two_numbers`
-   - `testTarget`: `tests/test_mathlib_addition.py::test_add_two_numbers`
-   - `lintCommand`: `python -m ruff check .`
-   - `expectedError`: `AssertionError: assert -1 == 3`
-   - `implementationTarget`: `/workspace/project/mathlib.py`
 4. Call `centian.task_complete_onboarding` with a concise project summary, relevant artifact map, and the planned commands.
 5. Call `centian.task_complete_planning` with the required planning artifact, including:
    - `selectedFiles`: `/workspace/project/mathlib.py` and `/workspace/project/tests/test_mathlib_addition.py`
-   - `testTarget`: `tests/test_mathlib_addition.py::test_add_two_numbers`
-   - `lintCommand`: `python -m ruff check .`
-   - `expectedFailure`: `AssertionError: assert -1 == 3`
-   - `implementationTarget`: `/workspace/project/mathlib.py`
+   - `parameters.testCommand`: `python -m pytest -q`
+   - `parameters.testFile`: `tests/test_mathlib_addition.py`
+   - `parameters.testName`: `test_add_two_numbers`
+   - `parameters.testTarget`: `tests/test_mathlib_addition.py::test_add_two_numbers`
+   - `parameters.lintCommand`: `python -m ruff check .`
+   - `parameters.expectedError`: `AssertionError: assert -1 == 3`
+   - `parameters.implementationTarget`: `/workspace/project/mathlib.py`
 6. After planning enters `scaffolding`, run all four steps in order.
 7. In scaffolding, create the new focused test file and leave the existing implementation file in place.
 8. In execution step 3, verify the new targeted test fails for the expected reason without extra edits.

--- a/demo/taskverification/agent/prompts/problem_score_parentheses.md
+++ b/demo/taskverification/agent/prompts/problem_score_parentheses.md
@@ -36,22 +36,18 @@ Bootstrap the task like this:
 
 1. Call `centian.task_list_templates`.
 2. Choose the generic Python TDD workflow template.
-3. Call `centian.task_register` immediately with these parameters:
+3. Call `centian.task_register` immediately with:
    - `templateId`: `python_tdd_workflow`
-   - `testCommand`: `python -m pytest -q`
-   - `testFile`: `tests/test_score_parentheses.py`
-   - `testName`: `test_score_parentheses_examples`
-   - `testTarget`: `tests/test_score_parentheses.py::test_score_parentheses_examples`
-   - `lintCommand`: `python -m ruff check .`
-   - `expectedError`: `AssertionError: assert 0 == 1`
-   - `implementationTarget`: `/workspace/project/score_parentheses.py`
 4. Call `centian.task_complete_onboarding` with a concise summary of the planned new module and test, plus useful commands and constraints.
 5. Call `centian.task_complete_planning` with the required planning artifact, including:
    - `selectedFiles`: `/workspace/project/score_parentheses.py` and `/workspace/project/tests/test_score_parentheses.py`
-   - `testTarget`: `tests/test_score_parentheses.py::test_score_parentheses_examples`
-   - `lintCommand`: `python -m ruff check .`
-   - `expectedFailure`: `AssertionError: assert 0 == 1`
-   - `implementationTarget`: `/workspace/project/score_parentheses.py`
+   - `parameters.testCommand`: `python -m pytest -q`
+   - `parameters.testFile`: `tests/test_score_parentheses.py`
+   - `parameters.testName`: `test_score_parentheses_examples`
+   - `parameters.testTarget`: `tests/test_score_parentheses.py::test_score_parentheses_examples`
+   - `parameters.lintCommand`: `python -m ruff check .`
+   - `parameters.expectedError`: `AssertionError: assert 0 == 1`
+   - `parameters.implementationTarget`: `/workspace/project/score_parentheses.py`
 6. After planning enters `scaffolding`, run all four steps in order with `centian.task_start_step` and `centian.task_complete_step`:
    - `setup_test_file`
    - `setup_test_scaffolding`

--- a/docs/TASK_TEMPLATE_AUTHORING.md
+++ b/docs/TASK_TEMPLATE_AUTHORING.md
@@ -66,7 +66,7 @@ parameters:
     description: "Command prefix used to run the targeted test."
   - name: "testTarget"
     description: "Concrete test target."
-  - name: "expectedFailure"
+  - name: "expectedError"
     description: "Stable failing output expected before the fix."
   - name: "sourceFile"
     description: "Implementation file expected to change."
@@ -86,12 +86,12 @@ workflow:
     editable_fields:
       - "parameters.testCommand"
       - "parameters.testTarget"
-      - "parameters.expectedFailure"
+      - "parameters.expectedError"
       - "parameters.sourceFile"
-    required_outputs:
+    required_inputs:
       - "selectedFiles"
       - "testTarget"
-      - "expectedFailure"
+      - "expectedError"
       - "implementationTarget"
 
   execution:
@@ -107,7 +107,7 @@ workflow:
             - type: exit_code
               value: 1
             - type: stdout_contains
-              value: "${expectedFailure}"
+              value: "${expectedError}"
 
     - id: "implement_fix"
       name: "Implement fix"
@@ -179,7 +179,7 @@ Reference parameters with `${name}` inside any string field:
 
 ```yaml
 command: "${testCommand} ${testTarget}"
-value: "${expectedFailure}"
+value: "${expectedError}"
 path: "${relativePath}"
 ```
 
@@ -243,7 +243,7 @@ planning:
   editable_fields:
     - "parameters.testCommand"
     - "parameters.testTarget"
-  required_outputs:
+  required_inputs:
     - "selectedFiles"
     - "testTarget"
   next: "execution.establish_failing_baseline"
@@ -255,7 +255,7 @@ Supported fields:
 - `tools_allowed`
 - `checkpoint.enabled`
 - `editable_fields`
-- `required_outputs`
+- `required_inputs`
 - `next`
 
 Rules for `editable_fields`:
@@ -264,14 +264,14 @@ Rules for `editable_fields`:
 - Only `parameters.<name>` is supported.
 - `<name>` must refer to a declared or placeholder-derived parameter.
 
-Rules for `required_outputs`:
+Rules for `required_inputs`:
 
 - Each value must be unique.
 - Only these outputs are supported:
   - `selectedFiles`
   - `testTarget`
   - `lintCommand`
-  - `expectedFailure`
+  - `expectedError`
   - `implementationTarget`
   - `invariants`
 
@@ -280,7 +280,7 @@ These outputs map to fields on the planning artifact sent to `centian.task_compl
 - `selectedFiles`: non-empty `[]string`, each entry trimmed and unique
 - `testTarget`: non-empty string
 - `lintCommand`: non-empty string
-- `expectedFailure`: non-empty string
+- `expectedError`: non-empty string
 - `implementationTarget`: non-empty string
 - `invariants`: non-empty `[]string`, each entry trimmed and unique
 
@@ -398,7 +398,7 @@ checks:
       - type: exit_code
         value: 1
       - type: stdout_contains
-        value: "${expectedFailure}"
+        value: "${expectedError}"
 ```
 
 Rules:
@@ -582,7 +582,7 @@ These are the errors template authors hit most often:
 - parameter declared but never referenced by a placeholder
 - placeholder used but missing from `parameters`
 - unsupported `editable_fields` entry
-- unsupported `required_outputs` value
+- unsupported `required_inputs` value
 - executable step with no checks
 - duplicate check or invariant IDs within a step
 - unsupported condition type
@@ -620,7 +620,7 @@ parameters:
     description: "Concrete Go test selector."
   - name: "testFile"
     description: "Relative path to the Go test file."
-  - name: "expectedFailure"
+  - name: "expectedError"
     description: "Stable failing output before the fix."
   - name: "implementationTarget"
     description: "Relative path to the implementation file."
@@ -641,12 +641,12 @@ workflow:
       - "parameters.testCommand"
       - "parameters.testTarget"
       - "parameters.testFile"
-      - "parameters.expectedFailure"
+      - "parameters.expectedError"
       - "parameters.implementationTarget"
-    required_outputs:
+    required_inputs:
       - "selectedFiles"
       - "testTarget"
-      - "expectedFailure"
+      - "expectedError"
       - "implementationTarget"
 
   scaffolding:
@@ -672,7 +672,7 @@ workflow:
             - type: exit_code
               value: 1
             - type: stdout_contains
-              value: "${expectedFailure}"
+              value: "${expectedError}"
 
     - id: "implement_fix"
       name: "Implement fix"

--- a/internal/agentrunner/assets/gemini_settings.json
+++ b/internal/agentrunner/assets/gemini_settings.json
@@ -1,0 +1,15 @@
+{
+  "mcp": {
+    "allowed": ["centian"]
+  },
+  "mcpServers": {
+    "centian": {
+      "httpUrl": "__MCP_URL__",
+      "trust": false
+    }
+  },
+  "tools": {
+    "core": []
+  },
+  "ideMode": false
+}

--- a/internal/agentrunner/assets/python_tdd_workflow.yaml
+++ b/internal/agentrunner/assets/python_tdd_workflow.yaml
@@ -8,6 +8,7 @@ task:
 
     Expectations:
     - Register the task before using any project-access MCP tool, then follow the step boundaries in order.
+    - Registration only selects the template; determine all template parameters during onboarding/planning and submit them in `planning.parameters`.
     - Prefer `centian.task_start_step` and `centian.task_complete_step` over manually rebuilding the full validation flow.
     - Treat `centian.task_complete_step` as the source of truth for whether a step passes.
     - The Centian taskverification working directory is the project root.
@@ -49,12 +50,14 @@ workflow:
       - "parameters.lintCommand"
       - "parameters.expectedError"
       - "parameters.implementationTarget"
-    required_outputs:
-      - "selectedFiles"
-      - "testTarget"
-      - "lintCommand"
-      - "expectedFailure"
+    required_inputs:
+      - "expectedError"
       - "implementationTarget"
+      - "lintCommand"
+      - "testCommand"
+      - "testFile"
+      - "testName"
+      - "testTarget"
   scaffolding:
     - id: "setup_test_file"
       name: "Setup test file"

--- a/internal/agentrunner/demo.go
+++ b/internal/agentrunner/demo.go
@@ -21,8 +21,12 @@ import (
 const (
 	// AgentClaude is the supported public agent identifier for the Claude CLI.
 	AgentClaude = "claude"
+	// AgentGemini is the supported public agent identifier for the Gemini CLI.
+	AgentGemini = "gemini"
 	// DefaultClaudeModel is the default Claude model alias for demo runs.
 	DefaultClaudeModel = "sonnet"
+	// DefaultGeminiModel is the default Gemini model alias for demo runs.
+	DefaultGeminiModel = "flash" //"gemini-3.1-pro-preview"
 	// DefaultAgentTimeout is the default maximum runtime for a demo agent invocation.
 	DefaultAgentTimeout = 5 * time.Minute
 )
@@ -36,6 +40,7 @@ type DemoOptions struct {
 	CentianBinaryPath string
 	Timeout           time.Duration
 	ClaudeModel       string
+	GeminiModel       string
 	OpenBrowser       bool
 	Stdout            io.Writer
 	Stderr            io.Writer
@@ -78,6 +83,7 @@ type demoLayout struct {
 	EventStorePath  string
 	PIDPath         string
 	ClaudeConfig    string
+	GeminiConfig    string
 	BaseURL         string
 	MCPURL          string
 	Port            string
@@ -152,6 +158,9 @@ func normalizeOptions(opts *DemoOptions) *DemoOptions {
 	if strings.TrimSpace(opts.ClaudeModel) == "" {
 		opts.ClaudeModel = DefaultClaudeModel
 	}
+	if strings.TrimSpace(opts.GeminiModel) == "" {
+		opts.GeminiModel = DefaultGeminiModel
+	}
 	if opts.Stdout == nil {
 		opts.Stdout = io.Discard
 	}
@@ -185,6 +194,7 @@ func prepareLayout(opts *DemoOptions) (*demoLayout, error) {
 		EventStorePath:  filepath.Join(root, "logs", "events.sqlite"),
 		PIDPath:         filepath.Join(root, "centian.pid"),
 		ClaudeConfig:    filepath.Join(root, "claude_mcp_config.json"),
+		GeminiConfig:    filepath.Join(root, "workspace", ".gemini", "settings.json"),
 	}
 	for _, dir := range []string{layout.RootPath, layout.WorkspacePath, layout.TemplatesPath, layout.LogsPath} {
 		if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -269,8 +279,10 @@ func selectAdapter(opts *DemoOptions) (agentAdapter, error) {
 	switch strings.ToLower(strings.TrimSpace(opts.Agent)) {
 	case AgentClaude:
 		return claudeAdapter{model: opts.ClaudeModel}, nil
+	case AgentGemini:
+		return geminiAdapter{model: opts.GeminiModel}, nil
 	default:
-		return nil, fmt.Errorf("unsupported agent %q; v1 supports %q only", opts.Agent, AgentClaude)
+		return nil, fmt.Errorf("unsupported agent %q; v1 supports %q and %q only", opts.Agent, AgentClaude, AgentGemini)
 	}
 }
 

--- a/internal/agentrunner/demo.go
+++ b/internal/agentrunner/demo.go
@@ -26,7 +26,7 @@ const (
 	// DefaultClaudeModel is the default Claude model alias for demo runs.
 	DefaultClaudeModel = "sonnet"
 	// DefaultGeminiModel is the default Gemini model alias for demo runs.
-	DefaultGeminiModel = "flash" //"gemini-3.1-pro-preview"
+	DefaultGeminiModel = "gemini-3.1-pro-preview" // "flash" is an alternative
 	// DefaultAgentTimeout is the default maximum runtime for a demo agent invocation.
 	DefaultAgentTimeout = 5 * time.Minute
 )

--- a/internal/agentrunner/demo_test.go
+++ b/internal/agentrunner/demo_test.go
@@ -51,6 +51,9 @@ func TestPrepareLayoutAllowsEmptyExistingDir(t *testing.T) {
 	if layout.AgentStdoutPath == "" || layout.AgentStderrPath == "" {
 		t.Fatal("expected agent log paths to be initialized")
 	}
+	if filepath.Base(layout.GeminiConfig) != "settings.json" {
+		t.Fatalf("unexpected gemini config path: %s", layout.GeminiConfig)
+	}
 }
 
 func TestRenderAssetsWritesExpectedFiles(t *testing.T) {
@@ -109,6 +112,53 @@ func TestClaudeCommandConstruction(t *testing.T) {
 			t.Fatalf("unexpected unsafe flag %q in %q", forbidden, joined)
 		}
 	}
+}
+
+func TestGeminiCommandConstruction(t *testing.T) {
+	layout := &demoLayout{
+		GeminiConfig:  "/tmp/demo/workspace/.gemini/settings.json",
+		WorkspacePath: "/tmp/demo/workspace",
+	}
+	command, err := geminiAdapter{model: "flash"}.command(layout, "solve the task")
+	if err != nil {
+		t.Fatalf("command: %v", err)
+	}
+	joined := strings.Join(command, " ")
+	for _, expected := range []string{
+		"gemini",
+		"-p solve the task",
+		"--output-format json",
+		"--sandbox",
+		"--approval-mode default",
+		"--allowed-mcp-server-names centian",
+		"--model flash",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("expected %q in command %q", expected, joined)
+		}
+	}
+	for _, forbidden := range []string{"yolo", "auto_edit"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("unexpected unsafe or broad approval mode %q in %q", forbidden, joined)
+		}
+	}
+}
+
+func TestGeminiWriteConfig(t *testing.T) {
+	allocateFreePortFunc = func() (string, error) { return "40123", nil }
+	defer func() { allocateFreePortFunc = allocateFreePort }()
+
+	root := filepath.Join(t.TempDir(), "demo")
+	layout, err := prepareLayout(&DemoOptions{RootPath: root})
+	if err != nil {
+		t.Fatalf("prepareLayout: %v", err)
+	}
+	if err := (geminiAdapter{}).writeConfig(layout); err != nil {
+		t.Fatalf("writeConfig: %v", err)
+	}
+	assertFileContains(t, layout.GeminiConfig, `"httpUrl": "`+layout.MCPURL+`"`)
+	assertFileContains(t, layout.GeminiConfig, `"allowed": [`)
+	assertFileContains(t, layout.GeminiConfig, `"core": []`)
 }
 
 func TestWritePIDAndStopHint(t *testing.T) {

--- a/internal/agentrunner/gemini.go
+++ b/internal/agentrunner/gemini.go
@@ -1,0 +1,62 @@
+package agentrunner
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type geminiAdapter struct {
+	model string
+}
+
+func (geminiAdapter) name() string { return AgentGemini }
+
+func (geminiAdapter) isAvailable() error {
+	_, err := exec.LookPath("gemini")
+	return err
+}
+
+func (g geminiAdapter) writeConfig(layout *demoLayout) error {
+	content, err := asset("gemini_settings.json")
+	if err != nil {
+		return err
+	}
+	content = strings.ReplaceAll(content, "__MCP_URL__", layout.MCPURL)
+	var payload any
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		return fmt.Errorf("parse gemini settings: %w", err)
+	}
+	encoded, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode gemini settings: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(layout.GeminiConfig), 0o750); err != nil {
+		return fmt.Errorf("create gemini config dir: %w", err)
+	}
+	if err := os.WriteFile(layout.GeminiConfig, encoded, 0o600); err != nil {
+		return fmt.Errorf("write gemini settings: %w", err)
+	}
+	return nil
+}
+
+func (g geminiAdapter) command(_ *demoLayout, prompt string) ([]string, error) {
+	command := []string{
+		"gemini",
+		"-p",
+		prompt,
+		"--debug",
+		"--output-format", "json",
+		"--sandbox",
+		"--approval-mode", "default",
+		"--allowed-mcp-server-names", "centian",
+	}
+	model := strings.TrimSpace(g.model)
+	if model != "" {
+		command = append(command, "--model", model)
+	}
+	return command, nil
+}

--- a/internal/agentrunner/gemini.go
+++ b/internal/agentrunner/gemini.go
@@ -48,7 +48,7 @@ func (g geminiAdapter) command(_ *demoLayout, prompt string) ([]string, error) {
 		"gemini",
 		"-p",
 		prompt,
-		"--debug",
+		// "--debug", // add this back in if there is Gemini trouble again
 		"--output-format", "json",
 		"--sandbox",
 		"--approval-mode", "default",

--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -20,6 +20,7 @@ coding agent against it, and print the live UI URL.
 
 Examples:
   centian demo --agent claude
+  centian demo --agent gemini
   centian demo --agent claude --path ./my-demo
 `,
 	Action: handleDemoCommand,
@@ -27,7 +28,7 @@ Examples:
 		&cli.StringFlag{
 			Name:     "agent",
 			Aliases:  []string{"a"},
-			Usage:    "Agent to run for the demo (v1 supports: claude)",
+			Usage:    "Agent to run for the demo (v1 supports: claude, gemini)",
 			Required: true,
 		},
 		&cli.StringFlag{
@@ -58,6 +59,7 @@ func handleDemoCommand(ctx context.Context, cmd *cli.Command) error {
 		CentianBinaryPath: binaryPath,
 		Timeout:           5 * time.Minute,
 		ClaudeModel:       agentrunner.DefaultClaudeModel,
+		GeminiModel:       agentrunner.DefaultGeminiModel,
 		Stdout:            os.Stdout,
 		Stderr:            os.Stderr,
 	})

--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -1,10 +1,14 @@
 package cli
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/T4cceptor/centian/internal/agentrunner"
@@ -53,7 +57,7 @@ func handleDemoCommand(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	runner := agentrunner.DemoRunner{}
-	_, err = runner.RunDemo(ctx, &agentrunner.DemoOptions{
+	result, err := runner.RunDemo(ctx, &agentrunner.DemoOptions{
 		Agent:             cmd.String("agent"),
 		RootPath:          rootPath,
 		CentianBinaryPath: binaryPath,
@@ -63,11 +67,56 @@ func handleDemoCommand(ctx context.Context, cmd *cli.Command) error {
 		Stdout:            os.Stdout,
 		Stderr:            os.Stderr,
 	})
+	if result != nil {
+		fmt.Printf("Agent run finished. UI: %s\n", result.UIPublicURL)
+		shutdownErr := promptDemoShutdown(os.Stdin, os.Stdout, result)
+		if err != nil {
+			return errors.Join(err, shutdownErr)
+		}
+		return shutdownErr
+	}
 	if err != nil {
 		return err
 	}
-	fmt.Println("Agent run finished. Centian is still running.")
 	return nil
+}
+
+func promptDemoShutdown(input io.Reader, output io.Writer, result *agentrunner.DemoResult) error {
+	if result == nil || result.PID <= 0 {
+		return nil
+	}
+	_, _ = fmt.Fprint(output, "Shut down the Centian server now? (Y/n): ")
+	if !shouldShutdownDemo(input) {
+		return nil
+	}
+	process, err := os.FindProcess(result.PID)
+	if err != nil {
+		return fmt.Errorf("resolve centian process: %w", err)
+	}
+	if err := process.Signal(os.Interrupt); err != nil {
+		return fmt.Errorf("shut down centian server: %w", err)
+	}
+	return nil
+}
+
+func shouldShutdownDemo(input io.Reader) bool {
+	if input == nil {
+		return true
+	}
+	line, err := bufio.NewReader(input).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return true
+	}
+	switch value := normalizePromptAnswer(line); value {
+	case "", "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizePromptAnswer(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }
 
 func resolveDemoRoot(flagValue string) (string, error) {

--- a/internal/cli/demo_test.go
+++ b/internal/cli/demo_test.go
@@ -70,3 +70,25 @@ func TestHandleDemoCommandRequiresAgent(t *testing.T) {
 		t.Fatal("expected error for missing agent")
 	}
 }
+
+func TestShouldShutdownDemo(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{name: "empty defaults to yes", input: "\n", expected: true},
+		{name: "explicit yes", input: "y\n", expected: true},
+		{name: "explicit no", input: "n\n", expected: false},
+		{name: "full no", input: "no\n", expected: false},
+		{name: "unexpected value treated as no", input: "later\n", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if actual := shouldShutdownDemo(strings.NewReader(tt.input)); actual != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/proxy/proxy_taskverification_tools.go
+++ b/internal/proxy/proxy_taskverification_tools.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -90,7 +91,7 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 
 	server.AddTool(&mcp.Tool{
 		Name:        taskCompletePlanningTool,
-		Description: taskToolDescription("Persist planning context, freeze the contract, and enter execution."),
+		Description: taskToolDescription("Persist planning context, freeze the execution contract, and enter execution. planning.parameters must contain every required planning parameter before execution can begin, and Centian enforces that contract."),
 		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: taskCompletePlanningSchema(),
 	}, p.wrapTaskToolHandler(session, taskCompletePlanningTool, p.handleTaskCompletePlanningTool))
@@ -405,6 +406,7 @@ func taskCompletePlanningSchema() map[string]any {
 						"items": map[string]any{"type": "string"},
 					},
 				},
+				"required": []string{"parameters"},
 			},
 		},
 		"required": []string{"planning"},
@@ -522,6 +524,10 @@ func (p *CentianEndpoint) handleTaskCompletePlanningTool(ctx context.Context, se
 		p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, sourcePhase, sourceNodeKind, taskverification.TaskEventTypePlanningCompleted, taskverification.TaskEventOutcomeFailed, taskActionRequestIDFromContext(ctx), map[string]any{
 			"error": err.Error(),
 		})
+		var validationErr *taskverification.PlanningValidationError
+		if errors.As(err, &validationErr) {
+			return planningValidationToolResult(validationErr, session.taskRun, p.server.TaskVerification.WorkingDir), nil
+		}
 		return nil, err
 	}
 	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
@@ -770,22 +776,23 @@ func runStructuredContent(run *taskverification.RunState, workingDir string) map
 	}
 
 	structured := map[string]any{
-		"taskRunId":            run.RunID,
-		"templateId":           run.TemplateID,
-		"templateName":         run.SelectedTemplate.Task.Name,
-		"description":          run.SelectedTemplate.Task.Description,
-		"instructions":         run.SelectedTemplate.Task.Instructions,
-		"status":               string(run.Status),
-		"phase":                string(run.Phase),
-		"hasOnboarding":        run.Onboarding != nil,
-		"hasPlanning":          run.Planning != nil,
-		"executionReady":       run.WorkflowReady,
-		"stepCount":            len(run.SelectedTemplate.CompiledWorkflow.WorkflowSteps),
-		"lastFailureMessage":   run.LastFailureMessage,
-		"explicitFailReason":   run.ExplicitFailReason,
-		"parameterDefinitions": run.SelectedTemplate.ParameterDefinitions(),
-		"requiredInputs":       run.SelectedTemplate.ParameterDefinitions(),
-		"requiredInputNames":   run.SelectedTemplate.RequiredParameterNames(),
+		"taskRunId":                  run.RunID,
+		"templateId":                 run.TemplateID,
+		"templateName":               run.SelectedTemplate.Task.Name,
+		"description":                run.SelectedTemplate.Task.Description,
+		"instructions":               run.SelectedTemplate.Task.Instructions,
+		"status":                     string(run.Status),
+		"phase":                      string(run.Phase),
+		"hasOnboarding":              run.Onboarding != nil,
+		"hasPlanning":                run.Planning != nil,
+		"executionReady":             run.WorkflowReady,
+		"stepCount":                  len(run.SelectedTemplate.CompiledWorkflow.WorkflowSteps),
+		"lastFailureMessage":         run.LastFailureMessage,
+		"explicitFailReason":         run.ExplicitFailReason,
+		"parameterDefinitions":       run.SelectedTemplate.ParameterDefinitions(),
+		"requiredInputs":             run.SelectedTemplate.ParameterDefinitions(),
+		"requiredInputNames":         run.SelectedTemplate.RequiredParameterNames(),
+		"requiredPlanningParameters": requiredPlanningParameters(run.SelectedTemplate.ParameterDefinitions()),
 	}
 	addTaskTimingFields(structured, run)
 	addWorkspaceContext(structured, workingDir)
@@ -800,6 +807,7 @@ func runStructuredContent(run *taskverification.RunState, workingDir string) map
 	}
 
 	structured["steps"] = workflowStepsSummary(run)
+	addStepContract(structured, run)
 	return structured
 }
 
@@ -843,7 +851,7 @@ func nextActionForRun(run *taskverification.RunState) string {
 	case taskverification.WorkflowNodeKindOnboarding:
 		return "Call centian.task_complete_onboarding to freeze the onboarding context."
 	case taskverification.WorkflowNodeKindPlanning:
-		return "Call centian.task_complete_planning to freeze the execution contract."
+		return "Call centian.task_complete_planning with planning.parameters containing every required planning parameter. Execution cannot begin until the full planning contract is provided, and Centian enforces it."
 	case taskverification.WorkflowNodeKindWaitingForApproval:
 		return "Wait for approval before continuing task work."
 	case taskverification.WorkflowNodeKindScaffolding, taskverification.WorkflowNodeKindExecution:
@@ -940,6 +948,18 @@ func addArtifactSummaries(structured map[string]any, run *taskverification.RunSt
 	structured["frozenContractSummary"] = frozenContractSummary(run)
 }
 
+func addStepContract(structured map[string]any, run *taskverification.RunState) {
+	if structured == nil || run == nil || run.RunnableTemplate == nil || run.RunnableTemplate.CompiledWorkflow == nil {
+		return
+	}
+	stepNumber, _ := activeOrCurrentStep(run)
+	if stepNumber == 0 || stepNumber > len(run.RunnableTemplate.CompiledWorkflow.WorkflowSteps) {
+		return
+	}
+	step := &run.RunnableTemplate.CompiledWorkflow.WorkflowSteps[stepNumber-1]
+	structured["stepContract"] = stepContract(stepNumber, step)
+}
+
 func workflowStepsSummary(run *taskverification.RunState) []map[string]any {
 	steps := make([]map[string]any, 0, len(run.Steps))
 	for index, step := range run.Steps {
@@ -999,9 +1019,109 @@ func addTaskTimingToToolResult(result *mcp.CallToolResult, run *taskverification
 
 func planningContract() map[string]any {
 	return map[string]any{
-		"topLevelFields": []string{"selectedFiles", "parameters", "invariants"},
-		"inputField":     "parameters",
+		"topLevelFields":  []string{"selectedFiles", "parameters", "invariants"},
+		"inputField":      "parameters",
+		"parametersField": "planning.parameters",
+		"instructions":    "Fill every entry in planning.parameters before execution can begin. Centian enforces the planning contract.",
 	}
+}
+
+func requiredPlanningParameters(definitions []taskverification.TemplateParameter) map[string]any {
+	if len(definitions) == 0 {
+		return map[string]any{}
+	}
+	required := make(map[string]any, len(definitions))
+	for _, definition := range definitions {
+		required[definition.Name] = map[string]any{
+			"name":        definition.Name,
+			"description": definition.Description,
+			"required":    true,
+		}
+	}
+	return required
+}
+
+func planningValidationToolResult(validationErr *taskverification.PlanningValidationError, run *taskverification.RunState, workingDir string) *mcp.CallToolResult {
+	structured := runStructuredContent(run, workingDir)
+	structured["error"] = validationErr.Error()
+	structured["planningParametersField"] = "planning.parameters"
+	structured["requiredPlanningParameterNames"] = append([]string(nil), validationErr.RequiredParameterNames...)
+	structured["providedPlanningParameterNames"] = append([]string(nil), validationErr.ProvidedParameterNames...)
+	if len(validationErr.MissingParameters) > 0 {
+		structured["missingRequiredPlanningParameters"] = append([]string(nil), validationErr.MissingParameters...)
+	}
+	if len(validationErr.UnknownParameters) > 0 {
+		structured["unknownPlanningParameters"] = append([]string(nil), validationErr.UnknownParameters...)
+	}
+	structured["nextAction"] = "Resend centian.task_complete_planning with a complete planning.parameters object containing every required planning parameter. Execution remains blocked until the enforced planning contract is satisfied."
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: validationErr.Error()},
+		},
+		StructuredContent: structured,
+	}
+}
+
+func stepContract(stepNumber int, step *taskverification.Step) map[string]any {
+	contract := map[string]any{
+		"step":         stepNumber,
+		"id":           step.ID,
+		"path":         string(step.Path),
+		"name":         step.Name,
+		"description":  step.Description,
+		"instructions": step.Instructions,
+	}
+	if len(step.Checks) > 0 {
+		checks := make([]map[string]any, 0, len(step.Checks))
+		for _, check := range step.Checks {
+			checks = append(checks, map[string]any{
+				"id":             check.ID,
+				"description":    check.Description,
+				"command":        check.Command,
+				"preConditions":  contractConditions(check.PreConditions),
+				"postConditions": contractConditions(check.PostConditions),
+			})
+		}
+		contract["checks"] = checks
+	}
+	if len(step.Invariants) > 0 {
+		invariants := make([]map[string]any, 0, len(step.Invariants))
+		for _, invariant := range step.Invariants {
+			invariants = append(invariants, map[string]any{
+				"id":                   invariant.ID,
+				"description":          invariant.Description,
+				"command":              invariant.Command,
+				"technicalDescription": taskverification.InvariantTechnicalDescription(invariant),
+			})
+		}
+		contract["invariants"] = invariants
+	}
+	return contract
+}
+
+func contractConditions(conditions []taskverification.Condition) []map[string]any {
+	if len(conditions) == 0 {
+		return []map[string]any{}
+	}
+	described := make([]map[string]any, 0, len(conditions))
+	for _, condition := range conditions {
+		entry := map[string]any{
+			"type":                 condition.Type,
+			"technicalDescription": taskverification.ConditionTechnicalDescription(condition),
+		}
+		if condition.Path != "" {
+			entry["path"] = condition.Path
+		}
+		if condition.Value != nil {
+			entry["value"] = condition.Value
+		}
+		if len(condition.Values) > 0 {
+			entry["values"] = append([]any(nil), condition.Values...)
+		}
+		described = append(described, entry)
+	}
+	return described
 }
 
 func frozenContractSummary(run *taskverification.RunState) map[string]any {

--- a/internal/proxy/proxy_taskverification_tools.go
+++ b/internal/proxy/proxy_taskverification_tools.go
@@ -26,8 +26,7 @@ const (
 )
 
 type taskRegisterArgs struct {
-	TemplateID string         `json:"templateId"`
-	Parameters map[string]any `json:"parameters"`
+	TemplateID string `json:"templateId"`
 }
 
 type taskStepArgs struct {
@@ -75,9 +74,8 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 			"type": "object",
 			"properties": map[string]any{
 				"templateId": map[string]any{"type": "string"},
-				"parameters": map[string]any{"type": "object"},
 			},
-			"required": []string{"templateId", "parameters"},
+			"required": []string{"templateId"},
 		},
 	}, p.wrapTaskToolHandler(session, taskRegisterTool, p.handleTaskRegisterTool))
 	session.registeredStaticTools[taskRegisterTool] = struct{}{}
@@ -398,10 +396,10 @@ func taskCompletePlanningSchema() map[string]any {
 						"type":  "array",
 						"items": map[string]any{"type": "string"},
 					},
-					"testTarget":           map[string]any{"type": "string"},
-					"lintCommand":          map[string]any{"type": "string"},
-					"expectedFailure":      map[string]any{"type": "string"},
-					"implementationTarget": map[string]any{"type": "string"},
+					"parameters": map[string]any{
+						"type":                 "object",
+						"additionalProperties": map[string]any{"type": "string"},
+					},
 					"invariants": map[string]any{
 						"type":  "array",
 						"items": map[string]any{"type": "string"},
@@ -438,24 +436,27 @@ func (p *CentianEndpoint) handleTaskListTemplatesTool(_ context.Context, _ *Upst
 	}
 	response := map[string]any{
 		"templates":  structured,
-		"nextAction": "Call centian.task_register with one templateId and its parameters.",
+		"nextAction": "Call centian.task_register with one templateId.",
 	}
 	addWorkspaceContext(response, p.server.TaskVerification.WorkingDir)
 	return toolResult(strings.Join(lines, "\n"), response), nil
 }
 
 func (p *CentianEndpoint) handleTaskRegisterTool(ctx context.Context, session *UpstreamSession, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if req != nil && req.Params != nil && len(req.Params.Arguments) > 0 {
+		raw := map[string]json.RawMessage{}
+		if err := json.Unmarshal(req.Params.Arguments, &raw); err == nil {
+			if _, exists := raw["parameters"]; exists {
+				return nil, fmt.Errorf("task_register no longer accepts parameters; provide them in task_complete_planning under planning.parameters")
+			}
+		}
+	}
 	args := taskRegisterArgs{}
 	if err := decodeToolArguments(req, &args); err != nil {
 		return nil, err
 	}
 	if strings.TrimSpace(args.TemplateID) == "" {
 		return nil, fmt.Errorf("templateId is required")
-	}
-
-	parameters := make(map[string]string, len(args.Parameters))
-	for key, value := range args.Parameters {
-		parameters[key] = fmt.Sprint(value)
 	}
 
 	session.taskMu.Lock()
@@ -465,15 +466,13 @@ func (p *CentianEndpoint) handleTaskRegisterTool(ctx context.Context, session *U
 		return nil, fmt.Errorf("an active task is already registered for this session")
 	}
 
-	run, err := p.server.TaskVerification.RegisterTask(args.TemplateID, parameters)
+	run, err := p.server.TaskVerification.RegisterTask(args.TemplateID)
 	if err != nil {
 		return nil, err
 	}
 	session.taskRun = run
 	sourcePhase, sourceNodeKind := taskPhaseSnapshot(run)
-	p.recordTaskEvent(session, run, sourcePhase, sourceNodeKind, sourcePhase, sourceNodeKind, taskverification.TaskEventTypeRegistered, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), map[string]any{
-		"draftParameters": run.DraftParameters,
-	})
+	p.recordTaskEvent(session, run, sourcePhase, sourceNodeKind, sourcePhase, sourceNodeKind, taskverification.TaskEventTypeRegistered, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
 
 	structured := runStructuredContent(run, p.server.TaskVerification.WorkingDir)
 	stepCount := len(run.SelectedTemplate.CompiledWorkflow.WorkflowSteps)
@@ -513,6 +512,7 @@ func (p *CentianEndpoint) handleTaskCompletePlanningTool(ctx context.Context, se
 	if err := decodeToolArguments(req, &args); err != nil {
 		return nil, err
 	}
+	normalizePlanningArtifactArguments(req, &args.Planning)
 
 	session.taskMu.Lock()
 	defer session.taskMu.Unlock()
@@ -536,6 +536,54 @@ func (p *CentianEndpoint) handleTaskCompletePlanningTool(ctx context.Context, se
 		structured["planning"] = session.taskRun.Planning
 	}
 	return toolResult(fmt.Sprintf("Task planning completed; task moved to %s.", session.taskRun.Phase), structured), nil
+}
+
+func normalizePlanningArtifactArguments(req *mcp.CallToolRequest, artifact *taskverification.PlanningArtifact) {
+	if req == nil || req.Params == nil || len(req.Params.Arguments) == 0 || artifact == nil {
+		return
+	}
+	rawArgs := map[string]json.RawMessage{}
+	if err := json.Unmarshal(req.Params.Arguments, &rawArgs); err != nil {
+		return
+	}
+	rawPlanning, exists := rawArgs["planning"]
+	if !exists {
+		return
+	}
+	planningMap := map[string]json.RawMessage{}
+	if err := json.Unmarshal(rawPlanning, &planningMap); err != nil {
+		return
+	}
+	if artifact.Parameters == nil {
+		artifact.Parameters = map[string]string{}
+	}
+	copyLegacyPlanningParameter(planningMap, artifact.Parameters, "testCommand", "testCommand")
+	copyLegacyPlanningParameter(planningMap, artifact.Parameters, "testTarget", "testTarget")
+	copyLegacyPlanningParameter(planningMap, artifact.Parameters, "testFile", "testFile")
+	copyLegacyPlanningParameter(planningMap, artifact.Parameters, "testName", "testName")
+	copyLegacyPlanningParameter(planningMap, artifact.Parameters, "lintCommand", "lintCommand")
+	copyLegacyPlanningParameter(planningMap, artifact.Parameters, "expectedError", "expectedError")
+	copyLegacyPlanningParameter(planningMap, artifact.Parameters, "expectedFailure", "expectedError")
+	copyLegacyPlanningParameter(planningMap, artifact.Parameters, "implementationTarget", "implementationTarget")
+}
+
+func copyLegacyPlanningParameter(raw map[string]json.RawMessage, parameters map[string]string, sourceKey, targetKey string) {
+	if _, exists := parameters[targetKey]; exists {
+		return
+	}
+	value, exists := raw[sourceKey]
+	if !exists {
+		return
+	}
+	var decoded string
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		return
+	}
+	decoded = strings.TrimSpace(decoded)
+	if decoded == "" {
+		return
+	}
+	parameters[targetKey] = decoded
 }
 
 func (p *CentianEndpoint) handleTaskStartStepTool(ctx context.Context, session *UpstreamSession, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -722,20 +770,22 @@ func runStructuredContent(run *taskverification.RunState, workingDir string) map
 	}
 
 	structured := map[string]any{
-		"taskRunId":          run.RunID,
-		"templateId":         run.TemplateID,
-		"templateName":       run.SelectedTemplate.Task.Name,
-		"description":        run.SelectedTemplate.Task.Description,
-		"instructions":       run.SelectedTemplate.Task.Instructions,
-		"status":             string(run.Status),
-		"phase":              string(run.Phase),
-		"draftParameters":    run.DraftParameters,
-		"hasOnboarding":      run.Onboarding != nil,
-		"hasPlanning":        run.Planning != nil,
-		"executionReady":     run.WorkflowReady,
-		"stepCount":          len(run.SelectedTemplate.CompiledWorkflow.WorkflowSteps),
-		"lastFailureMessage": run.LastFailureMessage,
-		"explicitFailReason": run.ExplicitFailReason,
+		"taskRunId":            run.RunID,
+		"templateId":           run.TemplateID,
+		"templateName":         run.SelectedTemplate.Task.Name,
+		"description":          run.SelectedTemplate.Task.Description,
+		"instructions":         run.SelectedTemplate.Task.Instructions,
+		"status":               string(run.Status),
+		"phase":                string(run.Phase),
+		"hasOnboarding":        run.Onboarding != nil,
+		"hasPlanning":          run.Planning != nil,
+		"executionReady":       run.WorkflowReady,
+		"stepCount":            len(run.SelectedTemplate.CompiledWorkflow.WorkflowSteps),
+		"lastFailureMessage":   run.LastFailureMessage,
+		"explicitFailReason":   run.ExplicitFailReason,
+		"parameterDefinitions": run.SelectedTemplate.ParameterDefinitions(),
+		"requiredInputs":       run.SelectedTemplate.ParameterDefinitions(),
+		"requiredInputNames":   run.SelectedTemplate.RequiredParameterNames(),
 	}
 	addTaskTimingFields(structured, run)
 	addWorkspaceContext(structured, workingDir)
@@ -852,8 +902,8 @@ func addCurrentNodeContext(structured map[string]any, run *taskverification.RunS
 	if len(node.EditableFields) > 0 {
 		structured["planningEditableFields"] = append([]string{}, node.EditableFields...)
 	}
-	if len(node.RequiredPlanningOutputs) > 0 {
-		structured["planningRequiredOutputs"] = append([]string{}, node.RequiredPlanningOutputs...)
+	if len(node.RequiredPlanningInputs) > 0 {
+		structured["planningRequiredInputs"] = append([]string{}, node.RequiredPlanningInputs...)
 	}
 	if node.NextPath != "" {
 		structured["nextNodePath"] = string(node.NextPath)
@@ -871,8 +921,8 @@ func addPlanningNodeContext(structured map[string]any, run *taskverification.Run
 	if _, present := structured["planningEditableFields"]; !present && len(planningNode.EditableFields) > 0 {
 		structured["planningEditableFields"] = append([]string{}, planningNode.EditableFields...)
 	}
-	if _, present := structured["planningRequiredOutputs"]; !present && len(planningNode.RequiredPlanningOutputs) > 0 {
-		structured["planningRequiredOutputs"] = append([]string{}, planningNode.RequiredPlanningOutputs...)
+	if _, present := structured["planningRequiredInputs"]; !present && len(planningNode.RequiredPlanningInputs) > 0 {
+		structured["planningRequiredInputs"] = append([]string{}, planningNode.RequiredPlanningInputs...)
 	}
 }
 
@@ -884,10 +934,8 @@ func addArtifactSummaries(structured map[string]any, run *taskverification.RunSt
 		return
 	}
 	structured["planningSummary"] = map[string]any{
-		"selectedFiles":        run.Planning.SelectedFiles,
-		"testTarget":           run.Planning.TestTarget,
-		"lintCommand":          run.Planning.LintCommand,
-		"implementationTarget": run.Planning.ImplementationTarget,
+		"selectedFiles": run.Planning.SelectedFiles,
+		"parameters":    run.Planning.Parameters,
 	}
 	structured["frozenContractSummary"] = frozenContractSummary(run)
 }
@@ -951,34 +999,23 @@ func addTaskTimingToToolResult(result *mcp.CallToolResult, run *taskverification
 
 func planningContract() map[string]any {
 	return map[string]any{
-		"supportedFields": []string{
-			"selectedFiles",
-			"testTarget",
-			"lintCommand",
-			"expectedFailure",
-			"implementationTarget",
-			"invariants",
-		},
+		"topLevelFields": []string{"selectedFiles", "parameters", "invariants"},
+		"inputField":     "parameters",
 	}
 }
 
 func frozenContractSummary(run *taskverification.RunState) map[string]any {
 	summary := map[string]any{
-		"selectedFiles":        []string{},
-		"testTarget":           "",
-		"implementationTarget": "",
-		"invariantCount":       0,
+		"selectedFiles":  []string{},
+		"parameters":     map[string]string{},
+		"invariantCount": 0,
 	}
 	if run == nil || run.Planning == nil {
 		return summary
 	}
 
 	summary["selectedFiles"] = append([]string{}, run.Planning.SelectedFiles...)
-	summary["testTarget"] = run.Planning.TestTarget
-	summary["implementationTarget"] = run.Planning.ImplementationTarget
-	if strings.TrimSpace(run.Planning.LintCommand) != "" {
-		summary["lintCommand"] = run.Planning.LintCommand
-	}
+	summary["parameters"] = cloneStringMap(run.Planning.Parameters)
 	if run.RunnableTemplate != nil && run.RunnableTemplate.CompiledWorkflow != nil {
 		invariantCount := 0
 		for idx := range run.RunnableTemplate.CompiledWorkflow.WorkflowSteps {
@@ -988,4 +1025,15 @@ func frozenContractSummary(run *taskverification.RunState) map[string]any {
 		summary["invariantCount"] = invariantCount
 	}
 	return summary
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -183,7 +183,6 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -237,7 +236,8 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, completeOnboardingStructured["nextNodePath"], "execution.step_one")
 	assert.Assert(t, completeOnboardingStructured["onboardingContract"] != nil)
 	assert.Assert(t, completeOnboardingStructured["planningContract"] != nil)
-	assert.DeepEqual(t, completeOnboardingStructured["planningRequiredOutputs"], []any{"testTarget"})
+	_, hasPlanningRequiredInputs := completeOnboardingStructured["planningRequiredInputs"]
+	assert.Assert(t, !hasPlanningRequiredInputs)
 	assert.Equal(t, completeOnboardingStructured["shellCommandHint"], "For compound shell commands or directory changes, use bash -lc '...'.")
 	assert.Equal(t, completeOnboardingStructured["hasOnboarding"], true)
 	assert.Equal(t, completeOnboardingStructured["taskSummary"], "Small test task context with one shell validation path.")
@@ -258,10 +258,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
 			"planning": map[string]any{
-				"selectedFiles":        []string{"tests/test_mathlib.py"},
-				"testTarget":           "python -m pytest -q tests/test_mathlib.py",
-				"lintCommand":          "ruff check .",
-				"implementationTarget": "mathlib.add",
+				"selectedFiles": []string{"tests/test_mathlib.py"},
 			},
 		},
 	})
@@ -271,18 +268,17 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, completePlanningStructured["phase"], "execution.step_one")
 	assert.Equal(t, completePlanningStructured["currentNodeKind"], string(taskverification.WorkflowNodeKindExecution))
 	assert.Equal(t, completePlanningStructured["approvalBlocked"], false)
-	assert.DeepEqual(t, completePlanningStructured["planningRequiredOutputs"], []any{"testTarget"})
+	_, hasPlanningRequiredInputs = completePlanningStructured["planningRequiredInputs"]
+	assert.Assert(t, !hasPlanningRequiredInputs)
 	assert.Equal(t, completePlanningStructured["hasPlanning"], true)
 	assert.DeepEqual(t, completePlanningStructured["allowedTools"], []any{"shell__*", "filesystem__*"})
 	assert.Equal(t, completePlanningStructured["executionReady"], true)
 	assert.Equal(t, completePlanningStructured["nextAction"], "Call centian.task_start_step for step 1.")
 	assert.Assert(t, completePlanningStructured["planningSummary"] != nil)
 	assert.DeepEqual(t, completePlanningStructured["frozenContractSummary"], map[string]any{
-		"selectedFiles":        []any{"tests/test_mathlib.py"},
-		"testTarget":           "python -m pytest -q tests/test_mathlib.py",
-		"implementationTarget": "mathlib.add",
-		"lintCommand":          "ruff check .",
-		"invariantCount":       float64(0),
+		"selectedFiles":  []any{"tests/test_mathlib.py"},
+		"parameters":     map[string]any{},
+		"invariantCount": float64(0),
 	})
 	assert.Assert(t, completePlanningStructured["steps"] != nil)
 
@@ -347,9 +343,6 @@ func TestTaskToolFlowAllowsNoCheckTemplate(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "minimal",
-			"parameters": map[string]any{
-				"taskName": "Investigate issue",
-			},
 		},
 	})
 	assert.NilError(t, err)
@@ -370,7 +363,11 @@ func TestTaskToolFlowAllowsNoCheckTemplate(t *testing.T) {
 	completePlanningResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
-			"planning": map[string]any{},
+			"planning": map[string]any{
+				"parameters": map[string]any{
+					"taskName": "Investigate issue",
+				},
+			},
 		},
 	})
 	assert.NilError(t, err)
@@ -430,10 +427,7 @@ func TestTaskVerificationToolSchemasExposeNestedArtifacts(t *testing.T) {
 	planningSchema := byName[taskCompletePlanningTool].InputSchema.(map[string]any)
 	planningProps := planningSchema["properties"].(map[string]any)["planning"].(map[string]any)["properties"].(map[string]any)
 	assert.Assert(t, planningProps["selectedFiles"] != nil)
-	assert.Assert(t, planningProps["testTarget"] != nil)
-	assert.Assert(t, planningProps["lintCommand"] != nil)
-	assert.Assert(t, planningProps["expectedFailure"] != nil)
-	assert.Assert(t, planningProps["implementationTarget"] != nil)
+	assert.Assert(t, planningProps["parameters"] != nil)
 	assert.Assert(t, planningProps["invariants"] != nil)
 
 	listTool := byName[taskListTemplatesTool]
@@ -475,10 +469,6 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "parameterized_task",
-			"parameters": map[string]any{
-				"testCommand":   "pytest",
-				"expectedError": "boom",
-			},
 		},
 	})
 	assert.NilError(t, err)
@@ -497,7 +487,10 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
 			"planning": map[string]any{
-				"testTarget": "tests/test_parameterized.py",
+				"parameters": map[string]any{
+					"testCommand":   "pytest",
+					"expectedError": "boom",
+				},
 			},
 		},
 	})
@@ -534,7 +527,6 @@ func TestTaskLifecycleEventsRecorded(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -628,7 +620,7 @@ workflow:
     tools_allowed: ["shell__*"]
   planning:
     tools_allowed: ["shell__*"]
-    required_outputs: ["testTarget"]
+    required_inputs: []
     next: "waiting_for_approval.review_plan"
   execution:
     - id: "review_plan"
@@ -649,7 +641,6 @@ workflow:
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -686,7 +677,6 @@ func TestActionEventTaskContextCreatedForBuiltInTaskTools(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -741,7 +731,6 @@ func TestProxiedActionCreatesTaskContextOnlyWhenActiveTaskRunExists(t *testing.T
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -773,7 +762,6 @@ func TestTaskToolCallsPersistToSQLiteActionAndTaskStores(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -817,7 +805,6 @@ func TestProxiedToolCallsPersistToSQLiteActionStoreAndContext(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -862,7 +849,7 @@ workflow:
     tools_allowed: ["shell__*"]
   planning:
     tools_allowed: ["shell__*"]
-    required_outputs: ["testTarget"]
+    required_inputs: []
     next: "waiting_for_approval.review_plan"
   execution:
     - id: "review_plan"
@@ -883,7 +870,6 @@ workflow:
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -945,7 +931,6 @@ func TestTaskRegistrationIsIsolatedPerSession(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -953,7 +938,6 @@ func TestTaskRegistrationIsIsolatedPerSession(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -975,7 +959,7 @@ workflow:
     tools_allowed: ["shell__*", "filesystem__*"]
   planning:
     tools_allowed: ["shell__*", "filesystem__*"]
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       tools_allowed: ["shell__*", "filesystem__*"]
@@ -997,7 +981,6 @@ workflow:
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -1049,7 +1032,6 @@ func TestWorkflowNodeToolGovernanceAllowsMatchingTool(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -1073,7 +1055,7 @@ func TestWorkflowNodeToolGovernanceDeniesCompletedTask(t *testing.T) {
 
 	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskRegisterTool,
-		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+		Arguments: map[string]any{"templateId": "task"},
 	})
 	assert.NilError(t, err)
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
@@ -1119,7 +1101,7 @@ func TestWorkflowNodeToolGovernanceDeniesFailedTask(t *testing.T) {
 
 	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskRegisterTool,
-		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+		Arguments: map[string]any{"templateId": "task"},
 	})
 	assert.NilError(t, err)
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
@@ -1150,7 +1132,7 @@ func TestTaskIdleTimeoutDeniesDownstreamToolsAndRecordsEvent(t *testing.T) {
 
 	registerResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskRegisterTool,
-		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+		Arguments: map[string]any{"templateId": "task"},
 	})
 	assert.NilError(t, err)
 	registerStructured := registerResult.StructuredContent.(map[string]any)
@@ -1192,7 +1174,7 @@ func TestTaskActivityRefreshesIdleTimeoutForTaskAndDownstreamCalls(t *testing.T)
 
 	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskRegisterTool,
-		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+		Arguments: map[string]any{"templateId": "task"},
 	})
 	assert.NilError(t, err)
 
@@ -1231,7 +1213,7 @@ func TestTaskResumeRequiresTimedOutRunAndPreservesWorkflowProgress(t *testing.T)
 
 	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskRegisterTool,
-		Arguments: map[string]any{"templateId": "task", "parameters": map[string]any{}},
+		Arguments: map[string]any{"templateId": "task"},
 	})
 	assert.NilError(t, err)
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
@@ -1326,7 +1308,6 @@ func TestWorkflowNodeToolGovernanceDeniesUnmatchedTool(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -1358,7 +1339,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -1374,7 +1355,6 @@ workflow:
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -1404,7 +1384,6 @@ func TestWorkflowNodeToolGovernanceMatchesAggregatedCanonicalToolName(t *testing
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -1431,7 +1410,7 @@ workflow:
     tools_allowed: ["shell__*"]
   planning:
     tools_allowed: ["shell__*"]
-    required_outputs: ["testTarget"]
+    required_inputs: []
   scaffolding:
     - id: "setup_files"
       tools_allowed: ["*"]
@@ -1460,7 +1439,6 @@ workflow:
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -1505,7 +1483,7 @@ workflow:
     tools_allowed: ["shell__*"]
   planning:
     tools_allowed: ["shell__*"]
-    required_outputs: ["testTarget"]
+    required_inputs: []
     next: "waiting_for_approval.review_plan"
   execution:
     - id: "review_plan"
@@ -1527,7 +1505,6 @@ workflow:
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -1582,7 +1559,6 @@ func TestTaskToolCallsAreWrittenToRequestLog(t *testing.T) {
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "task",
-			"parameters": map[string]any{},
 		},
 	})
 	assert.NilError(t, err)
@@ -1642,7 +1618,7 @@ workflow:
     tools_allowed: ["shell__*", "filesystem__*"]
   planning:
     tools_allowed: ["shell__*", "filesystem__*"]
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       tools_allowed: ["shell__*", "filesystem__*"]
@@ -1677,7 +1653,7 @@ workflow:
   planning:
     tools_allowed: ["shell__*", "filesystem__*"]
     editable_fields: ["parameters.testCommand", "parameters.expectedError"]
-    required_outputs: ["testTarget"]
+    required_inputs: ["expectedError", "testCommand"]
   execution:
     - id: "step_one"
       tools_allowed: ["shell__*", "filesystem__*"]

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -244,7 +244,8 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.DeepEqual(t, completeOnboardingStructured["allowedTools"], []any{"shell__*", "filesystem__*"})
 	assert.Assert(t, completeOnboardingStructured["onboarding"] != nil)
 	assert.Equal(t, completeOnboardingStructured["hasPlanning"], false)
-	assert.Equal(t, completeOnboardingStructured["nextAction"], "Call centian.task_complete_planning to freeze the execution contract.")
+	assert.Equal(t, completeOnboardingStructured["nextAction"], "Call centian.task_complete_planning with planning.parameters containing every required planning parameter. Execution cannot begin until the full planning contract is provided, and Centian enforces it.")
+	assert.DeepEqual(t, completeOnboardingStructured["requiredPlanningParameters"], map[string]any{})
 
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskStartStepTool,
@@ -259,6 +260,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 		Arguments: map[string]any{
 			"planning": map[string]any{
 				"selectedFiles": []string{"tests/test_mathlib.py"},
+				"parameters":    map[string]any{},
 			},
 		},
 	})
@@ -281,6 +283,7 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 		"invariantCount": float64(0),
 	})
 	assert.Assert(t, completePlanningStructured["steps"] != nil)
+	assert.Assert(t, completePlanningStructured["stepContract"] != nil)
 
 	startStepResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskStartStepTool,
@@ -425,10 +428,12 @@ func TestTaskVerificationToolSchemasExposeNestedArtifacts(t *testing.T) {
 	assert.DeepEqual(t, commonCommandItems["required"], []any{"command", "purpose"})
 
 	planningSchema := byName[taskCompletePlanningTool].InputSchema.(map[string]any)
-	planningProps := planningSchema["properties"].(map[string]any)["planning"].(map[string]any)["properties"].(map[string]any)
+	planningObject := planningSchema["properties"].(map[string]any)["planning"].(map[string]any)
+	planningProps := planningObject["properties"].(map[string]any)
 	assert.Assert(t, planningProps["selectedFiles"] != nil)
 	assert.Assert(t, planningProps["parameters"] != nil)
 	assert.Assert(t, planningProps["invariants"] != nil)
+	assert.DeepEqual(t, planningObject["required"], []any{"parameters"})
 
 	listTool := byName[taskListTemplatesTool]
 	assert.Assert(t, listTool.Annotations != nil)
@@ -465,13 +470,26 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
 	defer cleanup()
 
-	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+	registerResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskRegisterTool,
 		Arguments: map[string]any{
 			"templateId": "parameterized_task",
 		},
 	})
 	assert.NilError(t, err)
+	registerStructured := registerResult.StructuredContent.(map[string]any)
+	assert.DeepEqual(t, registerStructured["requiredPlanningParameters"], map[string]any{
+		"expectedError": map[string]any{
+			"name":        "expectedError",
+			"description": "Expected error",
+			"required":    true,
+		},
+		"testCommand": map[string]any{
+			"name":        "testCommand",
+			"description": "Command name",
+			"required":    true,
+		},
+	})
 
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompleteOnboardingTool,
@@ -498,6 +516,7 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 	completePlanningStructured := completePlanningResult.StructuredContent.(map[string]any)
 	assert.Equal(t, completePlanningStructured["phase"], "execution.step_one")
 	assert.Equal(t, completePlanningStructured["currentNodeKind"], string(taskverification.WorkflowNodeKindExecution))
+	assert.Assert(t, completePlanningStructured["stepContract"] != nil)
 
 	startStepResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskStartStepTool,
@@ -515,6 +534,97 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 	completeStepStructured := completeStepResult.StructuredContent.(map[string]any)
 	assert.Equal(t, completeStepStructured["stepStatus"], string(taskverification.StepStatusPassed))
 	assert.Equal(t, completeStepStructured["status"], string(taskverification.TaskStatusCompleted))
+}
+
+func TestTaskCompletePlanningReturnsStructuredPlanningValidationFailure(t *testing.T) {
+	_, session := newTaskToolTestProxy(t, parameterizedPlanningTaskTemplate())
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskRegisterTool,
+		Arguments: map[string]any{"templateId": "parameterized_task"},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompleteOnboardingTool,
+		Arguments: map[string]any{"onboarding": map[string]any{"taskSummary": "Ready"}},
+	})
+	assert.NilError(t, err)
+
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskCompletePlanningTool,
+		Arguments: map[string]any{
+			"planning": map[string]any{
+				"parameters": map[string]any{
+					"expectedError": "boom",
+					"unknown":       "value",
+				},
+			},
+		},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, result.IsError)
+	structured := result.StructuredContent.(map[string]any)
+	assert.Equal(t, structured["planningParametersField"], "planning.parameters")
+	assert.DeepEqual(t, structured["missingRequiredPlanningParameters"], []any{"testCommand"})
+	assert.DeepEqual(t, structured["unknownPlanningParameters"], []any{"unknown"})
+	assert.DeepEqual(t, structured["requiredPlanningParameterNames"], []any{"expectedError", "testCommand"})
+	assert.DeepEqual(t, structured["providedPlanningParameterNames"], []any{"expectedError", "unknown"})
+	assert.Equal(t, structured["nextAction"], "Resend centian.task_complete_planning with a complete planning.parameters object containing every required planning parameter. Execution remains blocked until the enforced planning contract is satisfied.")
+}
+
+func TestStepContractIncludesDescriptionsAndTechnicalDetails(t *testing.T) {
+	_, session := newTaskToolTestProxy(t, stepContractTemplate())
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskRegisterTool,
+		Arguments: map[string]any{"templateId": "step_contract"},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompleteOnboardingTool,
+		Arguments: map[string]any{"onboarding": map[string]any{"taskSummary": "Ready"}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskCompletePlanningTool,
+		Arguments: map[string]any{
+			"planning": map[string]any{
+				"parameters": map[string]any{
+					"testFile": "test_score_parentheses.py",
+				},
+			},
+		},
+	})
+	assert.NilError(t, err)
+
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskStartStepTool,
+		Arguments: map[string]any{"step": 1},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, !result.IsError)
+	structured := result.StructuredContent.(map[string]any)
+	stepContract := structured["stepContract"].(map[string]any)
+	assert.Equal(t, stepContract["description"], "Ensures the failing baseline is prepared.")
+	assert.Equal(t, stepContract["instructions"], "Prepare the baseline before implementation.")
+
+	checks := stepContract["checks"].([]any)
+	check := checks[0].(map[string]any)
+	assert.Equal(t, check["description"], "Makes sure the planned test scaffold exists.")
+	preConditions := check["preConditions"].([]any)
+	preCondition := preConditions[0].(map[string]any)
+	assert.Equal(t, preCondition["technicalDescription"], "Checks that a file is available at \"test_score_parentheses.py\".")
+
+	invariants := stepContract["invariants"].([]any)
+	invariant := invariants[0].(map[string]any)
+	assert.Equal(t, invariant["description"], "Keeps the chosen test file stable during implementation.")
+	assert.Equal(t, invariant["technicalDescription"], "Captures the command output when the step starts and requires it to remain unchanged until the step completes.")
 }
 
 func TestTaskLifecycleEventsRecorded(t *testing.T) {
@@ -540,7 +650,7 @@ func TestTaskLifecycleEventsRecorded(t *testing.T) {
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
-			"planning": map[string]any{"testTarget": "pytest -q"},
+			"planning": map[string]any{"parameters": map[string]any{}},
 		},
 	})
 	assert.NilError(t, err)
@@ -654,7 +764,7 @@ workflow:
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
-			"planning": map[string]any{"testTarget": "pytest -q"},
+			"planning": map[string]any{"parameters": map[string]any{}},
 		},
 	})
 	assert.NilError(t, err)
@@ -690,7 +800,7 @@ func TestActionEventTaskContextCreatedForBuiltInTaskTools(t *testing.T) {
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
-			"planning": map[string]any{"testTarget": "pytest -q"},
+			"planning": map[string]any{"parameters": map[string]any{}},
 		},
 	})
 	assert.NilError(t, err)
@@ -887,7 +997,7 @@ workflow:
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
 			"planning": map[string]any{
-				"testTarget": "pytest -q",
+				"parameters": map[string]any{},
 			},
 		},
 	})
@@ -994,7 +1104,7 @@ workflow:
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
-			"planning": map[string]any{"testTarget": "pytest -q"},
+			"planning": map[string]any{"parameters": map[string]any{}},
 		},
 	})
 	assert.NilError(t, err)
@@ -1065,7 +1175,7 @@ func TestWorkflowNodeToolGovernanceDeniesCompletedTask(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskCompletePlanningTool,
-		Arguments: map[string]any{"planning": map[string]any{"testTarget": "pytest -q"}},
+		Arguments: map[string]any{"planning": map[string]any{"parameters": map[string]any{}}},
 	})
 	assert.NilError(t, err)
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
@@ -1223,7 +1333,7 @@ func TestTaskResumeRequiresTimedOutRunAndPreservesWorkflowProgress(t *testing.T)
 	assert.NilError(t, err)
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskCompletePlanningTool,
-		Arguments: map[string]any{"planning": map[string]any{"testTarget": "pytest -q"}},
+		Arguments: map[string]any{"planning": map[string]any{"parameters": map[string]any{}}},
 	})
 	assert.NilError(t, err)
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
@@ -1452,7 +1562,7 @@ workflow:
 	completePlanningResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
-			"planning": map[string]any{"testTarget": "pytest -q"},
+			"planning": map[string]any{"parameters": map[string]any{}},
 		},
 	})
 	assert.NilError(t, err)
@@ -1518,7 +1628,7 @@ workflow:
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
-			"planning": map[string]any{"testTarget": "pytest -q"},
+			"planning": map[string]any{"parameters": map[string]any{}},
 		},
 	})
 	assert.NilError(t, err)
@@ -1575,7 +1685,7 @@ func TestTaskToolCallsAreWrittenToRequestLog(t *testing.T) {
 		Name: taskCompletePlanningTool,
 		Arguments: map[string]any{
 			"planning": map[string]any{
-				"testTarget": "pytest -q",
+				"parameters": map[string]any{},
 			},
 		},
 	})
@@ -1666,6 +1776,45 @@ workflow:
           post_conditions:
             - type: stdout_contains
               value: "pytest:boom"
+`
+}
+
+func stepContractTemplate() string {
+	return `
+version: "0.1"
+task:
+  id: "step_contract"
+  name: "Step Contract"
+  description: "Template exposing rich step metadata."
+parameters:
+  - name: "testFile"
+    description: "The test file kept stable."
+workflow:
+  onboarding:
+    tools_allowed: ["shell__*", "filesystem__*"]
+  planning:
+    tools_allowed: ["shell__*", "filesystem__*"]
+    required_inputs: ["testFile"]
+  execution:
+    - id: "prepare_baseline"
+      name: "Prepare baseline"
+      description: "Ensures the failing baseline is prepared."
+      instructions: "Prepare the baseline before implementation."
+      tools_allowed: ["shell__*", "filesystem__*"]
+      checks:
+        - id: "scaffold_exists"
+          description: "Makes sure the planned test scaffold exists."
+          command: "printf ok"
+          pre_conditions:
+            - type: file_exists
+              path: "${testFile}"
+          post_conditions:
+            - type: output_contains
+              value: "ok"
+      invariants:
+        - id: "stable_test_file"
+          description: "Keeps the chosen test file stable during implementation."
+          command: "cat ${testFile}"
 `
 }
 

--- a/internal/taskverification/contract_metadata.go
+++ b/internal/taskverification/contract_metadata.go
@@ -1,0 +1,36 @@
+package taskverification
+
+import "fmt"
+
+// ConditionTechnicalDescription explains the built-in meaning of a condition in concise prose.
+func ConditionTechnicalDescription(condition Condition) string {
+	switch condition.Type {
+	case "exit_code":
+		return "Checks that the command exits with the expected exit code."
+	case "exit_code_in":
+		return "Checks that the command exits with one of the allowed exit codes."
+	case "stdout_contains":
+		return "Checks that stdout includes the expected substring."
+	case "stdout_not_contains":
+		return "Checks that stdout does not include the forbidden substring."
+	case "output_contains":
+		return "Checks that combined stdout and stderr include the expected substring."
+	case "output_not_contains":
+		return "Checks that combined stdout and stderr do not include the forbidden substring."
+	case "file_exists":
+		return fmt.Sprintf("Checks that a file is available at %q.", condition.Path)
+	case "file_not_exists":
+		return fmt.Sprintf("Checks that no file is available at %q.", condition.Path)
+	case "file_contains":
+		return fmt.Sprintf("Checks that %q includes the expected substring.", condition.Path)
+	case "file_not_contains":
+		return fmt.Sprintf("Checks that %q does not include the forbidden substring.", condition.Path)
+	default:
+		return ""
+	}
+}
+
+// InvariantTechnicalDescription explains how Centian enforces an invariant.
+func InvariantTechnicalDescription(_ Invariant) string {
+	return "Captures the command output when the step starts and requires it to remain unchanged until the step completes."
+}

--- a/internal/taskverification/planning_validation.go
+++ b/internal/taskverification/planning_validation.go
@@ -1,0 +1,58 @@
+package taskverification
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// PlanningValidationError captures machine-readable planning contract failures.
+type PlanningValidationError struct {
+	RequiredParameterNames []string
+	ProvidedParameterNames []string
+	MissingParameters      []string
+	UnknownParameters      []string
+}
+
+// Error returns a concise human-facing validation message.
+func (e *PlanningValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if len(e.MissingParameters) == 1 && len(e.UnknownParameters) == 0 {
+		return fmt.Sprintf("planning.parameters.%s is required", e.MissingParameters[0])
+	}
+	if len(e.UnknownParameters) == 1 && len(e.MissingParameters) == 0 {
+		return fmt.Sprintf("planning.parameters.%s is unknown", e.UnknownParameters[0])
+	}
+
+	parts := make([]string, 0, 2)
+	if len(e.MissingParameters) > 0 {
+		parts = append(parts, fmt.Sprintf("missing required planning parameters: %s", strings.Join(e.MissingParameters, ", ")))
+	}
+	if len(e.UnknownParameters) > 0 {
+		parts = append(parts, fmt.Sprintf("unknown planning parameters: %s", strings.Join(e.UnknownParameters, ", ")))
+	}
+	if len(parts) == 0 {
+		return "planning.parameters is invalid"
+	}
+	return "planning.parameters is invalid: " + strings.Join(parts, "; ")
+}
+
+func newPlanningValidationError(required, provided, missing, unknown []string) *PlanningValidationError {
+	return &PlanningValidationError{
+		RequiredParameterNames: cloneSortedStrings(required),
+		ProvidedParameterNames: cloneSortedStrings(provided),
+		MissingParameters:      cloneSortedStrings(missing),
+		UnknownParameters:      cloneSortedStrings(unknown),
+	}
+}
+
+func cloneSortedStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := append([]string(nil), values...)
+	sort.Strings(cloned)
+	return cloned
+}

--- a/internal/taskverification/runtime_test.go
+++ b/internal/taskverification/runtime_test.go
@@ -22,9 +22,7 @@ func TestStartAndCompleteStepHappyPath(t *testing.T) {
 		},
 		Workflow: &Workflow{
 			Onboarding: &LifecycleNodeSpec{},
-			Planning: &PlanningNodeSpec{
-				RequiredOutputs: []string{"testTarget"},
-			},
+			Planning:   &PlanningNodeSpec{},
 			Execution: []ExecutionNodeSpec{
 				{
 					ID: "step_one",
@@ -153,7 +151,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -186,7 +184,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   scaffolding:
     - id: "setup_test_file"
       checks:
@@ -231,7 +229,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -253,7 +251,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -275,7 +273,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -305,9 +303,7 @@ func TestCompleteStepFailsInvariantMismatch(t *testing.T) {
 		},
 		Workflow: &Workflow{
 			Onboarding: &LifecycleNodeSpec{},
-			Planning: &PlanningNodeSpec{
-				RequiredOutputs: []string{"testTarget"},
-			},
+			Planning:   &PlanningNodeSpec{},
 			Execution: []ExecutionNodeSpec{
 				{
 					ID: "step_one",
@@ -357,7 +353,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -393,7 +389,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -429,7 +425,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -460,7 +456,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -505,7 +501,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -539,7 +535,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       next: "waiting_for_approval.review"
@@ -580,13 +576,11 @@ func newRuntimeTestService(t *testing.T, content string) (*Service, *RunState) {
 	assert.NilError(t, err)
 
 	service := NewService(dir, dir)
-	run, err := service.RegisterTask("task", map[string]string{})
+	run, err := service.RegisterTask("task")
 	assert.NilError(t, err)
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
-	err = service.CompletePlanning(run, &PlanningArtifact{
-		TestTarget: "pytest -q",
-	})
+	err = service.CompletePlanning(run, &PlanningArtifact{})
 	assert.NilError(t, err)
 	return service, run
 }
@@ -599,7 +593,7 @@ func newRuntimeShellTestService(t *testing.T, content string) (*Service, *RunSta
 	assert.NilError(t, err)
 
 	service := NewService(dir, dir)
-	run, err := service.RegisterTask("task", map[string]string{})
+	run, err := service.RegisterTask("task")
 	assert.NilError(t, err)
 	return service, run
 }
@@ -623,9 +617,7 @@ func TestCommandTimeout(t *testing.T) {
 		},
 		Workflow: &Workflow{
 			Onboarding: &LifecycleNodeSpec{},
-			Planning: &PlanningNodeSpec{
-				RequiredOutputs: []string{"testTarget"},
-			},
+			Planning:   &PlanningNodeSpec{},
 			Execution: []ExecutionNodeSpec{
 				{
 					ID: "step_one",
@@ -660,7 +652,6 @@ func newWorkflowReadyRun(template *Template) *RunState {
 		RunID:            newTaskRunID(),
 		TemplateID:       template.Task.ID,
 		SelectedTemplate: *template,
-		DraftParameters:  map[string]string{},
 		Status:           TaskStatusActive,
 		Phase:            template.CompiledWorkflow.FirstExecutablePath,
 		WorkflowReady:    true,

--- a/internal/taskverification/templates.go
+++ b/internal/taskverification/templates.go
@@ -62,12 +62,9 @@ func (s *Service) ListTemplates() ([]TemplateSummary, error) {
 }
 
 // RegisterTask creates a shell task run from the selected template.
-func (s *Service) RegisterTask(templateID string, parameters map[string]string) (*RunState, error) {
+func (s *Service) RegisterTask(templateID string) (*RunState, error) {
 	template, err := s.loadTemplateByID(templateID)
 	if err != nil {
-		return nil, err
-	}
-	if err := validateDraftParameters(template, parameters); err != nil {
 		return nil, err
 	}
 
@@ -75,7 +72,6 @@ func (s *Service) RegisterTask(templateID string, parameters map[string]string) 
 		RunID:            newTaskRunID(),
 		TemplateID:       template.Task.ID,
 		SelectedTemplate: *template,
-		DraftParameters:  cloneParameters(parameters),
 		Status:           TaskStatusActive,
 		Phase:            template.CompiledWorkflow.OnboardingPath,
 		WorkflowReady:    false,
@@ -102,7 +98,8 @@ func (s *Service) CompletePlanning(run *RunState, artifact *PlanningArtifact) er
 	if err := validatePlanningArtifact(&run.SelectedTemplate, artifact); err != nil {
 		return err
 	}
-	resolved, stepStates, err := freezeRunnableContract(run)
+	artifactCopy := clonePlanningArtifact(artifact)
+	resolved, stepStates, err := freezeRunnableContract(run, &artifactCopy)
 	if err != nil {
 		return err
 	}
@@ -118,7 +115,6 @@ func (s *Service) CompletePlanning(run *RunState, artifact *PlanningArtifact) er
 		return err
 	}
 
-	artifactCopy := clonePlanningArtifact(artifact)
 	run.Planning = &artifactCopy
 	run.WorkflowReady = true
 	run.RunnableTemplate = &resolved
@@ -187,15 +183,18 @@ func (s *Service) ResumeTask(run *RunState) error {
 	return nil
 }
 
-func freezeRunnableContract(run *RunState) (Template, []StepState, error) {
+func freezeRunnableContract(run *RunState, planning *PlanningArtifact) (Template, []StepState, error) {
 	if run == nil {
 		return Template{}, nil, fmt.Errorf("task is not registered")
 	}
 	if run.Status != TaskStatusActive {
 		return Template{}, nil, fmt.Errorf("task is %s", run.Status)
 	}
+	if planning == nil {
+		return Template{}, nil, fmt.Errorf("planning artifact is required")
+	}
 
-	resolved, err := run.SelectedTemplate.Resolve(run.DraftParameters)
+	resolved, err := run.SelectedTemplate.Resolve(planning.Parameters)
 	if err != nil {
 		return Template{}, nil, err
 	}
@@ -332,6 +331,9 @@ func (t *Template) validateParameters(checkCoverage bool) error {
 		}
 		definedParams[parameter.Name] = struct{}{}
 	}
+	if err := t.validatePlaceholderUsage(); err != nil {
+		return err
+	}
 
 	if !checkCoverage {
 		return nil
@@ -350,6 +352,34 @@ func (t *Template) validateParameters(checkCoverage bool) error {
 	for _, name := range requiredParams {
 		if _, exists := definedParams[name]; len(t.Parameters) > 0 && !exists {
 			return fmt.Errorf("parameter %q is used by a placeholder but missing from parameters", name)
+		}
+	}
+	return nil
+}
+
+func (t *Template) validatePlaceholderUsage() error {
+	if t == nil || t.Workflow == nil {
+		return nil
+	}
+	checks := []struct {
+		location string
+		value    any
+	}{
+		{location: "task", value: t.Task},
+		{location: "parameters", value: t.Parameters},
+		{location: "workflow.onboarding", value: t.Workflow.Onboarding},
+		{location: "workflow.planning", value: t.Workflow.Planning},
+	}
+	for _, check := range checks {
+		if check.value == nil {
+			continue
+		}
+		generic, err := genericValue(check.value)
+		if err != nil {
+			return err
+		}
+		if unresolved := findUnresolvedPlaceholder(generic); unresolved != "" {
+			return fmt.Errorf("%s must not reference template parameter placeholder %q", check.location, unresolved)
 		}
 	}
 	return nil
@@ -437,17 +467,13 @@ func validateCondition(condition Condition) error {
 
 // RequiredParameterNames returns the placeholder names referenced by the template.
 func (t *Template) RequiredParameterNames() []string {
-	if t == nil {
-		return nil
-	}
-
-	generic, err := genericValue(t)
-	if err != nil {
+	if t == nil || t.Workflow == nil {
 		return nil
 	}
 
 	params := make(map[string]struct{})
-	collectPlaceholders(generic, params)
+	collectPlaceholdersFromValue(t.Workflow.Scaffolding, params)
+	collectPlaceholdersFromValue(t.Workflow.Execution, params)
 
 	result := make([]string, 0, len(params))
 	for name := range params {
@@ -455,6 +481,14 @@ func (t *Template) RequiredParameterNames() []string {
 	}
 	sort.Strings(result)
 	return result
+}
+
+func collectPlaceholdersFromValue(value any, params map[string]struct{}) {
+	generic, err := genericValue(value)
+	if err != nil {
+		return
+	}
+	collectPlaceholders(generic, params)
 }
 
 // ParameterDefinitions returns placeholder metadata in stable name order.
@@ -630,17 +664,6 @@ func findUnresolvedPlaceholder(value any) string {
 	return ""
 }
 
-func cloneParameters(parameters map[string]string) map[string]string {
-	if len(parameters) == 0 {
-		return map[string]string{}
-	}
-	cloned := make(map[string]string, len(parameters))
-	for key, value := range parameters {
-		cloned[key] = value
-	}
-	return cloned
-}
-
 func transitionTaskPhase(run *RunState, next TaskPhase, allowed ...TaskPhase) error {
 	if run == nil {
 		return fmt.Errorf("task is not registered")
@@ -664,20 +687,6 @@ func transitionTaskPhase(run *RunState, next TaskPhase, allowed ...TaskPhase) er
 		}
 	}
 	return fmt.Errorf("task is in %s phase; cannot transition to %s", run.Phase, next)
-}
-
-func validateDraftParameters(template *Template, parameters map[string]string) error {
-	if template == nil {
-		return fmt.Errorf("template is required")
-	}
-
-	defined := parameterNameSet(template)
-	for name := range parameters {
-		if _, exists := defined[name]; !exists {
-			return fmt.Errorf("unknown task parameter %q", name)
-		}
-	}
-	return nil
 }
 
 func validateOnboardingArtifact(artifact *OnboardingArtifact) error {
@@ -731,7 +740,7 @@ func validatePlanningArtifact(template *Template, artifact *PlanningArtifact) er
 	if artifact == nil {
 		return fmt.Errorf("planning artifact is required")
 	}
-	if err := validatePlanningOutputs(template, artifact); err != nil {
+	if err := validatePlanningParameters(template, artifact.Parameters); err != nil {
 		return err
 	}
 	if err := validateUniqueTrimmedStrings("planning.selectedFiles", artifact.SelectedFiles); err != nil {
@@ -743,97 +752,46 @@ func validatePlanningArtifact(template *Template, artifact *PlanningArtifact) er
 	return nil
 }
 
-func validatePlanningOutputs(template *Template, artifact *PlanningArtifact) error {
-	for _, output := range orderedPlanningOutputs(requiredPlanningOutputs(template)) {
-		if err := validatePlanningOutput(output, artifact); err != nil {
+func validatePlanningParameters(template *Template, parameters map[string]string) error {
+	if parameters == nil {
+		parameters = map[string]string{}
+	}
+	defined := parameterNameSet(template)
+	for name := range parameters {
+		if _, exists := defined[name]; !exists {
+			return fmt.Errorf("planning.parameters.%s is unknown", name)
+		}
+	}
+	for _, name := range orderedPlanningInputs(template) {
+		if err := validateNonEmptyPlanningField("parameters."+name, parameters[name]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func requiredPlanningOutputs(template *Template) []string {
-	if template == nil || template.CompiledWorkflow == nil {
+func orderedPlanningInputs(template *Template) []string {
+	if template == nil {
 		return nil
 	}
-	planningNode, exists := template.CompiledWorkflow.Nodes[template.CompiledWorkflow.PlanningPath]
-	if !exists {
-		return nil
-	}
-	return append([]string(nil), planningNode.RequiredPlanningOutputs...)
-}
-
-func orderedPlanningOutputs(outputs []string) []string {
-	if len(outputs) == 0 {
-		return nil
-	}
-
-	required := make(map[string]struct{}, len(outputs))
-	for _, output := range outputs {
-		trimmed := strings.TrimSpace(output)
-		if trimmed == "" {
+	names := make([]string, 0, len(template.Parameters))
+	seen := make(map[string]struct{}, len(template.Parameters))
+	for _, parameter := range template.Parameters {
+		name := strings.TrimSpace(parameter.Name)
+		if name == "" {
 			continue
 		}
-		required[trimmed] = struct{}{}
-	}
-
-	ordered := make([]string, 0, len(required))
-	for _, output := range []string{
-		"testTarget",
-		"selectedFiles",
-		"lintCommand",
-		"expectedFailure",
-		"implementationTarget",
-		"invariants",
-	} {
-		if _, exists := required[output]; !exists {
+		if _, exists := seen[name]; exists {
 			continue
 		}
-		delete(required, output)
-		ordered = append(ordered, output)
+		seen[name] = struct{}{}
+		names = append(names, name)
 	}
-	for _, output := range outputs {
-		trimmed := strings.TrimSpace(output)
-		if _, exists := required[trimmed]; !exists {
-			continue
-		}
-		delete(required, trimmed)
-		ordered = append(ordered, trimmed)
+	if len(names) == 0 {
+		return append([]string(nil), template.RequiredParameterNames()...)
 	}
-	return ordered
-}
-
-func validatePlanningOutput(output string, artifact *PlanningArtifact) error {
-	switch output {
-	case "selectedFiles":
-		if len(artifact.SelectedFiles) == 0 {
-			return fmt.Errorf("planning.selectedFiles is required")
-		}
-		return nil
-	case "invariants":
-		if len(artifact.Invariants) == 0 {
-			return fmt.Errorf("planning.invariants is required")
-		}
-		return nil
-	case "testTarget", "lintCommand", "expectedFailure", "implementationTarget":
-		return validateNonEmptyPlanningField(output, planningFieldValue(output, artifact))
-	}
-	return nil
-}
-
-func planningFieldValue(output string, artifact *PlanningArtifact) string {
-	switch output {
-	case "testTarget":
-		return artifact.TestTarget
-	case "lintCommand":
-		return artifact.LintCommand
-	case "expectedFailure":
-		return artifact.ExpectedFailure
-	case "implementationTarget":
-		return artifact.ImplementationTarget
-	default:
-		return ""
-	}
+	sort.Strings(names)
+	return names
 }
 
 func validateNonEmptyPlanningField(output, value string) error {
@@ -852,13 +810,21 @@ func clonePlanningArtifact(artifact *PlanningArtifact) PlanningArtifact {
 		return PlanningArtifact{}
 	}
 	return PlanningArtifact{
-		SelectedFiles:        append([]string(nil), artifact.SelectedFiles...),
-		TestTarget:           artifact.TestTarget,
-		LintCommand:          artifact.LintCommand,
-		ExpectedFailure:      artifact.ExpectedFailure,
-		ImplementationTarget: artifact.ImplementationTarget,
-		Invariants:           append([]string(nil), artifact.Invariants...),
+		SelectedFiles: append([]string(nil), artifact.SelectedFiles...),
+		Parameters:    cloneParameterMap(artifact.Parameters),
+		Invariants:    append([]string(nil), artifact.Invariants...),
 	}
+}
+
+func cloneParameterMap(parameters map[string]string) map[string]string {
+	if len(parameters) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(parameters))
+	for key, value := range parameters {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func validateUniqueTrimmedStrings(field string, values []string) error {

--- a/internal/taskverification/templates.go
+++ b/internal/taskverification/templates.go
@@ -422,6 +422,9 @@ func validateCheck(stepID string, checkIndex int, check *Check, checkIDs map[str
 	if strings.TrimSpace(check.Command) == "" {
 		return fmt.Errorf("step %q check %q command is required", stepID, check.ID)
 	}
+	if check.Description != "" && strings.TrimSpace(check.Description) == "" {
+		return fmt.Errorf("step %q check %q description must not be blank", stepID, check.ID)
+	}
 	if err := validateConditions(stepID, check.ID, "pre_conditions", check.PreConditions); err != nil {
 		return err
 	}
@@ -440,6 +443,9 @@ func validateInvariants(step *Step) error {
 		invariantIDs[invariant.ID] = struct{}{}
 		if strings.TrimSpace(invariant.Command) == "" {
 			return fmt.Errorf("step %q invariant %q command is required", step.ID, invariant.ID)
+		}
+		if invariant.Description != "" && strings.TrimSpace(invariant.Description) == "" {
+			return fmt.Errorf("step %q invariant %q description must not be blank", step.ID, invariant.ID)
 		}
 	}
 	return nil
@@ -757,15 +763,22 @@ func validatePlanningParameters(template *Template, parameters map[string]string
 		parameters = map[string]string{}
 	}
 	defined := parameterNameSet(template)
+	provided := make([]string, 0, len(parameters))
+	unknown := make([]string, 0)
 	for name := range parameters {
+		provided = append(provided, name)
 		if _, exists := defined[name]; !exists {
-			return fmt.Errorf("planning.parameters.%s is unknown", name)
+			unknown = append(unknown, name)
 		}
 	}
+	missing := make([]string, 0)
 	for _, name := range orderedPlanningInputs(template) {
-		if err := validateNonEmptyPlanningField("parameters."+name, parameters[name]); err != nil {
-			return err
+		if strings.TrimSpace(parameters[name]) == "" {
+			missing = append(missing, name)
 		}
+	}
+	if len(missing) > 0 || len(unknown) > 0 {
+		return newPlanningValidationError(orderedPlanningInputs(template), provided, missing, unknown)
 	}
 	return nil
 }
@@ -792,17 +805,6 @@ func orderedPlanningInputs(template *Template) []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-func validateNonEmptyPlanningField(output, value string) error {
-	fieldName := "planning." + output
-	if value == "" {
-		return fmt.Errorf("%s is required", fieldName)
-	}
-	if strings.TrimSpace(value) == "" {
-		return fmt.Errorf("%s is required", fieldName)
-	}
-	return nil
 }
 
 func clonePlanningArtifact(artifact *PlanningArtifact) PlanningArtifact {

--- a/internal/taskverification/templates_test.go
+++ b/internal/taskverification/templates_test.go
@@ -1,6 +1,7 @@
 package taskverification
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -520,7 +521,79 @@ func TestValidatePlanningParametersRequiresDeclaredInputs(t *testing.T) {
 		},
 	}
 	err := validatePlanningParameters(template, map[string]string{})
-	assert.ErrorContains(t, err, "planning.parameters.expectedError is required")
+	var validationErr *PlanningValidationError
+	assert.Assert(t, errors.As(err, &validationErr))
+	assert.DeepEqual(t, validationErr.MissingParameters, []string{"expectedError", "testTarget"})
+	assert.DeepEqual(t, validationErr.RequiredParameterNames, []string{"expectedError", "testTarget"})
+	assert.ErrorContains(t, err, "planning.parameters is invalid")
+}
+
+func TestValidatePlanningParametersReturnsUnknownAndMissingDetails(t *testing.T) {
+	template := &Template{
+		Parameters: []TemplateParameter{
+			{Name: "expectedError"},
+			{Name: "testTarget"},
+		},
+		Workflow: &Workflow{
+			Execution: []ExecutionNodeSpec{{
+				ID: "step_one",
+				Checks: []Check{{
+					ID:      "check_one",
+					Command: "printf '%s' '${testTarget}:${expectedError}'",
+				}},
+			}},
+		},
+	}
+
+	err := validatePlanningParameters(template, map[string]string{
+		"expectedError": "boom",
+		"unknown":       "value",
+	})
+	var validationErr *PlanningValidationError
+	assert.Assert(t, errors.As(err, &validationErr))
+	assert.DeepEqual(t, validationErr.MissingParameters, []string{"testTarget"})
+	assert.DeepEqual(t, validationErr.UnknownParameters, []string{"unknown"})
+	assert.DeepEqual(t, validationErr.ProvidedParameterNames, []string{"expectedError", "unknown"})
+	assert.ErrorContains(t, err, "planning.parameters is invalid")
+}
+
+func TestResolvePreservesCheckAndInvariantDescriptions(t *testing.T) {
+	template := mustCompileTemplate(t, &Template{
+		Version: "0.1",
+		Task: Task{
+			ID:          "task",
+			Name:        "Task",
+			Description: "desc",
+		},
+		Parameters: []TemplateParameter{
+			{Name: "testFile"},
+		},
+		Workflow: &Workflow{
+			Onboarding: &LifecycleNodeSpec{},
+			Planning:   &PlanningNodeSpec{},
+			Execution: []ExecutionNodeSpec{{
+				ID: "step_one",
+				Checks: []Check{{
+					ID:          "check_one",
+					Description: "Explains the check",
+					Command:     "printf ok",
+					PostConditions: []Condition{
+						{Type: "file_exists", Path: "${testFile}"},
+					},
+				}},
+				Invariants: []Invariant{{
+					ID:          "stable_test_file",
+					Description: "Keeps the selected test file stable",
+					Command:     "cat ${testFile}",
+				}},
+			}},
+		},
+	})
+
+	resolved, err := template.Resolve(map[string]string{"testFile": "test_score_parentheses.py"})
+	assert.NilError(t, err)
+	assert.Equal(t, resolved.CompiledWorkflow.WorkflowSteps[0].Checks[0].Description, "Explains the check")
+	assert.Equal(t, resolved.CompiledWorkflow.WorkflowSteps[0].Invariants[0].Description, "Keeps the selected test file stable")
 }
 
 func TestPlanningCanAdvanceToConfiguredWaitingNode(t *testing.T) {
@@ -719,4 +792,11 @@ func newTemplateTestService(t *testing.T, content, fileName string) *Service {
 	err := os.WriteFile(filepath.Join(dir, fileName), []byte(content), 0o644)
 	assert.NilError(t, err)
 	return NewService(dir, dir)
+}
+
+func mustCompileTemplate(t *testing.T, template *Template) *Template {
+	t.Helper()
+	err := template.Validate()
+	assert.NilError(t, err)
+	return template
 }

--- a/internal/taskverification/templates_test.go
+++ b/internal/taskverification/templates_test.go
@@ -3,7 +3,6 @@ package taskverification
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/T4cceptor/centian/internal/identifiers"
@@ -24,7 +23,7 @@ parameters:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: ["testName"]
   execution:
     - id: "failing_test"
       instructions: "Start the step before changing anything."
@@ -50,7 +49,7 @@ workflow:
 	assert.Equal(t, summaries[0].Steps[0].Path, TaskPhase("execution.failing_test"))
 }
 
-func TestRegisterTaskAllowsMissingParametersButRejectsUnknownOnShellRegistration(t *testing.T) {
+func TestRegisterTaskCreatesShellWithoutPlanningParameters(t *testing.T) {
 	service := newTemplateTestService(t, `
 version: "0.1"
 task:
@@ -62,8 +61,7 @@ parameters:
     description: "The test case to target."
 workflow:
   onboarding: {}
-  planning:
-    required_outputs: ["testTarget"]
+  planning: {}
   execution:
     - id: "failing_test"
       checks:
@@ -71,19 +69,13 @@ workflow:
           command: "printf '%s' '${testName}'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 	assert.Equal(t, run.Status, TaskStatusActive)
 	assert.Equal(t, run.Phase, TaskPhaseOnboarding)
 	assert.Assert(t, !run.WorkflowReady)
 	assert.Assert(t, run.RunnableTemplate == nil)
 	assert.Equal(t, len(run.Steps), 0)
-
-	_, err = service.RegisterTask("simple_tdd", map[string]string{
-		"testName": "MyTest",
-		"unknown":  "value",
-	})
-	assert.ErrorContains(t, err, `unknown task parameter "unknown"`)
 }
 
 func TestTimeoutAndResumeTaskPreserveWorkflowState(t *testing.T) {
@@ -100,7 +92,7 @@ workflow:
     - id: "step_one"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 	run.Phase = TaskPhase("execution.step_one")
 	run.WorkflowReady = true
@@ -174,7 +166,7 @@ workflow:
 	assert.Equal(t, summaries[0].Steps[0].ID, "step_one")
 }
 
-func TestCompletePlanningResolvesDraftParametersAndEntersConfiguredExecutionNode(t *testing.T) {
+func TestCompletePlanningResolvesPlanningParametersAndEntersConfiguredExecutionNode(t *testing.T) {
 	service := newTemplateTestService(t, `
 version: "0.1"
 task:
@@ -189,7 +181,7 @@ parameters:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: ["expectedError", "testName"]
     next: "execution.failing_test"
   execution:
     - id: "failing_test"
@@ -198,17 +190,17 @@ workflow:
           command: "printf '%s' '${testName}:${expectedError}'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{
-		"testName":      "TestThing",
-		"expectedError": "boom",
-	})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
 	err = service.CompletePlanning(run, &PlanningArtifact{
-		TestTarget: "pytest tests/test_thing.py -q",
+		Parameters: map[string]string{
+			"testName":      "TestThing",
+			"expectedError": "boom",
+		},
 	})
 	assert.NilError(t, err)
 
@@ -236,15 +228,15 @@ workflow:
     - id: "Task ${taskName}"
 `, "free_form.yaml")
 
-	run, err := service.RegisterTask("free_form", map[string]string{
-		"taskName": "Investigate issue",
-	})
+	run, err := service.RegisterTask("free_form")
 	assert.NilError(t, err)
 
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
-	err = service.CompletePlanning(run, &PlanningArtifact{})
+	err = service.CompletePlanning(run, &PlanningArtifact{
+		Parameters: map[string]string{"taskName": "Investigate issue"},
+	})
 	assert.NilError(t, err)
 	assert.Equal(t, run.Phase, TaskPhase("execution.Task Investigate issue"))
 }
@@ -265,7 +257,7 @@ workflow:
   onboarding: {}
   planning:
     editable_fields: ["parameters.testCommand", "parameters.expectedError"]
-    required_outputs: ["testTarget"]
+    required_inputs: ["expectedError", "testCommand"]
   execution:
     - id: "failing_test"
       checks:
@@ -279,16 +271,18 @@ workflow:
               value: "pytest:boom"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{
-		"testCommand":   "pytest",
-		"expectedError": "boom",
-	})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
-	err = service.CompletePlanning(run, &PlanningArtifact{TestTarget: "tests/test_thing.py"})
+	err = service.CompletePlanning(run, &PlanningArtifact{
+		Parameters: map[string]string{
+			"testCommand":   "pytest",
+			"expectedError": "boom",
+		},
+	})
 	assert.NilError(t, err)
 	assert.Equal(t, run.Phase, TaskPhase("execution.failing_test"))
 	assert.Assert(t, run.WorkflowReady)
@@ -303,8 +297,7 @@ task:
   description: "Test driven task"
 workflow:
   onboarding: {}
-  planning:
-    required_outputs: ["testTarget"]
+  planning: {}
   execution:
     - id: "failing_test"
       checks:
@@ -312,7 +305,7 @@ workflow:
           command: "printf 'ok'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 	assert.Assert(t, run.Onboarding == nil)
 
@@ -345,8 +338,7 @@ task:
   description: "Test driven task"
 workflow:
   onboarding: {}
-  planning:
-    required_outputs: ["testTarget"]
+  planning: {}
   execution:
     - id: "failing_test"
       checks:
@@ -354,7 +346,7 @@ workflow:
           command: "printf 'ok'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 	assert.Assert(t, identifiers.IsKind(run.RunID, identifiers.KindTaskRun))
 	assert.Equal(t, run.Phase, TaskPhaseOnboarding)
@@ -373,7 +365,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "failing_test"
       checks:
@@ -381,7 +373,7 @@ workflow:
           command: "printf 'ok'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
@@ -401,7 +393,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "failing_test"
       checks:
@@ -409,7 +401,7 @@ workflow:
           command: "printf 'ok'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{})
@@ -428,7 +420,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "failing_test"
       checks:
@@ -436,7 +428,7 @@ workflow:
           command: "printf 'ok'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "stored summary"})
 	assert.NilError(t, err)
@@ -459,7 +451,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "failing_test"
       checks:
@@ -467,10 +459,10 @@ workflow:
           command: "printf 'ok'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 
-	err = service.CompletePlanning(run, &PlanningArtifact{TestTarget: "pytest -q"})
+	err = service.CompletePlanning(run, &PlanningArtifact{})
 	assert.ErrorContains(t, err, "cannot transition to")
 }
 
@@ -481,42 +473,54 @@ task:
   id: "simple_tdd"
   name: "Simple TDD"
   description: "Test driven task"
+parameters:
+  - name: "testTarget"
+    description: "Targeted test command."
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget", "selectedFiles"]
+    required_inputs: ["testTarget"]
   execution:
     - id: "failing_test"
       checks:
         - id: "selected_test_fails"
-          command: "printf 'ok'"
+          command: "printf '%s' '${testTarget}'"
 `, "simple_tdd.yaml")
 
-	run, err := service.RegisterTask("simple_tdd", map[string]string{})
+	run, err := service.RegisterTask("simple_tdd")
 	assert.NilError(t, err)
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
 
 	err = service.CompletePlanning(run, &PlanningArtifact{})
 	assert.Assert(t, err != nil)
-	assert.Assert(
-		t,
-		strings.Contains(err.Error(), "planning.testTarget is required") ||
-			strings.Contains(err.Error(), "planning.selectedFiles is required"),
-	)
+	assert.ErrorContains(t, err, "planning.parameters.testTarget is required")
 
 	err = service.CompletePlanning(run, &PlanningArtifact{
-		TestTarget:    "pytest -q",
+		Parameters:    map[string]string{"testTarget": "pytest -q"},
 		SelectedFiles: []string{"a.go", "a.go"},
 	})
 	assert.ErrorContains(t, err, `planning.selectedFiles contains duplicate value "a.go"`)
 }
 
-func TestValidatePlanningOutput_RequiresScalarFields(t *testing.T) {
-	for _, output := range []string{"testTarget", "lintCommand", "expectedFailure", "implementationTarget"} {
-		err := validatePlanningOutput(output, &PlanningArtifact{})
-		assert.ErrorContains(t, err, "planning."+output+" is required")
+func TestValidatePlanningParametersRequiresDeclaredInputs(t *testing.T) {
+	template := &Template{
+		Parameters: []TemplateParameter{
+			{Name: "testTarget"},
+			{Name: "expectedError"},
+		},
+		Workflow: &Workflow{
+			Scaffolding: []ExecutionNodeSpec{{
+				ID: "setup",
+				Checks: []Check{{
+					ID:      "check",
+					Command: "printf '%s' '${testTarget}:${expectedError}'",
+				}},
+			}},
+		},
 	}
+	err := validatePlanningParameters(template, map[string]string{})
+	assert.ErrorContains(t, err, "planning.parameters.expectedError is required")
 }
 
 func TestPlanningCanAdvanceToConfiguredWaitingNode(t *testing.T) {
@@ -529,7 +533,6 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
     next: "waiting_for_approval.review_plan"
   execution:
     - id: "review_plan"
@@ -541,11 +544,11 @@ workflow:
           command: "printf 'ok'"
 `, "approval_flow.yaml")
 
-	run, err := service.RegisterTask("approval_flow", map[string]string{})
+	run, err := service.RegisterTask("approval_flow")
 	assert.NilError(t, err)
 	err = service.CompleteOnboarding(run, &OnboardingArtifact{TaskSummary: "ready"})
 	assert.NilError(t, err)
-	err = service.CompletePlanning(run, &PlanningArtifact{TestTarget: "pytest -q"})
+	err = service.CompletePlanning(run, &PlanningArtifact{})
 	assert.NilError(t, err)
 	assert.Equal(t, run.Phase, TaskPhase("waiting_for_approval.review_plan"))
 	node, exists := run.CurrentNode()
@@ -565,7 +568,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -593,7 +596,7 @@ parameters:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "failing_test"
       checks:
@@ -634,7 +637,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "step_one"
       checks:
@@ -665,7 +668,7 @@ workflow:
   onboarding: {}
   planning:
     editable_fields: ["parameters.unknown"]
-    required_outputs: ["testTarget"]
+    required_inputs: []
   execution:
     - id: "failing_test"
       checks:
@@ -690,7 +693,7 @@ task:
 workflow:
   onboarding: {}
   planning:
-    required_outputs: ["testTarget"]
+    required_inputs: []
     next: "execution.second"
   execution:
     - id: "first"

--- a/internal/taskverification/types.go
+++ b/internal/taskverification/types.go
@@ -128,6 +128,8 @@ type Step struct {
 type Check struct {
 	// ID is the author-defined identifier for this check.
 	ID string `yaml:"id" json:"id"`
+	// Description is the optional human-facing explanation of what this check enforces.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	// Command is the shell command Centian executes when evaluating the check.
 	Command string `yaml:"command" json:"command"`
 	// PreConditions are assertions that must pass before the step action is accepted.
@@ -140,6 +142,8 @@ type Check struct {
 type Invariant struct {
 	// ID is the author-defined identifier for this invariant.
 	ID string `yaml:"id" json:"id"`
+	// Description is the optional human-facing explanation of what this invariant protects.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	// Command is the shell command whose output Centian snapshots and compares for drift.
 	Command string `yaml:"command" json:"command"`
 }

--- a/internal/taskverification/types.go
+++ b/internal/taskverification/types.go
@@ -4,139 +4,212 @@ import "encoding/json"
 
 // Template defines one task verification template loaded from YAML.
 type Template struct {
-	Version          string              `yaml:"version" json:"version"`
-	Task             Task                `yaml:"task" json:"task"`
-	Parameters       []TemplateParameter `yaml:"parameters,omitempty" json:"parameters,omitempty"`
-	Workflow         *Workflow           `yaml:"workflow" json:"workflow"`
-	CompiledWorkflow *CompiledWorkflow   `yaml:"-" json:"-"`
+	// Version is the template schema version declared in the YAML document.
+	Version string `yaml:"version" json:"version"`
+	// Task is the human-facing identity and description block for the template.
+	Task Task `yaml:"task" json:"task"`
+	// Parameters lists the agent-supplied placeholder values the template expects at registration time.
+	Parameters []TemplateParameter `yaml:"parameters,omitempty" json:"parameters,omitempty"`
+	// Workflow is the declarative lifecycle definition authored in the template YAML.
+	Workflow *Workflow `yaml:"workflow" json:"workflow"`
+	// CompiledWorkflow is the normalized internal workflow graph derived from the authored template and is not serialized.
+	CompiledWorkflow *CompiledWorkflow `yaml:"-" json:"-"`
 }
 
 // Task describes the human-facing identity of a template.
 type Task struct {
-	ID           string `yaml:"id" json:"id"`
-	Name         string `yaml:"name" json:"name"`
-	Description  string `yaml:"description" json:"description"`
+	// ID is the stable template identifier used when registering a task.
+	ID string `yaml:"id" json:"id"`
+	// Name is the display name shown to agents and UIs.
+	Name string `yaml:"name" json:"name"`
+	// Description is the short summary of what the template is meant to accomplish.
+	Description string `yaml:"description" json:"description"`
+	// Instructions provides template-level guidance that agents should treat as the workflow source of truth.
 	Instructions string `yaml:"instructions,omitempty" json:"instructions,omitempty"`
 }
 
 // Workflow describes the declarative task lifecycle.
 type Workflow struct {
-	Onboarding  *LifecycleNodeSpec  `yaml:"onboarding" json:"onboarding"`
-	Planning    *PlanningNodeSpec   `yaml:"planning" json:"planning"`
+	// Onboarding configures the discovery phase that runs before planning.
+	Onboarding *LifecycleNodeSpec `yaml:"onboarding" json:"onboarding"`
+	// Planning configures the phase that freezes execution inputs before steps begin.
+	Planning *PlanningNodeSpec `yaml:"planning" json:"planning"`
+	// Scaffolding defines additive setup nodes that run before the main execution steps.
 	Scaffolding []ExecutionNodeSpec `yaml:"scaffolding,omitempty" json:"scaffolding,omitempty"`
-	Execution   []ExecutionNodeSpec `yaml:"execution" json:"execution"`
+	// Execution defines the main executable workflow nodes that drive task completion.
+	Execution []ExecutionNodeSpec `yaml:"execution" json:"execution"`
 }
 
 // LifecycleNodeSpec describes a non-execution workflow node.
 type LifecycleNodeSpec struct {
-	Instructions string          `yaml:"instructions,omitempty" json:"instructions,omitempty"`
-	AllowedTools []string        `yaml:"tools_allowed,omitempty" json:"toolsAllowed,omitempty"`
-	Checkpoint   *CheckpointHint `yaml:"checkpoint,omitempty" json:"checkpoint,omitempty"`
+	// Instructions tells the agent what to accomplish during this lifecycle phase.
+	Instructions string `yaml:"instructions,omitempty" json:"instructions,omitempty"`
+	// AllowedTools is the tool allowlist pattern set active while this node is current.
+	AllowedTools []string `yaml:"tools_allowed,omitempty" json:"toolsAllowed,omitempty"`
+	// Checkpoint holds optional metadata about whether this node should be checkpointed later.
+	Checkpoint *CheckpointHint `yaml:"checkpoint,omitempty" json:"checkpoint,omitempty"`
 }
 
 // PlanningNodeSpec describes the planning workflow node.
 type PlanningNodeSpec struct {
-	Instructions    string          `yaml:"instructions,omitempty" json:"instructions,omitempty"`
-	AllowedTools    []string        `yaml:"tools_allowed,omitempty" json:"toolsAllowed,omitempty"`
-	Checkpoint      *CheckpointHint `yaml:"checkpoint,omitempty" json:"checkpoint,omitempty"`
-	EditableFields  []string        `yaml:"editable_fields,omitempty" json:"editableFields,omitempty"`
-	RequiredOutputs []string        `yaml:"required_outputs,omitempty" json:"requiredOutputs,omitempty"`
-	Next            string          `yaml:"next,omitempty" json:"next,omitempty"`
+	// Instructions tells the agent what planning contract it must produce before execution begins.
+	Instructions string `yaml:"instructions,omitempty" json:"instructions,omitempty"`
+	// AllowedTools is the tool allowlist pattern set active during planning.
+	AllowedTools []string `yaml:"tools_allowed,omitempty" json:"toolsAllowed,omitempty"`
+	// Checkpoint holds optional metadata about whether planning should emit a checkpoint hint.
+	Checkpoint *CheckpointHint `yaml:"checkpoint,omitempty" json:"checkpoint,omitempty"`
+	// EditableFields lists which registered draft parameters the planning step may revise.
+	EditableFields []string `yaml:"editable_fields,omitempty" json:"editableFields,omitempty"`
+	// RequiredOutputs lists the planning artifact fields that must be present before execution can start.
+	RequiredOutputs []string `yaml:"required_outputs,omitempty" json:"requiredOutputs,omitempty"`
+	// Next optionally overrides the default next workflow path after planning completes.
+	Next string `yaml:"next,omitempty" json:"next,omitempty"`
 }
 
 // ExecutionNodeSpec describes one author-facing execution or approval node.
 type ExecutionNodeSpec struct {
-	ID           string              `yaml:"id" json:"id"`
-	Kind         WorkflowNodeKind    `yaml:"kind,omitempty" json:"kind,omitempty"`
-	Name         string              `yaml:"name,omitempty" json:"name,omitempty"`
-	Description  string              `yaml:"description,omitempty" json:"description,omitempty"`
-	Instructions string              `yaml:"instructions,omitempty" json:"instructions,omitempty"`
-	AllowedTools []string            `yaml:"tools_allowed,omitempty" json:"toolsAllowed,omitempty"`
-	Checkpoint   *CheckpointHint     `yaml:"checkpoint,omitempty" json:"checkpoint,omitempty"`
-	Checks       []Check             `yaml:"checks,omitempty" json:"checks,omitempty"`
-	Invariants   []Invariant         `yaml:"invariants,omitempty" json:"invariants,omitempty"`
-	Next         string              `yaml:"next,omitempty" json:"next,omitempty"`
-	SubSteps     []ExecutionNodeSpec `yaml:"sub_steps,omitempty" json:"subSteps,omitempty"`
+	// ID is the template-authored node identifier used to build the workflow path.
+	ID string `yaml:"id" json:"id"`
+	// Kind optionally overrides whether this node is executable or a waiting-for-approval node.
+	Kind WorkflowNodeKind `yaml:"kind,omitempty" json:"kind,omitempty"`
+	// Name is the display label shown for this node in task summaries and UIs.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+	// Description is a short human-facing summary of the node's purpose.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	// Instructions tells the agent what this node expects before it can be completed.
+	Instructions string `yaml:"instructions,omitempty" json:"instructions,omitempty"`
+	// AllowedTools is the tool allowlist pattern set active while this node is current.
+	AllowedTools []string `yaml:"tools_allowed,omitempty" json:"toolsAllowed,omitempty"`
+	// Checkpoint holds optional metadata about whether this node should surface a checkpoint hint.
+	Checkpoint *CheckpointHint `yaml:"checkpoint,omitempty" json:"checkpoint,omitempty"`
+	// Checks defines the command-driven assertions Centian will evaluate for this node.
+	Checks []Check `yaml:"checks,omitempty" json:"checks,omitempty"`
+	// Invariants defines command outputs that must remain stable across the node's lifetime.
+	Invariants []Invariant `yaml:"invariants,omitempty" json:"invariants,omitempty"`
+	// Next optionally overrides the default next workflow path after this node passes.
+	Next string `yaml:"next,omitempty" json:"next,omitempty"`
+	// SubSteps nests additional execution nodes beneath this logical node in author-facing YAML.
+	SubSteps []ExecutionNodeSpec `yaml:"sub_steps,omitempty" json:"subSteps,omitempty"`
 }
 
 // CheckpointHint stores declarative checkpoint metadata for later runtime use.
 type CheckpointHint struct {
+	// Enabled indicates whether this node should advertise checkpoint capability to clients.
 	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 }
 
 // Step defines one compiled executable workflow node.
 type Step struct {
-	ID           string          `json:"id"`
-	Path         TaskPhase       `json:"path"`
-	ParentPath   TaskPhase       `json:"parentPath,omitempty"`
-	NextPath     TaskPhase       `json:"nextPath,omitempty"`
-	Name         string          `json:"name,omitempty"`
-	Description  string          `json:"description,omitempty"`
-	Instructions string          `json:"instructions,omitempty"`
-	AllowedTools []string        `json:"allowedTools,omitempty"`
-	Checkpoint   *CheckpointHint `json:"checkpoint,omitempty"`
-	Checks       []Check         `json:"checks"`
-	Invariants   []Invariant     `json:"invariants,omitempty"`
+	// ID is the author-defined identifier for this compiled executable node.
+	ID string `json:"id"`
+	// Path is the fully qualified workflow path for this step.
+	Path TaskPhase `json:"path"`
+	// ParentPath is the logical parent workflow path that contains this step.
+	ParentPath TaskPhase `json:"parentPath,omitempty"`
+	// NextPath is the workflow path Centian should enter after this step passes.
+	NextPath TaskPhase `json:"nextPath,omitempty"`
+	// Name is the display label exposed to agents and UIs for this step.
+	Name string `json:"name,omitempty"`
+	// Description is the short human-facing summary of this step.
+	Description string `json:"description,omitempty"`
+	// Instructions tells the agent what this step expects before completion.
+	Instructions string `json:"instructions,omitempty"`
+	// AllowedTools is the tool allowlist pattern set active while this step is current.
+	AllowedTools []string `json:"allowedTools,omitempty"`
+	// Checkpoint holds optional metadata about whether this step should surface a checkpoint hint.
+	Checkpoint *CheckpointHint `json:"checkpoint,omitempty"`
+	// Checks contains the command-driven assertions Centian evaluates for the step.
+	Checks []Check `json:"checks"`
+	// Invariants contains the command outputs that must remain stable while the step is active.
+	Invariants []Invariant `json:"invariants,omitempty"`
 }
 
 // Check defines one command plus its pre/post conditions.
 type Check struct {
-	ID             string      `yaml:"id" json:"id"`
-	Command        string      `yaml:"command" json:"command"`
-	PreConditions  []Condition `yaml:"pre_conditions,omitempty" json:"pre_conditions,omitempty"`
+	// ID is the author-defined identifier for this check.
+	ID string `yaml:"id" json:"id"`
+	// Command is the shell command Centian executes when evaluating the check.
+	Command string `yaml:"command" json:"command"`
+	// PreConditions are assertions that must pass before the step action is accepted.
+	PreConditions []Condition `yaml:"pre_conditions,omitempty" json:"pre_conditions,omitempty"`
+	// PostConditions are assertions that must pass after the step action completes.
 	PostConditions []Condition `yaml:"post_conditions,omitempty" json:"post_conditions,omitempty"`
 }
 
 // Invariant defines one command whose stdout must remain stable across a step.
 type Invariant struct {
-	ID      string `yaml:"id" json:"id"`
+	// ID is the author-defined identifier for this invariant.
+	ID string `yaml:"id" json:"id"`
+	// Command is the shell command whose output Centian snapshots and compares for drift.
 	Command string `yaml:"command" json:"command"`
 }
 
 // Condition defines one assertion evaluated against a command result or file.
 type Condition struct {
-	Type   string `yaml:"type" json:"type"`
-	Value  any    `yaml:"value,omitempty" json:"value,omitempty"`
-	Values []any  `yaml:"values,omitempty" json:"values,omitempty"`
-	Path   string `yaml:"path,omitempty" json:"path,omitempty"`
+	// Type selects the concrete condition evaluator such as exit code, file existence, or substring matching.
+	Type string `yaml:"type" json:"type"`
+	// Value is the primary operand for single-value conditions such as exit_code or file_contains.
+	Value any `yaml:"value,omitempty" json:"value,omitempty"`
+	// Values stores multi-value operands for condition types that compare against several values.
+	Values []any `yaml:"values,omitempty" json:"values,omitempty"`
+	// Path is the project-relative file path targeted by file-based conditions.
+	Path string `yaml:"path,omitempty" json:"path,omitempty"`
 }
 
 // TemplateParameter describes one agent-provided parameter expected by a template.
 type TemplateParameter struct {
-	Name        string `yaml:"name" json:"name"`
+	// Name is the placeholder identifier agents must fill when registering the template.
+	Name string `yaml:"name" json:"name"`
+	// Description explains what value the agent should provide for this parameter.
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 }
 
 // OnboardingArtifact stores reusable task/environment discovery context.
 type OnboardingArtifact struct {
-	TaskSummary    string                  `json:"taskSummary"`
-	ArtifactMap    []OnboardingArtifactRef `json:"artifactMap,omitempty"`
-	CommonCommands []OnboardingCommand     `json:"commonCommands,omitempty"`
-	Constraints    []string                `json:"constraints,omitempty"`
-	OpenQuestions  []string                `json:"openQuestions,omitempty"`
+	// TaskSummary is the agent's concise description of the project and task context discovered during onboarding.
+	TaskSummary string `json:"taskSummary"`
+	// ArtifactMap records important project artifacts the agent identified during onboarding.
+	ArtifactMap []OnboardingArtifactRef `json:"artifactMap,omitempty"`
+	// CommonCommands records useful project commands the agent discovered during onboarding.
+	CommonCommands []OnboardingCommand `json:"commonCommands,omitempty"`
+	// Constraints captures project or workflow constraints the agent believes it must respect.
+	Constraints []string `json:"constraints,omitempty"`
+	// OpenQuestions captures unresolved uncertainties the agent wants to preserve before planning.
+	OpenQuestions []string `json:"openQuestions,omitempty"`
 }
 
 // OnboardingArtifactRef describes a project artifact discovered during onboarding.
 type OnboardingArtifactRef struct {
-	Path  string `json:"path"`
-	Kind  string `json:"kind"`
+	// Path is the project-relative path to the discovered artifact.
+	Path string `json:"path"`
+	// Kind classifies the artifact, for example source, test, config, or docs.
+	Kind string `json:"kind"`
+	// Notes stores optional agent commentary about why the artifact matters.
 	Notes string `json:"notes,omitempty"`
 }
 
 // OnboardingCommand describes a useful project command discovered during onboarding.
 type OnboardingCommand struct {
+	// Command is the concrete shell command the agent discovered.
 	Command string `json:"command"`
+	// Purpose explains why the command is useful in this project context.
 	Purpose string `json:"purpose"`
 }
 
 // PlanningArtifact stores the frozen execution inputs produced during planning.
 type PlanningArtifact struct {
-	SelectedFiles        []string `json:"selectedFiles,omitempty"`
-	TestTarget           string   `json:"testTarget,omitempty"`
-	LintCommand          string   `json:"lintCommand,omitempty"`
-	ExpectedFailure      string   `json:"expectedFailure,omitempty"`
-	ImplementationTarget string   `json:"implementationTarget,omitempty"`
-	Invariants           []string `json:"invariants,omitempty"`
+	// SelectedFiles lists the project-relative files the agent expects to inspect or edit during execution.
+	SelectedFiles []string `json:"selectedFiles,omitempty"`
+	// TestTarget is the concrete test command target Centian should validate during execution.
+	TestTarget string `json:"testTarget,omitempty"`
+	// LintCommand is the project command Centian should run for the final verification step.
+	LintCommand string `json:"lintCommand,omitempty"`
+	// ExpectedFailure is the stable substring the agent expects in the intentionally failing baseline output.
+	ExpectedFailure string `json:"expectedFailure,omitempty"`
+	// ImplementationTarget is the project-relative production file the execution step should change.
+	ImplementationTarget string `json:"implementationTarget,omitempty"`
+	// Invariants lists additional invariants the agent wants frozen as part of the planning contract.
+	Invariants []string `json:"invariants,omitempty"`
 }
 
 // WorkflowNodeKind identifies the semantic meaning of one compiled workflow node.
@@ -157,49 +230,80 @@ const (
 
 // WorkflowNode is the normalized runtime representation of one workflow node.
 type WorkflowNode struct {
-	Path                    TaskPhase        `json:"path"`
-	Kind                    WorkflowNodeKind `json:"kind"`
-	ParentPath              TaskPhase        `json:"parentPath,omitempty"`
-	NextPath                TaskPhase        `json:"nextPath,omitempty"`
-	StepNumber              int              `json:"stepNumber,omitempty"`
-	StepID                  string           `json:"stepId,omitempty"`
-	Name                    string           `json:"name,omitempty"`
-	Description             string           `json:"description,omitempty"`
-	Instructions            string           `json:"instructions,omitempty"`
-	AllowedTools            []string         `json:"allowedTools,omitempty"`
-	Checkpoint              *CheckpointHint  `json:"checkpoint,omitempty"`
-	EditableFields          []string         `json:"editableFields,omitempty"`
-	RequiredPlanningOutputs []string         `json:"requiredPlanningOutputs,omitempty"`
+	// Path is the fully qualified workflow path for this normalized node.
+	Path TaskPhase `json:"path"`
+	// Kind identifies whether the node is onboarding, planning, executable, or waiting for approval.
+	Kind WorkflowNodeKind `json:"kind"`
+	// ParentPath is the containing workflow path for nested nodes.
+	ParentPath TaskPhase `json:"parentPath,omitempty"`
+	// NextPath is the workflow path Centian should enter after this node succeeds.
+	NextPath TaskPhase `json:"nextPath,omitempty"`
+	// StepNumber is the 1-based execution step number when this node is executable.
+	StepNumber int `json:"stepNumber,omitempty"`
+	// StepID is the author-defined identifier for the executable node backing this workflow node.
+	StepID string `json:"stepId,omitempty"`
+	// Name is the display label exposed to agents and UIs for this node.
+	Name string `json:"name,omitempty"`
+	// Description is the short human-facing summary of this workflow node.
+	Description string `json:"description,omitempty"`
+	// Instructions tells the agent what this normalized node expects before completion.
+	Instructions string `json:"instructions,omitempty"`
+	// AllowedTools is the tool allowlist pattern set active while this node is current.
+	AllowedTools []string `json:"allowedTools,omitempty"`
+	// Checkpoint holds optional metadata about whether this node should advertise checkpoint capability.
+	Checkpoint *CheckpointHint `json:"checkpoint,omitempty"`
+	// EditableFields lists the draft parameter fields planning may revise while this node is current.
+	EditableFields []string `json:"editableFields,omitempty"`
+	// RequiredPlanningOutputs lists the planning fields that must be present before leaving planning.
+	RequiredPlanningOutputs []string `json:"requiredPlanningOutputs,omitempty"`
 }
 
 // CompiledWorkflow stores normalized workflow nodes derived from the template schema.
 type CompiledWorkflow struct {
-	Nodes               map[TaskPhase]WorkflowNode `json:"-"`
-	OnboardingPath      TaskPhase                  `json:"-"`
-	PlanningPath        TaskPhase                  `json:"-"`
-	FirstExecutablePath TaskPhase                  `json:"-"`
-	WorkflowSteps       []Step                     `json:"-"`
+	// Nodes maps every compiled workflow path to its normalized node definition and is not serialized.
+	Nodes map[TaskPhase]WorkflowNode `json:"-"`
+	// OnboardingPath is the canonical workflow path for the onboarding node and is not serialized.
+	OnboardingPath TaskPhase `json:"-"`
+	// PlanningPath is the canonical workflow path for the planning node and is not serialized.
+	PlanningPath TaskPhase `json:"-"`
+	// FirstExecutablePath is the first compiled executable workflow path and is not serialized.
+	FirstExecutablePath TaskPhase `json:"-"`
+	// WorkflowSteps is the ordered list of compiled executable steps and is not serialized.
+	WorkflowSteps []Step `json:"-"`
 }
 
 // TemplateSummary is the lightweight view returned to MCP clients.
 type TemplateSummary struct {
-	ID           string              `json:"id"`
-	Name         string              `json:"name"`
-	Description  string              `json:"description"`
-	Instructions string              `json:"instructions,omitempty"`
-	Parameters   []TemplateParameter `json:"parameters"`
-	StepCount    int                 `json:"stepCount"`
-	Steps        []StepSummary       `json:"steps"`
+	// ID is the stable template identifier exposed to MCP clients.
+	ID string `json:"id"`
+	// Name is the display name shown in task template listings.
+	Name string `json:"name"`
+	// Description is the short summary shown in task template listings.
+	Description string `json:"description"`
+	// Instructions is the template-level guidance agents can inspect before registration.
+	Instructions string `json:"instructions,omitempty"`
+	// Parameters lists the registration-time parameter contract for this template.
+	Parameters []TemplateParameter `json:"parameters"`
+	// StepCount is the number of compiled executable steps in the template.
+	StepCount int `json:"stepCount"`
+	// Steps is the lightweight execution-step summary exposed to MCP clients.
+	Steps []StepSummary `json:"steps"`
 }
 
 // StepSummary is the lightweight view of one compiled execution step returned to MCP clients.
 type StepSummary struct {
-	Step         int       `json:"step"`
-	ID           string    `json:"id"`
-	Path         TaskPhase `json:"path"`
-	Name         string    `json:"name,omitempty"`
-	Description  string    `json:"description,omitempty"`
-	Instructions string    `json:"instructions,omitempty"`
+	// Step is the 1-based execution step number shown to the agent.
+	Step int `json:"step"`
+	// ID is the author-defined identifier for this compiled execution step.
+	ID string `json:"id"`
+	// Path is the fully qualified workflow path for the step.
+	Path TaskPhase `json:"path"`
+	// Name is the display label shown for the step in listings.
+	Name string `json:"name,omitempty"`
+	// Description is the short human-facing summary shown for the step.
+	Description string `json:"description,omitempty"`
+	// Instructions is the step guidance exposed in lightweight MCP summaries.
+	Instructions string `json:"instructions,omitempty"`
 }
 
 // TaskStatus enumerates the overall condition of a task run.
@@ -278,48 +382,82 @@ const (
 
 // StepState stores mutable runtime state for a single step.
 type StepState struct {
-	ID                 string            `json:"id"`
-	Path               TaskPhase         `json:"path"`
-	Status             StepStatus        `json:"status"`
+	// ID is the author-defined identifier for the compiled step this state belongs to.
+	ID string `json:"id"`
+	// Path is the fully qualified workflow path for the compiled step this state belongs to.
+	Path TaskPhase `json:"path"`
+	// Status is the mutable lifecycle status for this step within the current run.
+	Status StepStatus `json:"status"`
+	// InvariantBaselines stores captured invariant outputs for comparison and is intentionally not serialized.
 	InvariantBaselines map[string]string `json:"-"`
 }
 
 // RunState stores the mutable session-scoped state of one registered task.
 type RunState struct {
-	RunID              string              `json:"taskRunId"`
-	TemplateID         string              `json:"templateId"`
-	SelectedTemplate   Template            `json:"-"`
-	DraftParameters    map[string]string   `json:"draftParameters"`
-	Status             TaskStatus          `json:"status"`
-	Phase              TaskPhase           `json:"phase"`
-	Onboarding         *OnboardingArtifact `json:"onboarding,omitempty"`
-	Planning           *PlanningArtifact   `json:"planning,omitempty"`
-	WorkflowReady      bool                `json:"executionReady"`
-	RunnableTemplate   *Template           `json:"-"`
-	Steps              []StepState         `json:"steps,omitempty"`
-	LastFailureMessage string              `json:"lastFailureMessage,omitempty"`
-	ExplicitFailReason string              `json:"explicitFailReason,omitempty"`
-	LastActivityAt     int64               `json:"lastActivityAtUnixMilli,omitempty"`
-	ExpiresAt          int64               `json:"expiresAtUnixMilli,omitempty"`
+	// RunID is the stable identifier for this registered task run.
+	RunID string `json:"taskRunId"`
+	// TemplateID is the identifier of the template this run was registered from.
+	TemplateID string `json:"templateId"`
+	// SelectedTemplate is the original unresolved template chosen at registration time and is not serialized.
+	SelectedTemplate Template `json:"-"`
+	// DraftParameters stores the registration-time parameter values before planning freezes the execution contract.
+	DraftParameters map[string]string `json:"draftParameters"`
+	// Status is the overall lifecycle status of the task run.
+	Status TaskStatus `json:"status"`
+	// Phase is the current workflow path the run is positioned in.
+	Phase TaskPhase `json:"phase"`
+	// Onboarding stores the persisted onboarding artifact once onboarding completes.
+	Onboarding *OnboardingArtifact `json:"onboarding,omitempty"`
+	// Planning stores the frozen planning artifact once planning completes.
+	Planning *PlanningArtifact `json:"planning,omitempty"`
+	// WorkflowReady reports whether planning has completed and execution can proceed.
+	WorkflowReady bool `json:"executionReady"`
+	// RunnableTemplate holds the resolved execution-ready template for this run and is not serialized.
+	RunnableTemplate *Template `json:"-"`
+	// Steps stores the mutable per-step runtime state for the compiled workflow.
+	Steps []StepState `json:"steps,omitempty"`
+	// LastFailureMessage stores the most recent human-facing failure explanation for the run.
+	LastFailureMessage string `json:"lastFailureMessage,omitempty"`
+	// ExplicitFailReason stores the direct reason supplied when the task was explicitly failed.
+	ExplicitFailReason string `json:"explicitFailReason,omitempty"`
+	// LastActivityAt records the last observed task activity time in Unix milliseconds.
+	LastActivityAt int64 `json:"lastActivityAtUnixMilli,omitempty"`
+	// ExpiresAt records the inactivity timeout deadline in Unix milliseconds when applicable.
+	ExpiresAt int64 `json:"expiresAtUnixMilli,omitempty"`
 }
 
 // StepResult is the MCP-facing outcome of starting or completing a step.
 type StepResult struct {
-	Passed            bool             `json:"passed"`
-	Message           string           `json:"message"`
-	Step              int              `json:"step"`
-	StepID            string           `json:"stepId"`
-	Status            TaskStatus       `json:"status"`
-	Phase             TaskPhase        `json:"phase"`
-	StepStatus        StepStatus       `json:"stepStatus"`
-	FailureKind       StepFailureKind  `json:"failureKind,omitempty"`
-	FailurePhase      StepFailurePhase `json:"failurePhase,omitempty"`
-	FailedCheckID     string           `json:"failedCheckId,omitempty"`
-	FailedInvariantID string           `json:"failedInvariantId,omitempty"`
-	Summary           string           `json:"summary,omitempty"`
-	ExitCode          *int             `json:"exitCode,omitempty"`
-	StdoutSnippet     string           `json:"stdoutSnippet,omitempty"`
-	StderrSnippet     string           `json:"stderrSnippet,omitempty"`
+	// Passed indicates whether the requested step action succeeded.
+	Passed bool `json:"passed"`
+	// Message is the primary human-facing explanation for the step outcome.
+	Message string `json:"message"`
+	// Step is the 1-based execution step number the result refers to.
+	Step int `json:"step"`
+	// StepID is the author-defined identifier for the step the result refers to.
+	StepID string `json:"stepId"`
+	// Status is the overall task run status after the step action completed.
+	Status TaskStatus `json:"status"`
+	// Phase is the current workflow path after the step action completed.
+	Phase TaskPhase `json:"phase"`
+	// StepStatus is the updated lifecycle status for the referenced step.
+	StepStatus StepStatus `json:"stepStatus"`
+	// FailureKind classifies the high-level reason the step action failed.
+	FailureKind StepFailureKind `json:"failureKind,omitempty"`
+	// FailurePhase identifies which verification stage produced the failure.
+	FailurePhase StepFailurePhase `json:"failurePhase,omitempty"`
+	// FailedCheckID identifies the failing check when a check caused the step to fail.
+	FailedCheckID string `json:"failedCheckId,omitempty"`
+	// FailedInvariantID identifies the failing invariant when invariant capture or verification failed.
+	FailedInvariantID string `json:"failedInvariantId,omitempty"`
+	// Summary is an optional concise summary of the step outcome suitable for UIs.
+	Summary string `json:"summary,omitempty"`
+	// ExitCode is the command exit code when command execution produced one.
+	ExitCode *int `json:"exitCode,omitempty"`
+	// StdoutSnippet is the truncated stdout excerpt relevant to the step outcome.
+	StdoutSnippet string `json:"stdoutSnippet,omitempty"`
+	// StderrSnippet is the truncated stderr excerpt relevant to the step outcome.
+	StderrSnippet string `json:"stderrSnippet,omitempty"`
 }
 
 // TaskEventType identifies one task lifecycle event.
@@ -360,28 +498,48 @@ const (
 
 // TaskEvent is the append-only lifecycle record for one task run.
 type TaskEvent struct {
-	ID                     string           `json:"id"`
-	SchemaVersion          int              `json:"schemaVersion"`
-	CreatedAtUnixMilli     int64            `json:"createdAtUnixMilli"`
-	TaskRunID              string           `json:"taskRunId"`
-	SessionID              string           `json:"sessionId,omitempty"`
-	TemplateID             string           `json:"templateId"`
-	PrincipalID            string           `json:"principalId,omitempty"`
-	PhasePath              TaskPhase        `json:"phasePath"`
-	NodeKind               WorkflowNodeKind `json:"nodeKind,omitempty"`
-	ResultingPhasePath     TaskPhase        `json:"resultingPhasePath"`
-	ResultingNodeKind      WorkflowNodeKind `json:"resultingNodeKind,omitempty"`
-	EventType              TaskEventType    `json:"eventType"`
-	Outcome                TaskEventOutcome `json:"outcome"`
-	RelatedActionRequestID string           `json:"relatedActionRequestId,omitempty"`
-	Payload                json.RawMessage  `json:"payload,omitempty"`
+	// ID is the stable identifier for this persisted task lifecycle event.
+	ID string `json:"id"`
+	// SchemaVersion is the event schema version used when the event was written.
+	SchemaVersion int `json:"schemaVersion"`
+	// CreatedAtUnixMilli is the event creation time in Unix milliseconds.
+	CreatedAtUnixMilli int64 `json:"createdAtUnixMilli"`
+	// TaskRunID identifies which task run this lifecycle event belongs to.
+	TaskRunID string `json:"taskRunId"`
+	// SessionID records the upstream MCP session associated with the event when available.
+	SessionID string `json:"sessionId,omitempty"`
+	// TemplateID identifies the template backing the task run that emitted this event.
+	TemplateID string `json:"templateId"`
+	// PrincipalID records the authenticated principal associated with the event when available.
+	PrincipalID string `json:"principalId,omitempty"`
+	// PhasePath is the workflow path active when the lifecycle event was recorded.
+	PhasePath TaskPhase `json:"phasePath"`
+	// NodeKind is the semantic workflow node kind active when the event was recorded.
+	NodeKind WorkflowNodeKind `json:"nodeKind,omitempty"`
+	// ResultingPhasePath is the workflow path after the lifecycle action completed.
+	ResultingPhasePath TaskPhase `json:"resultingPhasePath"`
+	// ResultingNodeKind is the semantic workflow node kind after the lifecycle action completed.
+	ResultingNodeKind WorkflowNodeKind `json:"resultingNodeKind,omitempty"`
+	// EventType identifies which lifecycle operation produced this append-only record.
+	EventType TaskEventType `json:"eventType"`
+	// Outcome records whether the lifecycle operation succeeded or failed.
+	Outcome TaskEventOutcome `json:"outcome"`
+	// RelatedActionRequestID links this lifecycle event to a proxied action-event request when available.
+	RelatedActionRequestID string `json:"relatedActionRequestId,omitempty"`
+	// Payload stores event-specific opaque JSON data such as step failure details or submitted artifacts.
+	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
 // ActionEventTaskContext associates an action event with the active task snapshot.
 type ActionEventTaskContext struct {
-	RequestID           string           `json:"requestId"`
-	TaskRunID           string           `json:"taskRunId"`
-	InvocationPhasePath TaskPhase        `json:"invocationPhasePath"`
-	InvocationNodeKind  WorkflowNodeKind `json:"invocationNodeKind,omitempty"`
-	CreatedAtUnixMilli  int64            `json:"createdAtUnixMilli"`
+	// RequestID is the proxied action-event request identifier.
+	RequestID string `json:"requestId"`
+	// TaskRunID identifies the active task run associated with the action event.
+	TaskRunID string `json:"taskRunId"`
+	// InvocationPhasePath is the workflow path active when the action event was invoked.
+	InvocationPhasePath TaskPhase `json:"invocationPhasePath"`
+	// InvocationNodeKind is the semantic workflow node kind active when the action event was invoked.
+	InvocationNodeKind WorkflowNodeKind `json:"invocationNodeKind,omitempty"`
+	// CreatedAtUnixMilli is the timestamp in Unix milliseconds when the task context snapshot was recorded.
+	CreatedAtUnixMilli int64 `json:"createdAtUnixMilli"`
 }

--- a/internal/taskverification/types.go
+++ b/internal/taskverification/types.go
@@ -8,7 +8,7 @@ type Template struct {
 	Version string `yaml:"version" json:"version"`
 	// Task is the human-facing identity and description block for the template.
 	Task Task `yaml:"task" json:"task"`
-	// Parameters lists the agent-supplied placeholder values the template expects at registration time.
+	// Parameters lists the agent-supplied placeholder values the template expects before planning can complete.
 	Parameters []TemplateParameter `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 	// Workflow is the declarative lifecycle definition authored in the template YAML.
 	Workflow *Workflow `yaml:"workflow" json:"workflow"`
@@ -58,10 +58,10 @@ type PlanningNodeSpec struct {
 	AllowedTools []string `yaml:"tools_allowed,omitempty" json:"toolsAllowed,omitempty"`
 	// Checkpoint holds optional metadata about whether planning should emit a checkpoint hint.
 	Checkpoint *CheckpointHint `yaml:"checkpoint,omitempty" json:"checkpoint,omitempty"`
-	// EditableFields lists which registered draft parameters the planning step may revise.
+	// EditableFields lists which planning.parameters entries the planning step may revise.
 	EditableFields []string `yaml:"editable_fields,omitempty" json:"editableFields,omitempty"`
-	// RequiredOutputs lists the planning artifact fields that must be present before execution can start.
-	RequiredOutputs []string `yaml:"required_outputs,omitempty" json:"requiredOutputs,omitempty"`
+	// RequiredInputs lists the planning inputs that must be present before execution can start.
+	RequiredInputs []string `yaml:"required_inputs,omitempty" json:"requiredInputs,omitempty"`
 	// Next optionally overrides the default next workflow path after planning completes.
 	Next string `yaml:"next,omitempty" json:"next,omitempty"`
 }
@@ -158,9 +158,9 @@ type Condition struct {
 
 // TemplateParameter describes one agent-provided parameter expected by a template.
 type TemplateParameter struct {
-	// Name is the placeholder identifier agents must fill when registering the template.
+	// Name is the placeholder identifier agents must fill in planning.parameters before planning completes.
 	Name string `yaml:"name" json:"name"`
-	// Description explains what value the agent should provide for this parameter.
+	// Description explains what value the agent should determine during onboarding and planning for this parameter.
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 }
 
@@ -200,14 +200,8 @@ type OnboardingCommand struct {
 type PlanningArtifact struct {
 	// SelectedFiles lists the project-relative files the agent expects to inspect or edit during execution.
 	SelectedFiles []string `json:"selectedFiles,omitempty"`
-	// TestTarget is the concrete test command target Centian should validate during execution.
-	TestTarget string `json:"testTarget,omitempty"`
-	// LintCommand is the project command Centian should run for the final verification step.
-	LintCommand string `json:"lintCommand,omitempty"`
-	// ExpectedFailure is the stable substring the agent expects in the intentionally failing baseline output.
-	ExpectedFailure string `json:"expectedFailure,omitempty"`
-	// ImplementationTarget is the project-relative production file the execution step should change.
-	ImplementationTarget string `json:"implementationTarget,omitempty"`
+	// Parameters stores the template placeholder values the agent freezes at planning completion.
+	Parameters map[string]string `json:"parameters,omitempty"`
 	// Invariants lists additional invariants the agent wants frozen as part of the planning contract.
 	Invariants []string `json:"invariants,omitempty"`
 }
@@ -252,10 +246,10 @@ type WorkflowNode struct {
 	AllowedTools []string `json:"allowedTools,omitempty"`
 	// Checkpoint holds optional metadata about whether this node should advertise checkpoint capability.
 	Checkpoint *CheckpointHint `json:"checkpoint,omitempty"`
-	// EditableFields lists the draft parameter fields planning may revise while this node is current.
+	// EditableFields lists the planning.parameters fields planning may revise while this node is current.
 	EditableFields []string `json:"editableFields,omitempty"`
-	// RequiredPlanningOutputs lists the planning fields that must be present before leaving planning.
-	RequiredPlanningOutputs []string `json:"requiredPlanningOutputs,omitempty"`
+	// RequiredPlanningInputs lists the planning inputs that must be present before leaving planning.
+	RequiredPlanningInputs []string `json:"requiredPlanningInputs,omitempty"`
 }
 
 // CompiledWorkflow stores normalized workflow nodes derived from the template schema.
@@ -282,7 +276,7 @@ type TemplateSummary struct {
 	Description string `json:"description"`
 	// Instructions is the template-level guidance agents can inspect before registration.
 	Instructions string `json:"instructions,omitempty"`
-	// Parameters lists the registration-time parameter contract for this template.
+	// Parameters lists the planning-time parameter contract for this template.
 	Parameters []TemplateParameter `json:"parameters"`
 	// StepCount is the number of compiled executable steps in the template.
 	StepCount int `json:"stepCount"`
@@ -400,8 +394,6 @@ type RunState struct {
 	TemplateID string `json:"templateId"`
 	// SelectedTemplate is the original unresolved template chosen at registration time and is not serialized.
 	SelectedTemplate Template `json:"-"`
-	// DraftParameters stores the registration-time parameter values before planning freezes the execution contract.
-	DraftParameters map[string]string `json:"draftParameters"`
 	// Status is the overall lifecycle status of the task run.
 	Status TaskStatus `json:"status"`
 	// Phase is the current workflow path the run is positioned in.

--- a/internal/taskverification/workflow.go
+++ b/internal/taskverification/workflow.go
@@ -477,6 +477,7 @@ func cloneChecks(checks []Check) []Check {
 	for _, check := range checks {
 		cloned = append(cloned, Check{
 			ID:             check.ID,
+			Description:    check.Description,
 			Command:        check.Command,
 			PreConditions:  append([]Condition(nil), check.PreConditions...),
 			PostConditions: append([]Condition(nil), check.PostConditions...),

--- a/internal/taskverification/workflow.go
+++ b/internal/taskverification/workflow.go
@@ -6,15 +6,6 @@ import (
 	"strings"
 )
 
-var supportedPlanningOutputs = map[string]struct{}{
-	"selectedFiles":        {},
-	"testTarget":           {},
-	"lintCommand":          {},
-	"expectedFailure":      {},
-	"implementationTarget": {},
-	"invariants":           {},
-}
-
 //nolint:gocyclo // Workflow compilation is the central normalization pass; helper extraction keeps nested rules contained.
 func (t *Template) compileWorkflow() (*CompiledWorkflow, error) {
 	if err := validateWorkflowDefinition(t); err != nil {
@@ -22,7 +13,7 @@ func (t *Template) compileWorkflow() (*CompiledWorkflow, error) {
 	}
 
 	compiled := newCompiledWorkflow()
-	if err := addCompiledShellNodes(compiled, t.Workflow); err != nil {
+	if err := addCompiledShellNodes(compiled, t); err != nil {
 		return nil, err
 	}
 
@@ -179,7 +170,7 @@ func (t *Template) compileWorkflow() (*CompiledWorkflow, error) {
 	if err := validatePlanningEditableFields(t, t.Workflow.Planning); err != nil {
 		return nil, err
 	}
-	if err := validatePlanningRequiredOutputs(t.Workflow.Planning.RequiredOutputs); err != nil {
+	if err := validatePlanningRequiredInputs(t, t.Workflow.Planning.RequiredInputs); err != nil {
 		return nil, err
 	}
 	if err := validateWorkflowReachability(compiled); err != nil {
@@ -188,12 +179,12 @@ func (t *Template) compileWorkflow() (*CompiledWorkflow, error) {
 	return compiled, nil
 }
 
-func addCompiledShellNodes(compiled *CompiledWorkflow, workflow *Workflow) error {
-	onboardingNode := buildOnboardingNode(workflow.Onboarding)
+func addCompiledShellNodes(compiled *CompiledWorkflow, template *Template) error {
+	onboardingNode := buildOnboardingNode(template.Workflow.Onboarding)
 	if err := addCompiledNode(compiled, &onboardingNode); err != nil {
 		return err
 	}
-	planningNode := buildPlanningNode(workflow.Planning)
+	planningNode := buildPlanningNode(template)
 	return addCompiledNode(compiled, &planningNode)
 }
 
@@ -312,15 +303,16 @@ func buildOnboardingNode(spec *LifecycleNodeSpec) WorkflowNode {
 	}
 }
 
-func buildPlanningNode(spec *PlanningNodeSpec) WorkflowNode {
+func buildPlanningNode(template *Template) WorkflowNode {
+	spec := template.Workflow.Planning
 	return WorkflowNode{
-		Path:                    TaskPhasePlanning,
-		Kind:                    WorkflowNodeKindPlanning,
-		Instructions:            spec.Instructions,
-		AllowedTools:            cloneStringSlice(spec.AllowedTools),
-		Checkpoint:              cloneCheckpoint(spec.Checkpoint),
-		EditableFields:          cloneStringSlice(spec.EditableFields),
-		RequiredPlanningOutputs: cloneStringSlice(spec.RequiredOutputs),
+		Path:                   TaskPhasePlanning,
+		Kind:                   WorkflowNodeKindPlanning,
+		Instructions:           spec.Instructions,
+		AllowedTools:           cloneStringSlice(spec.AllowedTools),
+		Checkpoint:             cloneCheckpoint(spec.Checkpoint),
+		EditableFields:         cloneStringSlice(spec.EditableFields),
+		RequiredPlanningInputs: orderedPlanningInputs(template),
 	}
 }
 
@@ -404,20 +396,29 @@ func parameterNameSet(t *Template) map[string]struct{} {
 	return defined
 }
 
-func validatePlanningRequiredOutputs(outputs []string) error {
-	seen := make(map[string]struct{}, len(outputs))
-	for index, output := range outputs {
-		trimmed := strings.TrimSpace(output)
+func validatePlanningRequiredInputs(template *Template, inputs []string) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	expected := orderedPlanningInputs(template)
+	seen := make(map[string]struct{}, len(inputs))
+	normalized := make([]string, 0, len(inputs))
+	for index, input := range inputs {
+		trimmed := strings.TrimSpace(input)
 		if trimmed == "" {
-			return fmt.Errorf("workflow.planning.required_outputs[%d] is required", index)
+			return fmt.Errorf("workflow.planning.required_inputs[%d] is required", index)
 		}
 		if _, exists := seen[trimmed]; exists {
-			return fmt.Errorf("workflow.planning.required_outputs contains duplicate value %q", trimmed)
+			return fmt.Errorf("workflow.planning.required_inputs contains duplicate value %q", trimmed)
 		}
 		seen[trimmed] = struct{}{}
-		if _, supported := supportedPlanningOutputs[trimmed]; !supported {
-			return fmt.Errorf("workflow.planning.required_outputs %q is unsupported", trimmed)
-		}
+		normalized = append(normalized, trimmed)
+	}
+	sort.Strings(normalized)
+	sortedExpected := append([]string(nil), expected...)
+	sort.Strings(sortedExpected)
+	if strings.Join(normalized, ",") != strings.Join(sortedExpected, ",") {
+		return fmt.Errorf("workflow.planning.required_inputs must match the template parameter names exactly")
 	}
 	return nil
 }

--- a/task-templates/python_tdd_workflow.yaml
+++ b/task-templates/python_tdd_workflow.yaml
@@ -8,6 +8,7 @@ task:
 
     Expectations:
     - Register the task before using any project-access MCP tool, then follow the step boundaries in order.
+    - Registration only selects the template; determine all template parameters during onboarding/planning and submit them in `planning.parameters`.
     - Prefer `centian.task_start_step` and `centian.task_complete_step` over manually rebuilding the full validation flow.
     - Treat `centian.task_complete_step` as the source of truth for whether a step passes.
     - Use the scaffolding phase for additive setup, then use execution for baseline verification and implementation.
@@ -48,12 +49,14 @@ workflow:
       - "parameters.lintCommand"
       - "parameters.expectedError"
       - "parameters.implementationTarget"
-    required_outputs:
-      - "selectedFiles"
-      - "testTarget"
-      - "lintCommand"
-      - "expectedFailure"
+    required_inputs:
+      - "expectedError"
       - "implementationTarget"
+      - "lintCommand"
+      - "testCommand"
+      - "testFile"
+      - "testName"
+      - "testTarget"
   scaffolding:
     - id: "setup_test_file"
       name: "Setup test file"

--- a/task-templates/simple_tdd.yaml
+++ b/task-templates/simple_tdd.yaml
@@ -23,8 +23,10 @@ workflow:
       - "parameters.testCommand"
       - "parameters.testFile"
       - "parameters.expectedError"
-    required_outputs:
-      - "testTarget"
+    required_inputs:
+      - "expectedError"
+      - "testCommand"
+      - "testFile"
   execution:
     - id: "create_failing_test_baseline"
       name: "Create failing test baseline"

--- a/tests/integrationtests/demo/demo_integration_test.go
+++ b/tests/integrationtests/demo/demo_integration_test.go
@@ -53,6 +53,69 @@ func TestCentianDemoClaude(t *testing.T) {
 		filepath.Join(demoRoot, "prompt.md"),
 		filepath.Join(demoRoot, "claude_mcp_config.json"),
 		filepath.Join(demoRoot, "centian.pid"),
+		filepath.Join(demoRoot, "agent.stdout.log"),
+		filepath.Join(demoRoot, "agent.stderr.log"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected demo artifact %s: %v", path, err)
+		}
+	}
+
+	pidBytes, err := os.ReadFile(filepath.Join(demoRoot, "centian.pid"))
+	if err != nil {
+		t.Fatalf("read centian.pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
+	if err != nil {
+		t.Fatalf("parse centian pid: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(pid, syscall.SIGTERM)
+	})
+
+	port := readPort(t, filepath.Join(demoRoot, "config.json"))
+	baseURL := "http://127.0.0.1:" + port
+	waitForHTTP(t, baseURL+"/api/task-runs")
+}
+
+func TestCentianDemoGemini(t *testing.T) {
+	if os.Getenv(runDemoIntegrationEnv) != "1" {
+		t.Skipf("set %s=1 to run demo integration tests", runDemoIntegrationEnv)
+	}
+	if _, err := exec.LookPath("gemini"); err != nil {
+		t.Fatalf("gemini is not available: %v", err)
+	}
+	if _, err := exec.LookPath("npx"); err != nil {
+		t.Fatalf("npx is not available: %v", err)
+	}
+
+	root := t.TempDir()
+	binary := filepath.Join(root, "centian")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/main.go")
+	build.Dir = repoRoot(t)
+	build.Env = append(os.Environ(), "GOCACHE=/tmp/centian-gocache")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build centian binary: %v\n%s", err, strings.TrimSpace(string(output)))
+	}
+
+	demoRoot := filepath.Join(root, "demo")
+	cmd := exec.Command(binary, "demo", "--agent", "gemini", "--path", demoRoot)
+	cmd.Dir = repoRoot(t)
+	cmd.Env = os.Environ()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run centian demo: %v\n%s", err, strings.TrimSpace(string(output)))
+	}
+
+	for _, path := range []string{
+		filepath.Join(demoRoot, "workspace"),
+		filepath.Join(demoRoot, "workspace", ".gemini", "settings.json"),
+		filepath.Join(demoRoot, "templates", "python_tdd_workflow.yaml"),
+		filepath.Join(demoRoot, "logs"),
+		filepath.Join(demoRoot, "config.json"),
+		filepath.Join(demoRoot, "prompt.md"),
+		filepath.Join(demoRoot, "centian.pid"),
+		filepath.Join(demoRoot, "agent.stdout.log"),
+		filepath.Join(demoRoot, "agent.stderr.log"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected demo artifact %s: %v", path, err)

--- a/tests/integrationtests/taskverification/python_tdd_workflow.yaml
+++ b/tests/integrationtests/taskverification/python_tdd_workflow.yaml
@@ -8,6 +8,7 @@ task:
 
     Expectations:
     - Register the task before using any project-access MCP tool, then follow the step boundaries in order.
+    - Registration only selects the template; determine all template parameters during onboarding/planning and submit them in `planning.parameters`.
     - Prefer `centian.task_start_step` and `centian.task_complete_step` over manually rebuilding the full validation flow.
     - Treat `centian.task_complete_step` as the source of truth for whether a step passes.
     - The Centian taskverification working directory is the project root.
@@ -49,12 +50,14 @@ workflow:
       - "parameters.lintCommand"
       - "parameters.expectedError"
       - "parameters.implementationTarget"
-    required_outputs:
-      - "selectedFiles"
-      - "testTarget"
-      - "lintCommand"
-      - "expectedFailure"
+    required_inputs:
+      - "expectedError"
       - "implementationTarget"
+      - "lintCommand"
+      - "testCommand"
+      - "testFile"
+      - "testName"
+      - "testTarget"
   scaffolding:
     - id: "setup_test_file"
       name: "Setup test file"

--- a/web/src/ui/task-run-detail-page.tsx
+++ b/web/src/ui/task-run-detail-page.tsx
@@ -1123,10 +1123,10 @@ function extractPayloadPreview(payload: unknown, depth = 0): string {
     "args",
     "params",
     "parameters",
+    "requiredInputs",
+    "requiredInputNames",
     "request",
     "payload",
-    "draftParameters",
-    "draft_parameters",
   ];
   for (const key of nestedKeys) {
     const preview = extractPayloadPreview(record[key], depth + 1);


### PR DESCRIPTION
## **Summary**
This PR improves the taskverification workflow for coding agents by moving template parameter selection fully into onboarding/planning, strengthening the planning contract exposed through `centian.task_*` tools, and adding richer structured metadata/failure payloads for execution steps. It also adds initial Gemini support to the local `centian demo` flow and updates the related templates, prompts, docs, and integration coverage.

## **What Changed**
- Refactored task registration so `centian.task_register` only selects a template.
- Moved execution parameter freezing to `planning.parameters`.
- Added richer planning contract metadata, including required planning parameters and stronger planning guidance.
- Added structured planning validation failures with explicit missing/unknown parameter details.
- Added richer current-step metadata, including check/invariant descriptions and technical explanations for built-in checks and invariants.
- Added initial Gemini support to `centian demo`, including embedded settings and demo wiring.
- Updated taskverification templates, prompts, docs, UI payload expectations, and integration fixtures to match the new planning model.
- Expanded proxy, taskverification, demo, and integration coverage around the new behavior.

## **Why**
- Draft parameters were decided too early and made workflows brittle when onboarding/planning needed to refine execution inputs.
- Gemini and Claude both benefited from stronger planning contracts and clearer structured failure payloads.
- The planning phase now acts as the single enforced execution contract, which is a better base for future iterations.
