### PR TITLE
Improving AX, condensing error and success messages to avoid context …

### DIFF
--- a/docs/TASKVERIFICATION.md
+++ b/docs/TASKVERIFICATION.md
@@ -169,6 +169,14 @@ The current taskverification MCP tools are:
 
 These tools are injected as static proxy-owned tools on the Centian endpoint when `taskVerification.enabled` is true.
 
+Response-shape guidance:
+
+- `centian.task_complete_planning` is the rich execution handoff and returns the frozen execution contract summary plus the next actionable step contract
+- lifecycle tools such as register, onboarding completion, resume, restart, and fail return compact workflow state instead of the full task snapshot
+- `centian.task_start_step` and `centian.task_complete_step` return step-local context on success and compact diagnostics on failure
+- failed step actions are retryable in place unless the response explicitly says restart is required
+- `recoveryActions` is the canonical structured recovery field for failed step actions; `nextAction` mirrors the first recovery action summary
+
 ## Runtime Model
 
 ### Task run
@@ -301,6 +309,7 @@ That next node may be:
 - validates the active workflow node
 - runs preconditions
 - captures invariant baselines
+- leaves the step retryable in place when verification fails before activation
 
 `centian.task_complete_step`:
 
@@ -308,6 +317,7 @@ That next node may be:
 - verifies invariants
 - advances to the next workflow node
 - marks the task completed if there is no next node
+- keeps the step retryable in place when verification fails after activation
 
 ### 5. Resume, restart, and fail
 

--- a/internal/proxy/proxy_task_events.go
+++ b/internal/proxy/proxy_task_events.go
@@ -122,5 +122,14 @@ func stepEventPayload(result *taskverification.StepResult) map[string]any {
 	if result.FailedInvariantID != "" {
 		payload["failedInvariantId"] = result.FailedInvariantID
 	}
+	if result.Retryable {
+		payload["retryable"] = result.Retryable
+	}
+	if result.RestartRequired {
+		payload["restartRequired"] = result.RestartRequired
+	}
+	if len(result.RecoveryActions) > 0 {
+		payload["recoveryActions"] = result.RecoveryActions
+	}
 	return payload
 }

--- a/internal/proxy/proxy_taskverification_tools.go
+++ b/internal/proxy/proxy_taskverification_tools.go
@@ -426,13 +426,10 @@ func (p *CentianEndpoint) handleTaskListTemplatesTool(_ context.Context, _ *Upst
 	for _, template := range templates {
 		lines = append(lines, fmt.Sprintf("%s (%d steps)", template.ID, template.StepCount))
 		structured = append(structured, map[string]any{
-			"id":           template.ID,
-			"name":         template.Name,
-			"description":  template.Description,
-			"instructions": template.Instructions,
-			"parameters":   template.Parameters,
-			"stepCount":    template.StepCount,
-			"steps":        template.Steps,
+			"id":          template.ID,
+			"name":        template.Name,
+			"description": template.Description,
+			"stepCount":   template.StepCount,
 		})
 	}
 	if len(lines) == 0 {
@@ -478,9 +475,8 @@ func (p *CentianEndpoint) handleTaskRegisterTool(ctx context.Context, session *U
 	sourcePhase, sourceNodeKind := taskPhaseSnapshot(run)
 	p.recordTaskEvent(session, run, sourcePhase, sourceNodeKind, sourcePhase, sourceNodeKind, taskverification.TaskEventTypeRegistered, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
 
-	structured := runStructuredContent(run, p.server.TaskVerification.WorkingDir)
+	structured := lifecycleStructuredContent(run, p.server.TaskVerification.WorkingDir)
 	stepCount := len(run.SelectedTemplate.CompiledWorkflow.WorkflowSteps)
-	structured["stepCount"] = stepCount
 	return toolResult(fmt.Sprintf("Registered task %s with %d declared step(s).", run.TemplateID, stepCount), structured), nil
 }
 
@@ -504,10 +500,7 @@ func (p *CentianEndpoint) handleTaskCompleteOnboardingTool(ctx context.Context, 
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeOnboardingCompleted, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), map[string]any{
 		"taskSummary": args.Onboarding.TaskSummary,
 	})
-	structured := runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)
-	if session.taskRun.Onboarding != nil {
-		structured["onboarding"] = session.taskRun.Onboarding
-	}
+	structured := onboardingStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)
 	return toolResult("Task onboarding completed; task moved to planning.", structured), nil
 }
 
@@ -539,10 +532,7 @@ func (p *CentianEndpoint) handleTaskCompletePlanningTool(ctx context.Context, se
 	if node, exists := session.taskRun.CurrentNode(); exists && node.Kind == taskverification.WorkflowNodeKindWaitingForApproval {
 		p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeApprovalWaitEntered, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
 	}
-	structured := runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)
-	if session.taskRun.Planning != nil {
-		structured["planning"] = session.taskRun.Planning
-	}
+	structured := planningCompletionStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)
 	return toolResult(fmt.Sprintf("Task planning completed; task moved to %s.", session.taskRun.Phase), structured), nil
 }
 
@@ -618,7 +608,7 @@ func (p *CentianEndpoint) handleTaskStartStepTool(ctx context.Context, session *
 	}
 	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeStepStarted, outcome, taskActionRequestIDFromContext(ctx), stepEventPayload(result))
-	return stepToolResult(result, session.taskRun, p.server.TaskVerification.WorkingDir, taskStartStepTool), nil
+	return stepToolResult(result, session.taskRun, p.server.TaskVerification.WorkingDir), nil
 }
 
 func (p *CentianEndpoint) handleTaskCompleteStepTool(ctx context.Context, session *UpstreamSession, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -650,7 +640,7 @@ func (p *CentianEndpoint) handleTaskCompleteStepTool(ctx context.Context, sessio
 			p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeApprovalWaitEntered, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
 		}
 	}
-	return stepToolResult(result, session.taskRun, p.server.TaskVerification.WorkingDir, taskCompleteStepTool), nil
+	return stepToolResult(result, session.taskRun, p.server.TaskVerification.WorkingDir), nil
 }
 
 func (p *CentianEndpoint) handleTaskResumeTool(ctx context.Context, session *UpstreamSession, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -666,7 +656,7 @@ func (p *CentianEndpoint) handleTaskResumeTool(ctx context.Context, session *Ups
 	}
 	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeResumed, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
-	return toolResult("Task resumed.", runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
+	return toolResult("Task resumed.", lifecycleStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
 }
 
 func (p *CentianEndpoint) handleTaskRestartTool(ctx context.Context, session *UpstreamSession, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -682,7 +672,7 @@ func (p *CentianEndpoint) handleTaskRestartTool(ctx context.Context, session *Up
 	}
 	resultingPhase, resultingNodeKind := taskPhaseSnapshot(session.taskRun)
 	p.recordTaskEvent(session, session.taskRun, sourcePhase, sourceNodeKind, resultingPhase, resultingNodeKind, taskverification.TaskEventTypeRestarted, taskverification.TaskEventOutcomeSucceeded, taskActionRequestIDFromContext(ctx), nil)
-	return toolResult("Task restarted.", runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
+	return toolResult("Task restarted.", lifecycleStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
 }
 
 func (p *CentianEndpoint) handleTaskFailTool(ctx context.Context, session *UpstreamSession, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -710,7 +700,7 @@ func (p *CentianEndpoint) handleTaskFailTool(ctx context.Context, session *Upstr
 	if strings.TrimSpace(args.Reason) != "" {
 		message = fmt.Sprintf("Task failed: %s", strings.TrimSpace(args.Reason))
 	}
-	return toolResult(message, runStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
+	return toolResult(message, lifecycleStructuredContent(session.taskRun, p.server.TaskVerification.WorkingDir)), nil
 }
 
 func decodeToolArguments(req *mcp.CallToolRequest, target any) error {
@@ -733,8 +723,8 @@ func toolResult(message string, structured map[string]any) *mcp.CallToolResult {
 	}
 }
 
-func stepToolResult(result *taskverification.StepResult, run *taskverification.RunState, workingDir, actionTool string) *mcp.CallToolResult {
-	structured := runStructuredContent(run, workingDir)
+func stepToolResult(result *taskverification.StepResult, run *taskverification.RunState, workingDir string) *mcp.CallToolResult {
+	structured := stepStructuredContent(run, workingDir)
 	structured["passed"] = result.Passed
 	structured["message"] = result.Message
 	structured["step"] = result.Step
@@ -757,6 +747,15 @@ func stepToolResult(result *taskverification.StepResult, run *taskverification.R
 	if result.FailedInvariantID != "" {
 		structured["failedInvariantId"] = result.FailedInvariantID
 	}
+	if result.Retryable {
+		structured["retryable"] = result.Retryable
+	}
+	if result.RestartRequired {
+		structured["restartRequired"] = result.RestartRequired
+	}
+	if len(result.RecoveryActions) > 0 {
+		structured["recoveryActions"] = recoveryActionsStructuredContent(result.RecoveryActions)
+	}
 	if result.ExitCode != nil {
 		structured["exitCode"] = *result.ExitCode
 	}
@@ -766,11 +765,11 @@ func stepToolResult(result *taskverification.StepResult, run *taskverification.R
 	if result.StderrSnippet != "" {
 		structured["stderrSnippet"] = result.StderrSnippet
 	}
-	structured["nextAction"] = nextActionForStepResult(result, run, actionTool)
+	structured["nextAction"] = nextActionForStepResult(result, run)
 	return toolResult(result.Message, structured)
 }
 
-func runStructuredContent(run *taskverification.RunState, workingDir string) map[string]any {
+func lifecycleStructuredContent(run *taskverification.RunState, workingDir string) map[string]any {
 	if run == nil {
 		structured := map[string]any{}
 		addWorkspaceContext(structured, workingDir)
@@ -778,38 +777,22 @@ func runStructuredContent(run *taskverification.RunState, workingDir string) map
 	}
 
 	structured := map[string]any{
-		"taskRunId":                  run.RunID,
-		"templateId":                 run.TemplateID,
-		"templateName":               run.SelectedTemplate.Task.Name,
-		"description":                run.SelectedTemplate.Task.Description,
-		"instructions":               run.SelectedTemplate.Task.Instructions,
-		"status":                     string(run.Status),
-		"phase":                      string(run.Phase),
-		"hasOnboarding":              run.Onboarding != nil,
-		"hasPlanning":                run.Planning != nil,
-		"executionReady":             run.WorkflowReady,
-		"stepCount":                  len(run.SelectedTemplate.CompiledWorkflow.WorkflowSteps),
-		"lastFailureMessage":         run.LastFailureMessage,
-		"explicitFailReason":         run.ExplicitFailReason,
-		"parameterDefinitions":       run.SelectedTemplate.ParameterDefinitions(),
-		"requiredInputs":             run.SelectedTemplate.ParameterDefinitions(),
-		"requiredInputNames":         run.SelectedTemplate.RequiredParameterNames(),
-		"requiredPlanningParameters": requiredPlanningParameters(run.SelectedTemplate.ParameterDefinitions()),
+		"taskRunId":      run.RunID,
+		"templateId":     run.TemplateID,
+		"templateName":   run.SelectedTemplate.Task.Name,
+		"status":         string(run.Status),
+		"phase":          string(run.Phase),
+		"hasOnboarding":  run.Onboarding != nil,
+		"hasPlanning":    run.Planning != nil,
+		"executionReady": run.WorkflowReady,
+	}
+	if strings.TrimSpace(run.ExplicitFailReason) != "" {
+		structured["explicitFailReason"] = run.ExplicitFailReason
 	}
 	addTaskTimingFields(structured, run)
 	addWorkspaceContext(structured, workingDir)
-	addTaskContracts(structured)
 	addCurrentNodeContext(structured, run)
-	addPlanningNodeContext(structured, run)
-	addArtifactSummaries(structured, run)
 	structured["nextAction"] = nextActionForRun(run)
-
-	if !run.WorkflowReady || run.RunnableTemplate == nil {
-		return structured
-	}
-
-	structured["steps"] = workflowStepsSummary(run)
-	addStepContract(structured, run)
 	return structured
 }
 
@@ -822,10 +805,85 @@ func addWorkspaceContext(structured map[string]any, workingDir string) {
 	structured["commandWorkingDirectory"] = workingDir
 }
 
-func addTaskContracts(structured map[string]any) {
-	structured["onboardingContract"] = onboardingContract()
-	structured["planningContract"] = planningContract()
-	structured["shellCommandHint"] = "For compound shell commands or directory changes, use bash -lc '...'."
+func onboardingStructuredContent(run *taskverification.RunState, workingDir string) map[string]any {
+	structured := lifecycleStructuredContent(run, workingDir)
+	if run == nil {
+		return structured
+	}
+	structured["requiredInputNames"] = run.SelectedTemplate.RequiredParameterNames()
+	structured["requiredPlanningParameters"] = requiredPlanningParameters(run.SelectedTemplate.ParameterDefinitions())
+	addPlanningNodeContext(structured, run)
+	return structured
+}
+
+func planningCompletionStructuredContent(run *taskverification.RunState, workingDir string) map[string]any {
+	structured := lifecycleStructuredContent(run, workingDir)
+	if run == nil {
+		return structured
+	}
+	structured["planningSummary"] = planningSummary(run)
+	structured["frozenContractSummary"] = frozenContractSummary(run)
+	if run.WorkflowReady && run.RunnableTemplate != nil {
+		structured["steps"] = workflowStepsSummary(run)
+		addStepContract(structured, run)
+	}
+	return structured
+}
+
+func stepStructuredContent(run *taskverification.RunState, workingDir string) map[string]any {
+	if run == nil {
+		structured := map[string]any{}
+		addWorkspaceContext(structured, workingDir)
+		return structured
+	}
+	structured := map[string]any{
+		"taskRunId":    run.RunID,
+		"templateId":   run.TemplateID,
+		"templateName": run.SelectedTemplate.Task.Name,
+		"status":       string(run.Status),
+		"phase":        string(run.Phase),
+	}
+	addTaskTimingFields(structured, run)
+	addWorkspaceContext(structured, workingDir)
+	addCurrentNodeContext(structured, run)
+	addStepContract(structured, run)
+	return structured
+}
+
+func recoveryActionsStructuredContent(actions []taskverification.RecoveryAction) []map[string]any {
+	if len(actions) == 0 {
+		return []map[string]any{}
+	}
+	structured := make([]map[string]any, 0, len(actions))
+	for _, action := range actions {
+		entry := map[string]any{
+			"kind":    action.Kind,
+			"summary": action.Summary,
+		}
+		if action.Tool != "" {
+			entry["tool"] = action.Tool
+		}
+		if len(action.Arguments) > 0 {
+			entry["arguments"] = action.Arguments
+		}
+		structured = append(structured, entry)
+	}
+	return structured
+}
+
+func planningSummary(run *taskverification.RunState) map[string]any {
+	summary := map[string]any{
+		"planSummary":   "",
+		"selectedFiles": []string{},
+		"parameters":    map[string]string{},
+	}
+	if run == nil || run.Planning == nil {
+		return summary
+	}
+	summary["planSummary"] = run.Planning.PlanSummary
+	summary["selectedFiles"] = append([]string{}, run.Planning.SelectedFiles...)
+	summary["parameters"] = cloneStringMap(run.Planning.Parameters)
+	return summary
 }
 
 func nextActionForRun(run *taskverification.RunState) string {
@@ -870,18 +928,17 @@ func nextActionForRun(run *taskverification.RunState) string {
 	}
 }
 
-func nextActionForStepResult(result *taskverification.StepResult, run *taskverification.RunState, actionTool string) string {
+func nextActionForStepResult(result *taskverification.StepResult, run *taskverification.RunState) string {
 	if result == nil {
 		return nextActionForRun(run)
 	}
 	if result.Passed {
 		return nextActionForRun(run)
 	}
-	retryTool := actionTool
-	if retryTool == "" {
-		retryTool = taskCompleteStepTool
+	if len(result.RecoveryActions) > 0 && strings.TrimSpace(result.RecoveryActions[0].Summary) != "" {
+		return result.RecoveryActions[0].Summary
 	}
-	return fmt.Sprintf("Fix the failed check in workspaceRoot, then retry %s for step %d.", retryTool, result.Step)
+	return "Inspect the step failure and recover before retrying."
 }
 
 func activeOrCurrentStep(run *taskverification.RunState) (int, bool) {
@@ -909,19 +966,10 @@ func addCurrentNodeContext(structured map[string]any, run *taskverification.RunS
 	structured["currentNodeKind"] = string(node.Kind)
 	structured["approvalBlocked"] = node.Kind == taskverification.WorkflowNodeKindWaitingForApproval
 	structured["allowedTools"] = append([]string{}, node.AllowedTools...)
-	if len(node.EditableFields) > 0 {
-		structured["planningEditableFields"] = append([]string{}, node.EditableFields...)
-	}
-	if len(node.RequiredPlanningInputs) > 0 {
-		structured["planningRequiredInputs"] = append([]string{}, node.RequiredPlanningInputs...)
-	}
-	if node.NextPath != "" {
-		structured["nextNodePath"] = string(node.NextPath)
-	}
 }
 
 func addPlanningNodeContext(structured map[string]any, run *taskverification.RunState) {
-	if run.SelectedTemplate.CompiledWorkflow == nil {
+	if run == nil || run.SelectedTemplate.CompiledWorkflow == nil {
 		return
 	}
 	planningNode, exists := run.SelectedTemplate.CompiledWorkflow.Nodes[run.SelectedTemplate.CompiledWorkflow.PlanningPath]
@@ -936,23 +984,11 @@ func addPlanningNodeContext(structured map[string]any, run *taskverification.Run
 	}
 }
 
-func addArtifactSummaries(structured map[string]any, run *taskverification.RunState) {
-	if run.Onboarding != nil {
-		structured["taskSummary"] = run.Onboarding.TaskSummary
-	}
-	if run.Planning == nil {
-		return
-	}
-	structured["planningSummary"] = map[string]any{
-		"planSummary":   run.Planning.PlanSummary,
-		"selectedFiles": append([]string{}, run.Planning.SelectedFiles...),
-		"parameters":    cloneStringMap(run.Planning.Parameters),
-	}
-	structured["frozenContractSummary"] = frozenContractSummary(run)
-}
-
 func addStepContract(structured map[string]any, run *taskverification.RunState) {
 	if structured == nil || run == nil || run.RunnableTemplate == nil || run.RunnableTemplate.CompiledWorkflow == nil {
+		return
+	}
+	if run.Status != taskverification.TaskStatusActive {
 		return
 	}
 	stepNumber, _ := activeOrCurrentStep(run)
@@ -983,20 +1019,6 @@ func workflowStepsSummary(run *taskverification.RunState) []map[string]any {
 	return steps
 }
 
-func onboardingContract() map[string]any {
-	return map[string]any{
-		"requiredFields": []string{"taskSummary"},
-		"artifactMapItem": map[string]any{
-			"requiredFields": []string{"path", "kind"},
-			"optionalFields": []string{"notes"},
-		},
-		"commonCommandsItem": map[string]any{
-			"requiredFields": []string{"command", "purpose"},
-		},
-		"optionalFields": []string{"artifactMap", "commonCommands", "constraints", "openQuestions"},
-	}
-}
-
 func addTaskTimingFields(structured map[string]any, run *taskverification.RunState) {
 	if structured == nil || run == nil {
 		return
@@ -1020,15 +1042,6 @@ func addTaskTimingToToolResult(result *mcp.CallToolResult, run *taskverification
 	addTaskTimingFields(structured, run)
 }
 
-func planningContract() map[string]any {
-	return map[string]any{
-		"topLevelFields":  []string{"selectedFiles", "parameters", "invariants"},
-		"inputField":      "parameters",
-		"parametersField": "planning.parameters",
-		"instructions":    "Fill every entry in planning.parameters before execution can begin. Centian enforces the planning contract.",
-	}
-}
-
 func requiredPlanningParameters(definitions []taskverification.TemplateParameter) map[string]any {
 	if len(definitions) == 0 {
 		return map[string]any{}
@@ -1045,7 +1058,7 @@ func requiredPlanningParameters(definitions []taskverification.TemplateParameter
 }
 
 func planningValidationToolResult(validationErr *taskverification.PlanningValidationError, run *taskverification.RunState, workingDir string) *mcp.CallToolResult {
-	structured := runStructuredContent(run, workingDir)
+	structured := onboardingStructuredContent(run, workingDir)
 	structured["error"] = validationErr.Error()
 	structured["planningParametersField"] = "planning.parameters"
 	structured["requiredPlanningParameterNames"] = append([]string(nil), validationErr.RequiredParameterNames...)

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -188,12 +188,10 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, registerResult != nil)
 	registerStructured := registerResult.StructuredContent.(map[string]any)
-	assert.Equal(t, registerStructured["instructions"], "Use Centian validation instead of rebuilding checks manually.")
 	assert.Assert(t, registerStructured["taskRunId"] != "")
 	assert.Equal(t, registerStructured["status"], string(taskverification.TaskStatusActive))
 	assert.Equal(t, registerStructured["phase"], string(taskverification.TaskPhaseOnboarding))
 	assert.Equal(t, registerStructured["currentNodeKind"], string(taskverification.WorkflowNodeKindOnboarding))
-	assert.Equal(t, registerStructured["nextNodePath"], string(taskverification.TaskPhasePlanning))
 	assert.Equal(t, registerStructured["approvalBlocked"], false)
 	assert.DeepEqual(t, registerStructured["allowedTools"], []any{"shell__*", "filesystem__*"})
 	assert.Equal(t, registerStructured["executionReady"], false)
@@ -233,16 +231,10 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, completeOnboardingStructured["status"], string(taskverification.TaskStatusActive))
 	assert.Equal(t, completeOnboardingStructured["phase"], string(taskverification.TaskPhasePlanning))
 	assert.Equal(t, completeOnboardingStructured["currentNodeKind"], string(taskverification.WorkflowNodeKindPlanning))
-	assert.Equal(t, completeOnboardingStructured["nextNodePath"], "execution.step_one")
-	assert.Assert(t, completeOnboardingStructured["onboardingContract"] != nil)
-	assert.Assert(t, completeOnboardingStructured["planningContract"] != nil)
 	_, hasPlanningRequiredInputs := completeOnboardingStructured["planningRequiredInputs"]
 	assert.Assert(t, !hasPlanningRequiredInputs)
-	assert.Equal(t, completeOnboardingStructured["shellCommandHint"], "For compound shell commands or directory changes, use bash -lc '...'.")
 	assert.Equal(t, completeOnboardingStructured["hasOnboarding"], true)
-	assert.Equal(t, completeOnboardingStructured["taskSummary"], "Small test task context with one shell validation path.")
 	assert.DeepEqual(t, completeOnboardingStructured["allowedTools"], []any{"shell__*", "filesystem__*"})
-	assert.Assert(t, completeOnboardingStructured["onboarding"] != nil)
 	assert.Equal(t, completeOnboardingStructured["hasPlanning"], false)
 	assert.Equal(t, completeOnboardingStructured["nextAction"], "Call centian.task_complete_planning with planning.parameters containing every required planning parameter. Execution cannot begin until the full planning contract is provided, and Centian enforces it.")
 	assert.DeepEqual(t, completeOnboardingStructured["requiredPlanningParameters"], map[string]any{})
@@ -301,6 +293,12 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, startStepStructured["nextAction"], "Do the step work in workspaceRoot, then call centian.task_complete_step for step 1.")
 	_, hasFailureKind := startStepStructured["failureKind"]
 	assert.Assert(t, !hasFailureKind)
+	_, hasPlanningSummary := startStepStructured["planningSummary"]
+	assert.Assert(t, !hasPlanningSummary)
+	_, hasFrozenContractSummary := startStepStructured["frozenContractSummary"]
+	assert.Assert(t, !hasFrozenContractSummary)
+	_, hasSteps = startStepStructured["steps"]
+	assert.Assert(t, !hasSteps)
 
 	restartResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskRestartTool,
@@ -313,7 +311,6 @@ func TestTaskToolFlowAndRestartFail(t *testing.T) {
 	assert.Equal(t, restartStructured["currentNodeKind"], string(taskverification.WorkflowNodeKindOnboarding))
 	assert.Equal(t, restartStructured["hasOnboarding"], true)
 	assert.Equal(t, restartStructured["hasPlanning"], false)
-	assert.Equal(t, restartStructured["taskSummary"], "Small test task context with one shell validation path.")
 	assert.Equal(t, restartStructured["nextAction"], "Call centian.task_complete_onboarding to freeze the onboarding context.")
 
 	failResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
@@ -482,7 +479,20 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 	})
 	assert.NilError(t, err)
 	registerStructured := registerResult.StructuredContent.(map[string]any)
-	assert.DeepEqual(t, registerStructured["requiredPlanningParameters"], map[string]any{
+	_, hasRequiredPlanningParameters := registerStructured["requiredPlanningParameters"]
+	assert.Assert(t, !hasRequiredPlanningParameters)
+
+	onboardingResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskCompleteOnboardingTool,
+		Arguments: map[string]any{
+			"onboarding": map[string]any{
+				"taskSummary": "Small task context with parameterized planning fields.",
+			},
+		},
+	})
+	assert.NilError(t, err)
+	onboardingStructured := onboardingResult.StructuredContent.(map[string]any)
+	assert.DeepEqual(t, onboardingStructured["requiredPlanningParameters"], map[string]any{
 		"expectedError": map[string]any{
 			"name":        "expectedError",
 			"description": "Expected error",
@@ -494,16 +504,6 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 			"required":    true,
 		},
 	})
-
-	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
-		Name: taskCompleteOnboardingTool,
-		Arguments: map[string]any{
-			"onboarding": map[string]any{
-				"taskSummary": "Small task context with parameterized planning fields.",
-			},
-		},
-	})
-	assert.NilError(t, err)
 
 	completePlanningResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskCompletePlanningTool,
@@ -541,6 +541,8 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 	assert.NilError(t, err)
 	startStepStructured := startStepResult.StructuredContent.(map[string]any)
 	assert.Equal(t, startStepStructured["stepStatus"], string(taskverification.StepStatusActive))
+	_, hasPlanningSummary := startStepStructured["planningSummary"]
+	assert.Assert(t, !hasPlanningSummary)
 
 	completeStepResult, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      taskCompleteStepTool,
@@ -550,6 +552,8 @@ func TestTaskToolFullLifecycleSupportsParameterizedPlanningEditableFields(t *tes
 	completeStepStructured := completeStepResult.StructuredContent.(map[string]any)
 	assert.Equal(t, completeStepStructured["stepStatus"], string(taskverification.StepStatusPassed))
 	assert.Equal(t, completeStepStructured["status"], string(taskverification.TaskStatusCompleted))
+	_, hasStepContract := completeStepStructured["stepContract"]
+	assert.Assert(t, !hasStepContract)
 }
 
 func TestTaskCompletePlanningReturnsStructuredPlanningValidationFailure(t *testing.T) {
@@ -1034,7 +1038,6 @@ workflow:
 	assert.Equal(t, structured["currentNodeKind"], string(taskverification.WorkflowNodeKindWaitingForApproval))
 	assert.Equal(t, structured["approvalBlocked"], true)
 	assert.DeepEqual(t, structured["allowedTools"], []any{"shell__*"})
-	assert.Equal(t, structured["nextNodePath"], "execution.step_one")
 
 	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: taskStartStepTool,
@@ -1154,8 +1157,121 @@ workflow:
 	assert.Equal(t, structured["failedCheckId"], "check_one")
 	assert.Assert(t, structured["stdoutSnippet"] != nil)
 	assert.Assert(t, structured["summary"] != nil)
-	assert.Assert(t, structured["frozenContractSummary"] != nil)
+	assert.Equal(t, structured["retryable"], true)
+	assert.Assert(t, structured["recoveryActions"] != nil)
+	assert.Assert(t, structured["stepContract"] != nil)
+	_, hasFrozenContractSummary := structured["frozenContractSummary"]
+	assert.Assert(t, !hasFrozenContractSummary)
 	assert.Equal(t, structured["nextAction"], "Fix the failed check in workspaceRoot, then retry centian.task_complete_step for step 1.")
+}
+
+func TestTaskStartStepCanRetryAfterScaffoldingFileFix(t *testing.T) {
+	endpoint, session := newTaskToolTestProxy(t, `
+version: "0.1"
+task:
+  id: "guided_retry"
+  name: "Guided Retry"
+  description: "Reproduces retryable scaffolding precondition failures."
+workflow:
+  onboarding:
+    tools_allowed: ["shell__*", "filesystem__*"]
+  planning:
+    tools_allowed: ["shell__*", "filesystem__*"]
+    required_inputs: []
+  scaffolding:
+    - id: "setup_test_file"
+      tools_allowed: ["shell__*", "filesystem__*"]
+      checks:
+        - id: "file_created"
+          command: "printf scaffold"
+          pre_conditions:
+            - type: file_not_exists
+              path: "test_score_parentheses.py"
+          post_conditions:
+            - type: file_exists
+              path: "test_score_parentheses.py"
+    - id: "setup_test_scaffolding"
+      tools_allowed: ["shell__*", "filesystem__*"]
+      checks:
+        - id: "scaffold_ready"
+          command: "printf ok"
+          pre_conditions:
+            - type: file_exists
+              path: "test_score_parentheses.py"
+            - type: file_not_contains
+              path: "test_score_parentheses.py"
+              value: "test_score_parentheses"
+          post_conditions:
+            - type: stdout_contains
+              value: "ok"
+            - type: file_exists
+              path: "score_parentheses.py"
+  execution:
+    - id: "implement_solution"
+      tools_allowed: ["shell__*", "filesystem__*"]
+`)
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskRegisterTool,
+		Arguments: map[string]any{"templateId": "guided_retry"},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompleteOnboardingTool,
+		Arguments: map[string]any{"onboarding": map[string]any{"taskSummary": "Stored summary"}},
+	})
+	assert.NilError(t, err)
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskCompletePlanningTool,
+		Arguments: map[string]any{
+			"planning": map[string]any{
+				"planSummary": "Stored plan",
+				"parameters":  map[string]any{},
+			},
+		},
+	})
+	assert.NilError(t, err)
+
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskStartStepTool,
+		Arguments: map[string]any{"step": 1},
+	})
+	assert.NilError(t, err)
+
+	testFile := filepath.Join(endpoint.server.TaskVerification.WorkingDir, "test_score_parentheses.py")
+	err = os.WriteFile(testFile, []byte("# test_score_parentheses.py\n"), 0o644)
+	assert.NilError(t, err)
+
+	_, err = clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskCompleteStepTool,
+		Arguments: map[string]any{"step": 1},
+	})
+	assert.NilError(t, err)
+
+	failedStart, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskStartStepTool,
+		Arguments: map[string]any{"step": 2},
+	})
+	assert.NilError(t, err)
+	failedStructured := failedStart.StructuredContent.(map[string]any)
+	assert.Equal(t, failedStructured["passed"], false)
+	assert.Equal(t, failedStructured["retryable"], true)
+	assert.Equal(t, failedStructured["stepStatus"], string(taskverification.StepStatusPending))
+
+	err = os.WriteFile(testFile, []byte("# placeholder\n"), 0o644)
+	assert.NilError(t, err)
+
+	retryStart, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      taskStartStepTool,
+		Arguments: map[string]any{"step": 2},
+	})
+	assert.NilError(t, err)
+	retryStructured := retryStart.StructuredContent.(map[string]any)
+	assert.Equal(t, retryStructured["passed"], true)
+	assert.Equal(t, retryStructured["stepStatus"], string(taskverification.StepStatusActive))
 }
 
 func TestWorkflowNodeToolGovernanceAllowsMatchingTool(t *testing.T) {

--- a/internal/taskverification/run_persistence_test.go
+++ b/internal/taskverification/run_persistence_test.go
@@ -216,7 +216,7 @@ func TestStepFailurePersistsSnapshot(t *testing.T) {
 	result, err := service.StartStep(context.Background(), run, 1)
 	assert.NilError(t, err)
 	assert.Assert(t, !result.Passed)
-	assert.Equal(t, store.latest().Steps[0].Status, string(StepStatusFailed))
+	assert.Equal(t, store.latest().Steps[0].Status, string(StepStatusPending))
 	assert.Assert(t, store.latest().LastFailureMessage != "")
 }
 

--- a/internal/taskverification/runtime.go
+++ b/internal/taskverification/runtime.go
@@ -16,6 +16,10 @@ type commandResult struct {
 }
 
 const outputSnippetLimit = 240
+const (
+	startStepRecoveryTool    = "centian.task_start_step"
+	completeStepRecoveryTool = "centian.task_complete_step"
+)
 
 type stepFailureDetails struct {
 	kind            StepFailureKind
@@ -47,6 +51,7 @@ func (s *Service) StartStep(ctx context.Context, run *RunState, stepNumber int) 
 	}
 
 	if result, failed := s.runStepChecks(ctx, run, step, stepIndex, stepNumber, StepFailurePhasePrecondition, preConditionsForCheck); failed {
+		attachRetryRecovery(result, startStepRecoveryTool)
 		if persistErr := s.persistRunSnapshot(ctx, run); persistErr != nil {
 			return result, persistErr
 		}
@@ -54,6 +59,7 @@ func (s *Service) StartStep(ctx context.Context, run *RunState, stepNumber int) 
 	}
 	baselines, result, failed := s.captureInvariantBaselines(ctx, run, step, stepIndex, stepNumber)
 	if failed {
+		attachRetryRecovery(result, startStepRecoveryTool)
 		if persistErr := s.persistRunSnapshot(ctx, run); persistErr != nil {
 			return result, persistErr
 		}
@@ -86,12 +92,14 @@ func (s *Service) completeWorkflowStep(ctx context.Context, run *RunState, stepI
 	}
 
 	if result, failed := s.runStepChecks(ctx, run, step, stepIndex, stepIndex+1, StepFailurePhasePostcondition, postConditionsForCheck); failed {
+		attachRetryRecovery(result, completeStepRecoveryTool)
 		if persistErr := s.persistRunSnapshot(ctx, run); persistErr != nil {
 			return result, persistErr
 		}
 		return result, nil
 	}
 	if result, failed := s.verifyInvariants(ctx, run, step, stepIndex); failed {
+		attachRetryRecovery(result, completeStepRecoveryTool)
 		if persistErr := s.persistRunSnapshot(ctx, run); persistErr != nil {
 			return result, persistErr
 		}
@@ -145,6 +153,23 @@ func completeWorkflowStep(run *RunState, stepIndex int, step *Step) *StepResult 
 		Phase:      run.Phase,
 		StepStatus: run.Steps[stepIndex].Status,
 	}
+}
+
+func attachRetryRecovery(result *StepResult, tool string) {
+	if result == nil || result.Passed {
+		return
+	}
+	summary := fmt.Sprintf("Fix the failed check in workspaceRoot, then retry %s for step %d.", tool, result.Step)
+	result.Retryable = true
+	result.RestartRequired = false
+	result.RecoveryActions = []RecoveryAction{{
+		Kind:    "retry_tool",
+		Summary: summary,
+		Tool:    tool,
+		Arguments: map[string]any{
+			"step": result.Step,
+		},
+	}}
 }
 
 func workflowStepRequest(run *RunState, stepNumber int) (int, *Step, error) {
@@ -265,7 +290,6 @@ func (s *Service) captureInvariantBaselines(ctx context.Context, run *RunState, 
 			return nil, s.invariantExecutionFailure(run, step, stepIndex, stepNumber, invariant.ID, StepFailurePhaseInvariantCapture, result, err), true
 		}
 		if result.ExitCode != 0 {
-			run.Steps[stepIndex].Status = StepStatusFailed
 			details := failureDetailsFromCommand(
 				StepFailureKindInvariant,
 				StepFailurePhaseInvariantCapture,
@@ -298,7 +322,6 @@ func (s *Service) verifyInvariants(ctx context.Context, run *RunState, step *Ste
 }
 
 func (s *Service) executionFailure(run *RunState, step *Step, stepIndex, stepNumber int, checkID string, result *commandResult, err error) *StepResult {
-	run.Steps[stepIndex].Status = StepStatusFailed
 	details := failureDetailsFromCommand(
 		StepFailureKindCommandExecution,
 		StepFailurePhaseCommandExecution,
@@ -319,7 +342,6 @@ func (s *Service) invariantExecutionFailure(
 	result *commandResult,
 	err error,
 ) *StepResult {
-	run.Steps[stepIndex].Status = StepStatusFailed
 	details := failureDetailsFromCommand(
 		StepFailureKindCommandExecution,
 		StepFailurePhaseCommandExecution,
@@ -377,9 +399,6 @@ func verifyInvariantResult(run *RunState, step *Step, stepIndex int, result *com
 func failureResult(run *RunState, stepIndex, stepNumber int, stepID string, details *stepFailureDetails) *StepResult {
 	if details == nil {
 		details = &stepFailureDetails{}
-	}
-	if stepIndex >= 0 && stepIndex < len(run.Steps) {
-		run.Steps[stepIndex].Status = StepStatusFailed
 	}
 	message := details.summary
 	run.LastFailureMessage = message

--- a/internal/taskverification/runtime_test.go
+++ b/internal/taskverification/runtime_test.go
@@ -137,8 +137,18 @@ func TestStepWithoutChecksStillVerifiesInvariantDrift(t *testing.T) {
 	assert.Equal(t, result.FailureKind, StepFailureKindInvariant)
 	assert.Equal(t, result.FailurePhase, StepFailurePhaseInvariantVerify)
 	assert.Equal(t, result.FailedInvariantID, "stable_file")
+	assert.Assert(t, result.Retryable)
+	assert.Equal(t, result.RecoveryActions[0].Tool, completeStepRecoveryTool)
 	assert.Assert(t, strings.Contains(result.StdoutSnippet, "after"))
-	assert.Equal(t, run.Steps[0].Status, StepStatusFailed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
+
+	err = os.WriteFile(stateFile, []byte("before"), 0o644)
+	assert.NilError(t, err)
+
+	retry, err := service.CompleteStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, retry.Passed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusPassed)
 }
 
 func TestStartStepFailsPreconditions(t *testing.T) {
@@ -169,9 +179,11 @@ workflow:
 	assert.Equal(t, result.FailurePhase, StepFailurePhasePrecondition)
 	assert.Equal(t, result.FailedCheckID, "check_one")
 	assert.Equal(t, result.Summary, result.Message)
+	assert.Assert(t, result.Retryable)
+	assert.Equal(t, result.RecoveryActions[0].Tool, startStepRecoveryTool)
 	assert.Assert(t, strings.Contains(result.StdoutSnippet, "ok"))
 	assert.Assert(t, result.ExitCode != nil)
-	assert.Equal(t, run.Steps[0].Status, StepStatusFailed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusPending)
 }
 
 func TestScaffoldingStepTransitionsIntoExecution(t *testing.T) {
@@ -338,8 +350,10 @@ func TestCompleteStepFailsInvariantMismatch(t *testing.T) {
 	assert.Equal(t, result.FailureKind, StepFailureKindInvariant)
 	assert.Equal(t, result.FailurePhase, StepFailurePhaseInvariantVerify)
 	assert.Equal(t, result.FailedInvariantID, "stable_file")
+	assert.Assert(t, result.Retryable)
+	assert.Equal(t, result.RecoveryActions[0].Tool, completeStepRecoveryTool)
 	assert.Assert(t, strings.Contains(result.StdoutSnippet, "after"))
-	assert.Equal(t, run.Steps[0].Status, StepStatusFailed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
 	assert.Assert(t, result.Message != "")
 }
 
@@ -376,7 +390,10 @@ workflow:
 	assert.Equal(t, result.FailureKind, StepFailureKindCheck)
 	assert.Equal(t, result.FailurePhase, StepFailurePhasePostcondition)
 	assert.Equal(t, result.FailedCheckID, "check_one")
+	assert.Assert(t, result.Retryable)
+	assert.Equal(t, result.RecoveryActions[0].Tool, completeStepRecoveryTool)
 	assert.Assert(t, strings.Contains(result.StdoutSnippet, "unexpected output"))
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
 }
 
 func TestStartStepFailsInvariantCaptureWithInvariantMetadata(t *testing.T) {
@@ -411,8 +428,10 @@ workflow:
 	assert.Equal(t, result.FailedInvariantID, "stable")
 	assert.Assert(t, result.ExitCode != nil)
 	assert.Equal(t, *result.ExitCode, 4)
+	assert.Assert(t, result.Retryable)
+	assert.Equal(t, result.RecoveryActions[0].Tool, startStepRecoveryTool)
 	assert.Assert(t, strings.Contains(result.StderrSnippet, "boom"))
-	assert.Equal(t, run.Steps[0].Status, StepStatusFailed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusPending)
 }
 
 func TestStartStepReturnsCommandExecutionFailure(t *testing.T) {
@@ -443,7 +462,101 @@ workflow:
 	assert.Equal(t, result.FailureKind, StepFailureKindCommandExecution)
 	assert.Equal(t, result.FailurePhase, StepFailurePhaseCommandExecution)
 	assert.Equal(t, result.FailedCheckID, "check_one")
-	assert.Equal(t, run.Steps[0].Status, StepStatusFailed)
+	assert.Assert(t, result.Retryable)
+	assert.Equal(t, result.RecoveryActions[0].Tool, startStepRecoveryTool)
+	assert.Equal(t, run.Steps[0].Status, StepStatusPending)
+}
+
+func TestStartStepCanRetryAfterWorkspaceFix(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "state.txt")
+	err := os.WriteFile(stateFile, []byte("bad"), 0o644)
+	assert.NilError(t, err)
+
+	template := mustCompileRuntimeTemplate(t, &Template{
+		Version: "0.1",
+		Task:    Task{ID: "task", Name: "Task", Description: "desc"},
+		Workflow: &Workflow{
+			Onboarding: &LifecycleNodeSpec{},
+			Planning:   &PlanningNodeSpec{},
+			Execution: []ExecutionNodeSpec{{
+				ID: "step_one",
+				Checks: []Check{{
+					ID:      "check_one",
+					Command: "printf 'ok'",
+					PreConditions: []Condition{
+						{Type: "file_not_contains", Path: "state.txt", Value: "bad"},
+					},
+					PostConditions: []Condition{
+						{Type: "stdout_contains", Value: "ok"},
+					},
+				}},
+			}},
+		},
+	})
+	service := NewService(dir, dir)
+	run := newWorkflowReadyRun(&template)
+
+	result, err := service.StartStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, !result.Passed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusPending)
+
+	err = os.WriteFile(stateFile, []byte("good"), 0o644)
+	assert.NilError(t, err)
+
+	retry, err := service.StartStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, retry.Passed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
+}
+
+func TestCompleteStepCanRetryAfterWorkspaceFix(t *testing.T) {
+	dir := t.TempDir()
+	statusFile := filepath.Join(dir, "status.txt")
+	err := os.WriteFile(statusFile, []byte("ready"), 0o644)
+	assert.NilError(t, err)
+
+	template := mustCompileRuntimeTemplate(t, &Template{
+		Version: "0.1",
+		Task:    Task{ID: "task", Name: "Task", Description: "desc"},
+		Workflow: &Workflow{
+			Onboarding: &LifecycleNodeSpec{},
+			Planning:   &PlanningNodeSpec{},
+			Execution: []ExecutionNodeSpec{{
+				ID: "step_one",
+				Checks: []Check{{
+					ID:      "check_one",
+					Command: "cat status.txt",
+					PreConditions: []Condition{
+						{Type: "stdout_contains", Value: "ready"},
+					},
+					PostConditions: []Condition{
+						{Type: "stdout_contains", Value: "done"},
+					},
+				}},
+			}},
+		},
+	})
+	service := NewService(dir, dir)
+	run := newWorkflowReadyRun(&template)
+
+	start, err := service.StartStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, start.Passed)
+
+	result, err := service.CompleteStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, !result.Passed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusActive)
+
+	err = os.WriteFile(statusFile, []byte("done"), 0o644)
+	assert.NilError(t, err)
+
+	retry, err := service.CompleteStep(context.Background(), run, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, retry.Passed)
+	assert.Equal(t, run.Steps[0].Status, StepStatusPassed)
 }
 
 func TestStartStepImplicitlyCompletesPreviousStepAndAdvancesPhase(t *testing.T) {

--- a/internal/taskverification/types.go
+++ b/internal/taskverification/types.go
@@ -424,6 +424,18 @@ type RunState struct {
 	ExpiresAt int64 `json:"expiresAtUnixMilli,omitempty"`
 }
 
+// RecoveryAction describes one agent-facing recovery option for a failed step action.
+type RecoveryAction struct {
+	// Kind classifies the recovery option so agents can route it consistently.
+	Kind string `json:"kind"`
+	// Summary is the human-facing recovery instruction.
+	Summary string `json:"summary"`
+	// Tool identifies the suggested tool to call when the recovery is tool-driven.
+	Tool string `json:"tool,omitempty"`
+	// Arguments contains suggested tool arguments for the recovery action.
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
 // StepResult is the MCP-facing outcome of starting or completing a step.
 type StepResult struct {
 	// Passed indicates whether the requested step action succeeded.
@@ -450,6 +462,12 @@ type StepResult struct {
 	FailedInvariantID string `json:"failedInvariantId,omitempty"`
 	// Summary is an optional concise summary of the step outcome suitable for UIs.
 	Summary string `json:"summary,omitempty"`
+	// Retryable indicates whether the agent can recover and retry without restarting the task.
+	Retryable bool `json:"retryable,omitempty"`
+	// RestartRequired indicates whether the agent must restart the task to continue.
+	RestartRequired bool `json:"restartRequired,omitempty"`
+	// RecoveryActions enumerates structured recovery options for failed step actions.
+	RecoveryActions []RecoveryAction `json:"recoveryActions,omitempty"`
 	// ExitCode is the command exit code when command execution produced one.
 	ExitCode *int `json:"exitCode,omitempty"`
 	// StdoutSnippet is the truncated stdout excerpt relevant to the step outcome.


### PR DESCRIPTION
## Description

Improves token count as well as context for agent to know:
- the next step, and what its pre- and post-conditions are
- how to recover from failure
- removed duplicate/unnecessary success messages -> model only needs to know that the action succeeded, it does not need to get the full plan back into context

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or breaking changes are described below)
- [ ] Code has been linted and formatted
