### PR TITLE
feat: add Codex demo adapter with per-gateway ForceReadOnlyHints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ centian demo -a gemini
 ```bash
 centian demo -a codex
 ```
-Note: for codex a new `CODEX_HOME` directory is created in the demo folder and auth.json moved over for authentication at the OpenAI API.
+Note: for the codex demo centian will copy (and later cleanup) existing auth material for the OpenAI API.
 
 **What the demo shows**
 - Setup environment: create a local folder `.centian/demo`, copying required artifacts there (see [here](internal/agentrunner/assets)), adjusting configs.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ centian demo -a claude
 centian demo -a gemini
 ```
 
-**Codex:** coming soon
+**Codex:** (using default option)
+```bash
+centian demo -a codex
+```
+Note: for codex a new `CODEX_HOME` directory is created in the demo folder and auth.json moved over for authentication at the OpenAI API.
 
 **What the demo shows**
 - Setup environment: create a local folder `.centian/demo`, copying required artifacts there (see [here](internal/agentrunner/assets)), adjusting configs.

--- a/internal/agentrunner/assets/centian_config.json
+++ b/internal/agentrunner/assets/centian_config.json
@@ -27,6 +27,7 @@
   "gateways": {
     "taskverification": {
       "setupGateway": true,
+      "forceReadOnlyHints": true,
       "mcpServers": {
         "filesystem": {
           "command": "npx",

--- a/internal/agentrunner/assets/codex_config.toml
+++ b/internal/agentrunner/assets/codex_config.toml
@@ -1,0 +1,21 @@
+__MODEL_BLOCK__
+sandbox_mode = "workspace-write"
+
+[mcp_servers.centian]
+url = "__MCP_URL__"
+enabled = true
+destructive_enabled = true
+open_world_enabled = true
+default_tools_approval_mode = "auto"
+
+[projects."__WORK_DIR__"]
+trust_level = "trusted"
+destructive_enabled = true
+open_world_enabled = true
+default_tools_approval_mode = "auto"
+
+[apps._default]
+enabled = true
+destructive_enabled = true
+open_world_enabled = true
+default_tools_approval_mode = "auto"

--- a/internal/agentrunner/claude.go
+++ b/internal/agentrunner/claude.go
@@ -41,6 +41,8 @@ func (c claudeAdapter) writeConfig(layout *demoLayout) error {
 
 func (claudeAdapter) env(*demoLayout) []string { return nil }
 
+func (claudeAdapter) cleanup(*demoLayout) error { return nil }
+
 func (c claudeAdapter) command(layout *demoLayout, _ string) ([]string, error) {
 	command := []string{
 		"claude",

--- a/internal/agentrunner/claude.go
+++ b/internal/agentrunner/claude.go
@@ -39,6 +39,8 @@ func (c claudeAdapter) writeConfig(layout *demoLayout) error {
 	return nil
 }
 
+func (claudeAdapter) env(*demoLayout) []string { return nil }
+
 func (c claudeAdapter) command(layout *demoLayout, _ string) ([]string, error) {
 	command := []string{
 		"claude",

--- a/internal/agentrunner/codex.go
+++ b/internal/agentrunner/codex.go
@@ -70,6 +70,10 @@ func (codexAdapter) env(layout *demoLayout) []string {
 	return []string{"CODEX_HOME=" + filepath.Dir(layout.CodexConfig)}
 }
 
+func (codexAdapter) cleanup(layout *demoLayout) error {
+	return os.RemoveAll(filepath.Dir(layout.CodexConfig))
+}
+
 func (c codexAdapter) command(layout *demoLayout, _ string) ([]string, error) {
 	command := []string{
 		"codex",

--- a/internal/agentrunner/codex.go
+++ b/internal/agentrunner/codex.go
@@ -1,0 +1,60 @@
+package agentrunner
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type codexAdapter struct {
+	model string
+}
+
+func (codexAdapter) name() string { return AgentCodex }
+
+func (codexAdapter) isAvailable() error {
+	_, err := exec.LookPath("codex")
+	return err
+}
+
+func (c codexAdapter) writeConfig(layout *demoLayout) error {
+	content, err := asset("codex_config.toml")
+	if err != nil {
+		return err
+	}
+	modelBlock := ""
+	if model := strings.TrimSpace(c.model); model != "" {
+		modelBlock = `model = "` + model + `"`
+	}
+	content = strings.NewReplacer(
+		"__MODEL_BLOCK__", modelBlock,
+		"__MCP_URL__", layout.MCPURL,
+		"__WORK_DIR__", layout.WorkspacePath,
+	).Replace(content)
+	if err := os.MkdirAll(filepath.Dir(layout.CodexConfig), 0o750); err != nil {
+		return fmt.Errorf("create codex config dir: %w", err)
+	}
+	if err := os.WriteFile(layout.CodexConfig, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write codex config.toml: %w", err)
+	}
+	return nil
+}
+
+func (codexAdapter) env(layout *demoLayout) []string {
+	return []string{"CODEX_HOME=" + filepath.Dir(layout.CodexConfig)}
+}
+
+func (c codexAdapter) command(layout *demoLayout, _ string) ([]string, error) {
+	command := []string{
+		"codex",
+		"exec",
+		"--skip-git-repo-check",
+		"--json",
+		"-C", layout.WorkspacePath,
+		"-o", filepath.Join(layout.RootPath, "codex_output.txt"),
+		"-",
+	}
+	return command, nil
+}

--- a/internal/agentrunner/codex.go
+++ b/internal/agentrunner/codex.go
@@ -51,10 +51,12 @@ func copyCodexAuth(codexHome string) error {
 		return fmt.Errorf("resolve user home dir: %w", err)
 	}
 	sourcePath := filepath.Join(homeDir, ".codex", "auth.json")
+	//nolint:gosec // sourcePath is the fixed auth file under the current user's Codex home.
 	authData, err := os.ReadFile(sourcePath)
 	switch {
 	case err == nil:
 		targetPath := filepath.Join(codexHome, "auth.json")
+		//nolint:gosec // targetPath is the fixed auth file inside the demo-specific CODEX_HOME.
 		if err := os.WriteFile(targetPath, authData, 0o600); err != nil {
 			return fmt.Errorf("write codex auth.json: %w", err)
 		}

--- a/internal/agentrunner/codex.go
+++ b/internal/agentrunner/codex.go
@@ -36,10 +36,34 @@ func (c codexAdapter) writeConfig(layout *demoLayout) error {
 	if err := os.MkdirAll(filepath.Dir(layout.CodexConfig), 0o750); err != nil {
 		return fmt.Errorf("create codex config dir: %w", err)
 	}
+	if err := copyCodexAuth(filepath.Dir(layout.CodexConfig)); err != nil {
+		return err
+	}
 	if err := os.WriteFile(layout.CodexConfig, []byte(content), 0o600); err != nil {
 		return fmt.Errorf("write codex config.toml: %w", err)
 	}
 	return nil
+}
+
+func copyCodexAuth(codexHome string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve user home dir: %w", err)
+	}
+	sourcePath := filepath.Join(homeDir, ".codex", "auth.json")
+	authData, err := os.ReadFile(sourcePath)
+	switch {
+	case err == nil:
+		targetPath := filepath.Join(codexHome, "auth.json")
+		if err := os.WriteFile(targetPath, authData, 0o600); err != nil {
+			return fmt.Errorf("write codex auth.json: %w", err)
+		}
+		return nil
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return fmt.Errorf("read codex auth.json: %w", err)
+	}
 }
 
 func (codexAdapter) env(layout *demoLayout) []string {

--- a/internal/agentrunner/demo.go
+++ b/internal/agentrunner/demo.go
@@ -100,6 +100,7 @@ type agentAdapter interface {
 	name() string
 	isAvailable() error
 	writeConfig(*demoLayout) error
+	cleanup(*demoLayout) error
 	command(*demoLayout, string) ([]string, error)
 	env(*demoLayout) []string
 }
@@ -146,6 +147,11 @@ func (DemoRunner) RunDemo(ctx context.Context, opts *DemoOptions) (*DemoResult, 
 	if err := adapter.writeConfig(layout); err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := adapter.cleanup(layout); err != nil && options.Stderr != nil {
+			_, _ = fmt.Fprintf(options.Stderr, "warning: cleanup %s demo artifacts: %v\n", adapter.name(), err)
+		}
+	}()
 
 	centianCmd, errCh, err := startCentianProcess(layout, options)
 	if err != nil {

--- a/internal/agentrunner/demo.go
+++ b/internal/agentrunner/demo.go
@@ -24,10 +24,14 @@ const (
 	AgentClaude = "claude"
 	// AgentGemini is the supported public agent identifier for the Gemini CLI.
 	AgentGemini = "gemini"
+	// AgentCodex is the supported public agent identifier for the Codex CLI.
+	AgentCodex = "codex"
 	// DefaultClaudeModel is the default Claude model alias for demo runs.
 	DefaultClaudeModel = "sonnet"
 	// DefaultGeminiModel is the default Gemini model alias for demo runs.
 	DefaultGeminiModel = "gemini-2.5-flash"
+	// DefaultCodexModel is the default Codex model alias for demo runs (empty uses Codex default).
+	DefaultCodexModel = ""
 	// DefaultAgentTimeout is the default maximum runtime for a demo agent invocation.
 	DefaultAgentTimeout = 5 * time.Minute
 )
@@ -42,6 +46,8 @@ var disposableDemoPaths = []string{
 	"prompt.md",
 	"centian.pid",
 	"claude_mcp_config.json",
+	"codex-home",
+	"codex_output.txt",
 }
 
 var allowedDemoRootEntries = map[string]struct{}{
@@ -54,6 +60,8 @@ var allowedDemoRootEntries = map[string]struct{}{
 	"agent.stderr.log":       {},
 	"centian.pid":            {},
 	"claude_mcp_config.json": {},
+	"codex-home":             {},
+	"codex_output.txt":       {},
 	".DS_Store":              {},
 }
 
@@ -65,6 +73,7 @@ type DemoOptions struct {
 	Timeout           time.Duration
 	ClaudeModel       string
 	GeminiModel       string
+	CodexModel        string
 	OpenBrowser       bool
 	Stdout            io.Writer
 	Stderr            io.Writer
@@ -92,6 +101,7 @@ type agentAdapter interface {
 	isAvailable() error
 	writeConfig(*demoLayout) error
 	command(*demoLayout, string) ([]string, error)
+	env(*demoLayout) []string
 }
 
 type demoLayout struct {
@@ -108,6 +118,7 @@ type demoLayout struct {
 	PIDPath         string
 	ClaudeConfig    string
 	GeminiConfig    string
+	CodexConfig     string
 	BaseURL         string
 	MCPURL          string
 	Port            string
@@ -219,6 +230,7 @@ func prepareLayout(opts *DemoOptions) (*demoLayout, error) {
 		PIDPath:         filepath.Join(root, "centian.pid"),
 		ClaudeConfig:    filepath.Join(root, "claude_mcp_config.json"),
 		GeminiConfig:    filepath.Join(root, "workspace", ".gemini", "settings.json"),
+		CodexConfig:     filepath.Join(root, "codex-home", "config.toml"),
 	}
 	for _, dir := range []string{layout.RootPath, layout.WorkspacePath, layout.TemplatesPath, layout.LogsPath} {
 		if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -367,8 +379,10 @@ func selectAdapter(opts *DemoOptions) (agentAdapter, error) {
 		return claudeAdapter{model: opts.ClaudeModel}, nil
 	case AgentGemini:
 		return geminiAdapter{model: opts.GeminiModel}, nil
+	case AgentCodex:
+		return codexAdapter{model: opts.CodexModel}, nil
 	default:
-		return nil, fmt.Errorf("unsupported agent %q; v1 supports %q and %q only", opts.Agent, AgentClaude, AgentGemini)
+		return nil, fmt.Errorf("unsupported agent %q; v1 supports %q, %q, and %q", opts.Agent, AgentClaude, AgentGemini, AgentCodex)
 	}
 }
 
@@ -449,6 +463,9 @@ func runAgent(ctx context.Context, adapter agentAdapter, layout *demoLayout, opt
 	//nolint:gosec // The command is constructed by the selected internal agent adapter.
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	cmd.Dir = layout.WorkspacePath
+	if envVars := adapter.env(layout); len(envVars) > 0 {
+		cmd.Env = append(os.Environ(), envVars...)
+	}
 	cmd.Stdout = io.MultiWriter(stdoutFile, &stdout)
 	cmd.Stderr = io.MultiWriter(stderrFile, &stderr)
 	cmd.Stdin = strings.NewReader(loadPrompt(layout.PromptPath))

--- a/internal/agentrunner/demo_test.go
+++ b/internal/agentrunner/demo_test.go
@@ -17,6 +17,7 @@ type fakeAdapter struct {
 func (f fakeAdapter) name() string                { return f.agentName }
 func (fakeAdapter) isAvailable() error            { return nil }
 func (fakeAdapter) writeConfig(*demoLayout) error { return nil }
+func (fakeAdapter) cleanup(*demoLayout) error     { return nil }
 func (f fakeAdapter) command(layout *demoLayout, prompt string) ([]string, error) {
 	return f.commandFn(layout, prompt)
 }
@@ -551,6 +552,34 @@ func TestCodexWriteConfigCopiesAuthJSON(t *testing.T) {
 	}
 	if string(data) != `{"access_token":"test-token"}` {
 		t.Fatalf("unexpected auth.json contents: %s", string(data))
+	}
+}
+
+func TestCodexCleanupRemovesDemoHome(t *testing.T) {
+	// Given: a demo CODEX_HOME containing auth material and config
+	tmpDir := t.TempDir()
+	codexHome := filepath.Join(tmpDir, "codex-home")
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("mkdir codex home: %v", err)
+	}
+	for path, contents := range map[string]string{
+		filepath.Join(codexHome, "auth.json"):   `{"access_token":"test-token"}`,
+		filepath.Join(codexHome, "config.toml"): `model = "o3"`,
+	} {
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	layout := &demoLayout{CodexConfig: filepath.Join(codexHome, "config.toml")}
+
+	// When: cleaning up after the Codex run
+	if err := (codexAdapter{}).cleanup(layout); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+
+	// Then: the isolated demo home is removed
+	if _, err := os.Stat(codexHome); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed, got %v", codexHome, err)
 	}
 }
 

--- a/internal/agentrunner/demo_test.go
+++ b/internal/agentrunner/demo_test.go
@@ -519,6 +519,41 @@ func TestCodexWriteConfigNoModel(t *testing.T) {
 	}
 }
 
+func TestCodexWriteConfigCopiesAuthJSON(t *testing.T) {
+	// Given: a user Codex home with auth.json and a temporary demo layout
+	tmpDir := t.TempDir()
+	homeDir := filepath.Join(tmpDir, "home")
+	authPath := filepath.Join(homeDir, ".codex", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(authPath), 0o755); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.WriteFile(authPath, []byte(`{"access_token":"test-token"}`), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	t.Setenv("HOME", homeDir)
+
+	layout := &demoLayout{
+		MCPURL:        "http://127.0.0.1:12345/mcp/taskverification",
+		WorkspacePath: "/tmp/demo/workspace",
+		CodexConfig:   filepath.Join(tmpDir, "codex-home", "config.toml"),
+	}
+
+	// When: writing the demo Codex config
+	if err := (codexAdapter{model: "o3"}).writeConfig(layout); err != nil {
+		t.Fatalf("writeConfig: %v", err)
+	}
+
+	// Then: auth.json is copied into the isolated CODEX_HOME
+	copiedAuthPath := filepath.Join(filepath.Dir(layout.CodexConfig), "auth.json")
+	data, err := os.ReadFile(copiedAuthPath)
+	if err != nil {
+		t.Fatalf("read copied auth.json: %v", err)
+	}
+	if string(data) != `{"access_token":"test-token"}` {
+		t.Fatalf("unexpected auth.json contents: %s", string(data))
+	}
+}
+
 func TestSelectAdapterCodex(t *testing.T) {
 	// Given: demo options with agent "codex"
 	opts := &DemoOptions{Agent: "codex", CodexModel: "o3"}

--- a/internal/agentrunner/demo_test.go
+++ b/internal/agentrunner/demo_test.go
@@ -20,6 +20,7 @@ func (fakeAdapter) writeConfig(*demoLayout) error { return nil }
 func (f fakeAdapter) command(layout *demoLayout, prompt string) ([]string, error) {
 	return f.commandFn(layout, prompt)
 }
+func (fakeAdapter) env(*demoLayout) []string { return nil }
 
 func TestPrepareLayoutRejectsNonDemoNonEmptyDir(t *testing.T) {
 	allocateFreePortFunc = func() (string, error) { return "40123", nil }
@@ -395,12 +396,12 @@ func TestRunDemoUnsupportedAgent(t *testing.T) {
 	defer func() { allocateFreePortFunc = allocateFreePort }()
 
 	_, err := (DemoRunner{}).RunDemo(context.Background(), &DemoOptions{
-		Agent:             "codex",
+		Agent:             "unsupported-agent",
 		RootPath:          filepath.Join(t.TempDir(), "demo"),
 		CentianBinaryPath: "/tmp/centian",
 		Timeout:           time.Second,
 	})
-	if err == nil || !strings.Contains(err.Error(), "supports") {
+	if err == nil || !strings.Contains(err.Error(), "unsupported agent") {
 		t.Fatalf("expected unsupported agent error, got %v", err)
 	}
 }
@@ -413,5 +414,123 @@ func assertFileContains(t *testing.T, path, fragment string) {
 	}
 	if !strings.Contains(string(data), fragment) {
 		t.Fatalf("expected %q in %s", fragment, path)
+	}
+}
+
+func TestCodexCommandConstruction(t *testing.T) {
+	// Given: a Codex adapter with a demo layout
+	layout := &demoLayout{
+		WorkspacePath: "/tmp/demo/workspace",
+		RootPath:      "/tmp/demo",
+		CodexConfig:   "/tmp/demo/codex-home/config.toml",
+	}
+
+	// When: constructing the command
+	command, err := codexAdapter{}.command(layout, "prompt")
+	if err != nil {
+		t.Fatalf("command: %v", err)
+	}
+
+	// Then: the command includes expected Codex flags
+	joined := strings.Join(command, " ")
+	for _, expected := range []string{
+		"codex",
+		"exec",
+		"--skip-git-repo-check",
+		"--json",
+		"-C /tmp/demo/workspace",
+		"-o /tmp/demo/codex_output.txt",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("expected %q in command %q", expected, joined)
+		}
+	}
+
+	// Then: no dangerous bypass flags are present
+	for _, forbidden := range []string{"--full-auto", "--dangerously-bypass-approvals-and-sandbox"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("unexpected unsafe flag %q in %q", forbidden, joined)
+		}
+	}
+}
+
+func TestCodexEnvSetsCODEXHOME(t *testing.T) {
+	// Given: a Codex adapter with a layout
+	layout := &demoLayout{
+		CodexConfig: "/tmp/demo/codex-home/config.toml",
+	}
+
+	// When: requesting env vars
+	envVars := codexAdapter{}.env(layout)
+
+	// Then: CODEX_HOME points to the parent of the config file
+	if len(envVars) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(envVars))
+	}
+	if envVars[0] != "CODEX_HOME=/tmp/demo/codex-home" {
+		t.Fatalf("expected CODEX_HOME=/tmp/demo/codex-home, got %q", envVars[0])
+	}
+}
+
+func TestCodexWriteConfig(t *testing.T) {
+	// Given: a Codex adapter and a temporary layout
+	tmpDir := t.TempDir()
+	layout := &demoLayout{
+		MCPURL:        "http://127.0.0.1:12345/mcp/taskverification",
+		WorkspacePath: "/tmp/demo/workspace",
+		CodexConfig:   filepath.Join(tmpDir, "codex-home", "config.toml"),
+	}
+
+	// When: writing the config
+	err := codexAdapter{model: "o3"}.writeConfig(layout)
+	if err != nil {
+		t.Fatalf("writeConfig: %v", err)
+	}
+
+	// Then: the config file is written with placeholders replaced
+	assertFileContains(t, layout.CodexConfig, `url = "http://127.0.0.1:12345/mcp/taskverification"`)
+	assertFileContains(t, layout.CodexConfig, `model = "o3"`)
+	assertFileContains(t, layout.CodexConfig, "/tmp/demo/workspace")
+	assertFileContains(t, layout.CodexConfig, `default_tools_approval_mode = "auto"`)
+}
+
+func TestCodexWriteConfigNoModel(t *testing.T) {
+	// Given: a Codex adapter without a model
+	tmpDir := t.TempDir()
+	layout := &demoLayout{
+		MCPURL:        "http://127.0.0.1:12345/mcp/taskverification",
+		WorkspacePath: "/tmp/demo/workspace",
+		CodexConfig:   filepath.Join(tmpDir, "codex-home", "config.toml"),
+	}
+
+	// When: writing the config with empty model
+	err := codexAdapter{model: ""}.writeConfig(layout)
+	if err != nil {
+		t.Fatalf("writeConfig: %v", err)
+	}
+
+	// Then: no model line appears
+	data, err := os.ReadFile(layout.CodexConfig)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(data), "model =") {
+		t.Fatalf("expected no model line, got:\n%s", string(data))
+	}
+}
+
+func TestSelectAdapterCodex(t *testing.T) {
+	// Given: demo options with agent "codex"
+	opts := &DemoOptions{Agent: "codex", CodexModel: "o3"}
+
+	// When: selecting the adapter
+	adapter, err := selectAdapter(opts)
+
+	// Then: a codex adapter is returned
+	if err != nil {
+		t.Fatalf("selectAdapter: %v", err)
+	}
+	if adapter.name() != AgentCodex {
+		t.Fatalf("expected codex adapter, got %q", adapter.name())
 	}
 }

--- a/internal/agentrunner/gemini.go
+++ b/internal/agentrunner/gemini.go
@@ -45,6 +45,8 @@ func (g geminiAdapter) writeConfig(layout *demoLayout) error {
 
 func (geminiAdapter) env(*demoLayout) []string { return nil }
 
+func (geminiAdapter) cleanup(*demoLayout) error { return nil }
+
 func (g geminiAdapter) command(_ *demoLayout, prompt string) ([]string, error) {
 	command := []string{
 		"gemini",

--- a/internal/agentrunner/gemini.go
+++ b/internal/agentrunner/gemini.go
@@ -43,6 +43,8 @@ func (g geminiAdapter) writeConfig(layout *demoLayout) error {
 	return nil
 }
 
+func (geminiAdapter) env(*demoLayout) []string { return nil }
+
 func (g geminiAdapter) command(_ *demoLayout, prompt string) ([]string, error) {
 	command := []string{
 		"gemini",

--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -32,7 +32,7 @@ Examples:
 		&cli.StringFlag{
 			Name:     "agent",
 			Aliases:  []string{"a"},
-			Usage:    "Agent to run for the demo (v1 supports: claude, gemini)",
+			Usage:    "Agent to run for the demo (v1 supports: claude, gemini, codex)",
 			Required: true,
 		},
 		&cli.StringFlag{
@@ -64,6 +64,7 @@ func handleDemoCommand(ctx context.Context, cmd *cli.Command) error {
 		Timeout:           5 * time.Minute,
 		ClaudeModel:       agentrunner.DefaultClaudeModel,
 		GeminiModel:       agentrunner.DefaultGeminiModel,
+		CodexModel:        agentrunner.DefaultCodexModel,
 		Stdout:            os.Stdout,
 		Stderr:            os.Stderr,
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -345,10 +345,10 @@ func (p *ProxySettings) UIEnabled() bool {
 
 // GatewayConfig represents a logical grouping of HTTP MCP servers.
 type GatewayConfig struct {
-	AllowDynamic         bool                        `json:"allowDynamic,omitempty"`         // Allow dynamic proxy endpoints
-	AllowGatewayEndpoint bool                        `json:"setupGateway,omitempty"`         // Setup gateway endpoint with namespacing
-	ForceReadOnlyHints   *bool                       `json:"forceReadOnlyHints,omitempty"`   // Override all tool annotations to readOnlyHint=true
-	MCPServers           map[string]*MCPServerConfig `json:"mcpServers"`                     // HTTP MCP servers in this gateway
+	AllowDynamic         bool                        `json:"allowDynamic,omitempty"`       // Allow dynamic proxy endpoints
+	AllowGatewayEndpoint bool                        `json:"setupGateway,omitempty"`       // Setup gateway endpoint with namespacing
+	ForceReadOnlyHints   *bool                       `json:"forceReadOnlyHints,omitempty"` // Override all tool annotations to readOnlyHint=true
+	MCPServers           map[string]*MCPServerConfig `json:"mcpServers"`                   // HTTP MCP servers in this gateway
 	Processors           []*ProcessorConfig          `json:"processors,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -345,9 +345,10 @@ func (p *ProxySettings) UIEnabled() bool {
 
 // GatewayConfig represents a logical grouping of HTTP MCP servers.
 type GatewayConfig struct {
-	AllowDynamic         bool                        `json:"allowDynamic,omitempty"` // Allow dynamic proxy endpoints
-	AllowGatewayEndpoint bool                        `json:"setupGateway,omitempty"` // Setup gateway endpoint with namespacing
-	MCPServers           map[string]*MCPServerConfig `json:"mcpServers"`             // HTTP MCP servers in this gateway
+	AllowDynamic         bool                        `json:"allowDynamic,omitempty"`         // Allow dynamic proxy endpoints
+	AllowGatewayEndpoint bool                        `json:"setupGateway,omitempty"`         // Setup gateway endpoint with namespacing
+	ForceReadOnlyHints   *bool                       `json:"forceReadOnlyHints,omitempty"`   // Override all tool annotations to readOnlyHint=true
+	MCPServers           map[string]*MCPServerConfig `json:"mcpServers"`                     // HTTP MCP servers in this gateway
 	Processors           []*ProcessorConfig          `json:"processors,omitempty"`
 }
 
@@ -381,6 +382,12 @@ func (g *GatewayConfig) HasServer(name string) bool {
 		}
 	}
 	return false
+}
+
+// ForceReadOnlyHintsEnabled reports whether all tool annotations should be
+// overridden to readOnlyHint=true for this gateway. Defaults to false.
+func (g *GatewayConfig) ForceReadOnlyHintsEnabled() bool {
+	return g != nil && g.ForceReadOnlyHints != nil && *g.ForceReadOnlyHints
 }
 
 //////// PROCESSOR CONFIG STRUCTS ///////.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,3 +87,35 @@ func TestConfigLifecycle(t *testing.T) {
 	t.Logf("Configuration lifecycle test completed successfully")
 	t.Logf("Config file location: %s", configPath)
 }
+
+func TestGatewayConfigForceReadOnlyHintsEnabled(t *testing.T) {
+	// Given: nil gateway config
+	// Then: returns false
+	var nilGateway *GatewayConfig
+	if nilGateway.ForceReadOnlyHintsEnabled() {
+		t.Fatal("expected false for nil gateway")
+	}
+
+	// Given: gateway with nil ForceReadOnlyHints
+	// Then: returns false
+	gateway := &GatewayConfig{}
+	if gateway.ForceReadOnlyHintsEnabled() {
+		t.Fatal("expected false for nil ForceReadOnlyHints")
+	}
+
+	// Given: gateway with ForceReadOnlyHints=false
+	// Then: returns false
+	f := false
+	gateway.ForceReadOnlyHints = &f
+	if gateway.ForceReadOnlyHintsEnabled() {
+		t.Fatal("expected false for ForceReadOnlyHints=false")
+	}
+
+	// Given: gateway with ForceReadOnlyHints=true
+	// Then: returns true
+	tr := true
+	gateway.ForceReadOnlyHints = &tr
+	if !gateway.ForceReadOnlyHintsEnabled() {
+		t.Fatal("expected true for ForceReadOnlyHints=true")
+	}
+}

--- a/internal/proxy/proxy_auth_tools.go
+++ b/internal/proxy/proxy_auth_tools.go
@@ -81,16 +81,21 @@ func (p *CentianEndpoint) registerStaticProxyTools(session *UpstreamSession, ser
 	if p.taskVerificationToolsEnabled() {
 		p.registerTaskVerificationTools(session, server)
 	}
+	forceRO := p.config.ForceReadOnlyHintsEnabled()
 	if p.hasOAuthDownstreams() {
 		if _, exists := session.registeredStaticTools[authStatusToolName]; !exists {
-			server.AddTool(&mcp.Tool{
+			authTool := &mcp.Tool{
 				Name:        authStatusToolName,
 				Description: "Show downstream OAuth connection state for this Centian endpoint.",
 				InputSchema: map[string]any{
 					"type":       "object",
 					"properties": map[string]any{},
 				},
-			}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			}
+			if forceRO {
+				applyForceReadOnlyHints(authTool)
+			}
+			server.AddTool(authTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 				return p.handleAuthStatusTool(ctx, session, req)
 			})
 			session.registeredStaticTools[authStatusToolName] = struct{}{}
@@ -102,7 +107,7 @@ func (p *CentianEndpoint) registerStaticProxyTools(session *UpstreamSession, ser
 	if _, exists := session.registeredStaticTools[testNotificationsTool]; exists {
 		return
 	}
-	server.AddTool(&mcp.Tool{
+	notifTool := &mcp.Tool{
 		Name:        testNotificationsTool,
 		Description: "Emit test log notifications on a timer for this session.",
 		InputSchema: map[string]any{
@@ -118,7 +123,11 @@ func (p *CentianEndpoint) registerStaticProxyTools(session *UpstreamSession, ser
 				},
 			},
 		},
-	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	}
+	if forceRO {
+		applyForceReadOnlyHints(notifTool)
+	}
+	server.AddTool(notifTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return p.handleTestNotificationsTool(ctx, session, req)
 	})
 	session.registeredStaticTools[testNotificationsTool] = struct{}{}
@@ -342,14 +351,18 @@ func (p *CentianEndpoint) registerLoginTool(session *UpstreamSession, serverName
 		return
 	}
 	session.registeredTools[name] = struct{}{}
-	session.upstreamServer.AddTool(&mcp.Tool{
+	loginTool := &mcp.Tool{
 		Name:        name,
 		Description: fmt.Sprintf("Start or resume login for downstream %s.", serverName),
 		InputSchema: map[string]any{
 			"type":       "object",
 			"properties": map[string]any{},
 		},
-	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	}
+	if p.config.ForceReadOnlyHintsEnabled() {
+		applyForceReadOnlyHints(loginTool)
+	}
+	session.upstreamServer.AddTool(loginTool, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return p.handleLoginTool(ctx, session, serverName, req)
 	})
 }

--- a/internal/proxy/proxy_taskverification_tools.go
+++ b/internal/proxy/proxy_taskverification_tools.go
@@ -56,7 +56,17 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 		return
 	}
 
-	server.AddTool(&mcp.Tool{
+	forceRO := p.config.ForceReadOnlyHintsEnabled()
+
+	addTaskTool := func(tool *mcp.Tool, name string, handler taskToolHandler) {
+		if forceRO {
+			applyForceReadOnlyHints(tool)
+		}
+		server.AddTool(tool, p.wrapTaskToolHandler(session, name, handler))
+		session.registeredStaticTools[name] = struct{}{}
+	}
+
+	addTaskTool(&mcp.Tool{
 		Name:        taskListTemplatesTool,
 		Description: taskToolDescription("List available task verification templates."),
 		Annotations: taskReadOnlyAnnotations(),
@@ -64,10 +74,9 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 			"type":       "object",
 			"properties": map[string]any{},
 		},
-	}, p.wrapTaskToolHandler(session, taskListTemplatesTool, p.handleTaskListTemplatesTool))
-	session.registeredStaticTools[taskListTemplatesTool] = struct{}{}
+	}, taskListTemplatesTool, p.handleTaskListTemplatesTool)
 
-	server.AddTool(&mcp.Tool{
+	addTaskTool(&mcp.Tool{
 		Name:        taskRegisterTool,
 		Description: taskToolDescription("Register a task verification run from a template."),
 		Annotations: taskStateTransitionAnnotations(),
@@ -78,26 +87,23 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 			},
 			"required": []string{"templateId"},
 		},
-	}, p.wrapTaskToolHandler(session, taskRegisterTool, p.handleTaskRegisterTool))
-	session.registeredStaticTools[taskRegisterTool] = struct{}{}
+	}, taskRegisterTool, p.handleTaskRegisterTool)
 
-	server.AddTool(&mcp.Tool{
+	addTaskTool(&mcp.Tool{
 		Name:        taskCompleteOnboardingTool,
 		Description: taskToolDescription("Persist onboarding context and advance the task into planning."),
 		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: taskCompleteOnboardingSchema(),
-	}, p.wrapTaskToolHandler(session, taskCompleteOnboardingTool, p.handleTaskCompleteOnboardingTool))
-	session.registeredStaticTools[taskCompleteOnboardingTool] = struct{}{}
+	}, taskCompleteOnboardingTool, p.handleTaskCompleteOnboardingTool)
 
-	server.AddTool(&mcp.Tool{
+	addTaskTool(&mcp.Tool{
 		Name:        taskCompletePlanningTool,
 		Description: taskToolDescription("Persist planning context, freeze the execution contract, and enter execution. planning.parameters must contain every required planning parameter before execution can begin, and Centian enforces that contract."),
 		Annotations: taskStateTransitionAnnotations(),
 		InputSchema: taskCompletePlanningSchema(),
-	}, p.wrapTaskToolHandler(session, taskCompletePlanningTool, p.handleTaskCompletePlanningTool))
-	session.registeredStaticTools[taskCompletePlanningTool] = struct{}{}
+	}, taskCompletePlanningTool, p.handleTaskCompletePlanningTool)
 
-	server.AddTool(&mcp.Tool{
+	addTaskTool(&mcp.Tool{
 		Name:        taskStartStepTool,
 		Description: taskToolDescription("Start a task step by running preconditions and capturing invariant baselines."),
 		Annotations: taskStateTransitionAnnotations(),
@@ -108,10 +114,9 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 			},
 			"required": []string{"step"},
 		},
-	}, p.wrapTaskToolHandler(session, taskStartStepTool, p.handleTaskStartStepTool))
-	session.registeredStaticTools[taskStartStepTool] = struct{}{}
+	}, taskStartStepTool, p.handleTaskStartStepTool)
 
-	server.AddTool(&mcp.Tool{
+	addTaskTool(&mcp.Tool{
 		Name:        taskCompleteStepTool,
 		Description: taskToolDescription("Complete a task step by running postconditions and invariant checks."),
 		Annotations: taskStateTransitionAnnotations(),
@@ -122,10 +127,9 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 			},
 			"required": []string{"step"},
 		},
-	}, p.wrapTaskToolHandler(session, taskCompleteStepTool, p.handleTaskCompleteStepTool))
-	session.registeredStaticTools[taskCompleteStepTool] = struct{}{}
+	}, taskCompleteStepTool, p.handleTaskCompleteStepTool)
 
-	server.AddTool(&mcp.Tool{
+	addTaskTool(&mcp.Tool{
 		Name:        taskResumeTool,
 		Description: taskToolDescription("Resume a timed-out task verification run without resetting workflow progress."),
 		Annotations: taskStateTransitionAnnotations(),
@@ -133,10 +137,9 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 			"type":       "object",
 			"properties": map[string]any{},
 		},
-	}, p.wrapTaskToolHandler(session, taskResumeTool, p.handleTaskResumeTool))
-	session.registeredStaticTools[taskResumeTool] = struct{}{}
+	}, taskResumeTool, p.handleTaskResumeTool)
 
-	server.AddTool(&mcp.Tool{
+	addTaskTool(&mcp.Tool{
 		Name:        taskRestartTool,
 		Description: taskToolDescription("Restart the active task verification run and clear step state."),
 		Annotations: taskStateTransitionAnnotations(),
@@ -144,10 +147,9 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 			"type":       "object",
 			"properties": map[string]any{},
 		},
-	}, p.wrapTaskToolHandler(session, taskRestartTool, p.handleTaskRestartTool))
-	session.registeredStaticTools[taskRestartTool] = struct{}{}
+	}, taskRestartTool, p.handleTaskRestartTool)
 
-	server.AddTool(&mcp.Tool{
+	addTaskTool(&mcp.Tool{
 		Name:        taskFailTool,
 		Description: taskToolDescription("Explicitly fail the active task verification run."),
 		Annotations: taskStateTransitionAnnotations(),
@@ -157,8 +159,7 @@ func (p *CentianEndpoint) registerTaskVerificationTools(session *UpstreamSession
 				"reason": map[string]any{"type": "string"},
 			},
 		},
-	}, p.wrapTaskToolHandler(session, taskFailTool, p.handleTaskFailTool))
-	session.registeredStaticTools[taskFailTool] = struct{}{}
+	}, taskFailTool, p.handleTaskFailTool)
 }
 
 func taskToolDescription(base string) string {

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -1923,3 +1923,47 @@ func bytesSplitLines(data []byte) [][]byte {
 	}
 	return lines
 }
+
+func TestForceReadOnlyHintsOverridesAllTaskToolAnnotations(t *testing.T) {
+	// Given: a proxy endpoint with ForceReadOnlyHints enabled
+	forceRO := true
+	endpoint, session := newTaskToolTestProxy(t, basicTaskTemplate())
+	endpoint.config.ForceReadOnlyHints = &forceRO
+
+	// When: re-registering tools with the flag (clear previous registrations first)
+	session.registeredStaticTools = make(map[string]struct{})
+	session.upstreamServer = endpoint.newUpstreamServer(session)
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	result, err := clientSession.ListTools(context.Background(), nil)
+	assert.NilError(t, err)
+
+	// Then: all task verification tools have ReadOnlyHint=true
+	byName := make(map[string]*mcp.Tool, len(result.Tools))
+	for _, tool := range result.Tools {
+		if tool == nil {
+			continue
+		}
+		byName[tool.Name] = tool
+	}
+
+	allTaskTools := []string{
+		taskListTemplatesTool,
+		taskRegisterTool,
+		taskCompleteOnboardingTool,
+		taskCompletePlanningTool,
+		taskStartStepTool,
+		taskCompleteStepTool,
+		taskResumeTool,
+		taskRestartTool,
+		taskFailTool,
+	}
+	for _, toolName := range allTaskTools {
+		tool := byName[toolName]
+		assert.Assert(t, tool != nil, "missing tool: %s", toolName)
+		assert.Assert(t, tool.Annotations != nil, "nil annotations on %s", toolName)
+		assert.Equal(t, tool.Annotations.ReadOnlyHint, true, "expected ReadOnlyHint=true on %s", toolName)
+	}
+}

--- a/internal/proxy/proxy_tools.go
+++ b/internal/proxy/proxy_tools.go
@@ -225,6 +225,9 @@ func (p *CentianEndpoint) registerTool(session *UpstreamSession, serverName stri
 	}
 
 	clonedTool := copyToolForRegistration(tool)
+	if p.config.ForceReadOnlyHintsEnabled() {
+		applyForceReadOnlyHints(clonedTool)
+	}
 	toolServerName := serverName
 	if p.isAggregatedProxy {
 		clonedTool.Name = fmt.Sprintf("%s%s%s", serverName, NamespaceSeparator, tool.Name)

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -243,6 +243,16 @@ func sanitizeLogValue(value string) string {
 	return strings.TrimSpace(sanitized)
 }
 
+// applyForceReadOnlyHints overrides a tool's annotations so that it appears
+// read-only to upstream clients. Used when the gateway's ForceReadOnlyHints
+// flag is enabled (e.g. for Codex demo runs where Centian is the trust boundary).
+func applyForceReadOnlyHints(tool *mcp.Tool) {
+	if tool.Annotations == nil {
+		tool.Annotations = &mcp.ToolAnnotations{}
+	}
+	tool.Annotations.ReadOnlyHint = true
+}
+
 func copyToolForRegistration(tool *mcp.Tool) *mcp.Tool {
 	return &mcp.Tool{
 		Name:         tool.Name,

--- a/internal/proxy/proxy_types_test.go
+++ b/internal/proxy/proxy_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/T4cceptor/centian/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"gotest.tools/assert"
 )
 
@@ -44,4 +45,41 @@ func TestDownstreamSessionPoolHasActiveConnectWorker(t *testing.T) {
 	assert.Assert(t, pool.HasActiveConnectWorker("server-a"))
 	assert.Assert(t, !pool.HasActiveConnectWorker("server-b"))
 	assert.Assert(t, !pool.HasActiveConnectWorker("missing"))
+}
+
+func TestApplyForceReadOnlyHintsNilAnnotations(t *testing.T) {
+	// Given: a tool with nil annotations
+	tool := &mcp.Tool{Name: "test-tool"}
+
+	// When: applying force read-only hints
+	applyForceReadOnlyHints(tool)
+
+	// Then: annotations are created with ReadOnlyHint=true
+	assert.Assert(t, tool.Annotations != nil)
+	assert.Equal(t, tool.Annotations.ReadOnlyHint, true)
+}
+
+func TestApplyForceReadOnlyHintsPreservesExistingFields(t *testing.T) {
+	// Given: a tool with existing annotations (destructive=false, open-world=false)
+	destructive := false
+	openWorld := false
+	tool := &mcp.Tool{
+		Name: "test-tool",
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: &destructive,
+			OpenWorldHint:   &openWorld,
+			IdempotentHint:  true,
+		},
+	}
+
+	// When: applying force read-only hints
+	applyForceReadOnlyHints(tool)
+
+	// Then: ReadOnlyHint is set and other fields are preserved
+	assert.Equal(t, tool.Annotations.ReadOnlyHint, true)
+	assert.Equal(t, tool.Annotations.IdempotentHint, true)
+	assert.Assert(t, tool.Annotations.DestructiveHint != nil)
+	assert.Equal(t, *tool.Annotations.DestructiveHint, false)
+	assert.Assert(t, tool.Annotations.OpenWorldHint != nil)
+	assert.Equal(t, *tool.Annotations.OpenWorldHint, false)
 }


### PR DESCRIPTION
Codex auto-approves only MCP tools annotated with readOnlyHint=true,
regardless of its TOML config settings. Since Centian is the trust
boundary for demo runs, this adds a per-gateway ForceReadOnlyHints
config flag that overrides all tool annotations to readOnlyHint=true
at registration time (both downstream proxied tools and Centian's own
task verification/auth tools).

Also adds a Codex adapter to the demo runner, following the existing
Claude/Gemini adapter pattern, with CODEX_HOME env var support via a
new env() method on the agentAdapter interface.

https://claude.ai/code/session_01YRS2hfuvSeMaxN1BF5tvmX