### PR TITLE
Feature/mcp events UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.4.2 - 2026-04-23
+
+### Minor
+- Added per-gateway task verification control via `verificationRequirement`, so each gateway can now independently run with task verification `off`, `optional`, or `required` instead of inheriting one project-wide enforcement mode.
+- Added a global persisted MCP events feed with the new `/api/events` API and `/ui/events` page, making it possible to inspect MCP request/response traffic even when an event is not associated with a task run.
+- Updated README and task verification/configuration docs to describe the new gateway-level verification modes and the broader event-observability flow.
+
 ## v0.4.1 - 2026-04-21
 
 ### Major

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ All tool calls flow through Centian's proxy — giving you:
 
 ## Agent Process Verification — define success upfront
 
-Centian verifies that agents do what they committed to do.
+Centian verifies that agents do what they committed to do - why this is a problem is described in detail in our benchmark where we tested 9 agents on a test-driven development task using centian: ["Done!" — But Did Your Agent Actually Do the Work?](https://t4cceptor.github.io/centian-benchmarks/).
 
 Before execution, you define what success looks like — and Centian enforces it step by step.
 

--- a/docs/TASKVERIFICATION.md
+++ b/docs/TASKVERIFICATION.md
@@ -55,13 +55,17 @@ Add `proxy.capabilities.taskVerification` to your Centian config. If you also wa
 
 Notes:
 
-- `taskVerification.enabled` controls whether `centian.task_*` tools are exposed.
+- `taskVerification.enabled` enables the task verification runtime for the project.
 - `taskVerification.templatesPath` overrides where Centian looks for runtime disk templates.
 - `taskVerification.idleTimeoutSeconds` enables task idle timeout when greater than `0`.
 - `eventStorage.enabled` defaults to `true`.
 - `eventStorage.driver` currently only supports `sqlite`.
 - `eventStorage.path` is optional. If omitted, Centian uses `~/.centian/logs/events.sqlite`.
 - `ui.enabled` only exposes the embedded frontend. It does not enable taskverification tools by itself.
+- Each gateway can further control task verification participation with `verificationRequirement`:
+  - `off`: no `centian.task_*` tools on that gateway; downstream tools still work normally
+  - `optional`: `centian.task_*` tools are exposed, but downstream tools can be used before registration
+  - `required`: `centian.task_*` tools are exposed and downstream tools are blocked until registration
 
 ### 2. Understand template sources
 
@@ -87,6 +91,8 @@ The agent then talks to one Centian endpoint and receives both:
 
 - normal proxied MCP tools
 - `centian.task_*` tools
+
+If you only want some gateways to participate in task verification, set `verificationRequirement` per gateway instead of disabling the project capability globally.
 
 ### 4. Start Centian
 

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -129,6 +129,7 @@ Each gateway is keyed by its gateway name. Gateway names must be URL-safe: lette
 | `setupGateway` | boolean | No | `false` | Reserved gateway field. Present in the config model, but current server startup does not branch on it. |
 | `forceReadOnlyHints` | boolean | No | `false` | Overrides all registered tool annotations in this gateway to `readOnlyHint=true`. |
 | `forceSafeToolHints` | boolean | No | `false` | Overrides all registered tool annotations in this gateway to conservative safe defaults for upstream MCP clients. Sets `readOnlyHint=true`, `idempotentHint=true`, `destructiveHint=false`, and `openWorldHint=false`. |
+| `verificationRequirement` | string | No | `required` when project task verification is enabled, otherwise `off` | Gateway-level task verification mode. Supported values: `off`, `optional`, `required`. |
 | `mcpServers` | object | Yes in strict mode | none | Map of server name to MCP server config. |
 | `processors` | array | No | `[]` | Gateway-level processor chain appended after global processors. |
 
@@ -140,6 +141,9 @@ Runtime notes:
 - `allowDynamic` and `setupGateway` are currently best treated as reserved fields rather than active runtime controls.
 - `forceSafeToolHints` changes tool metadata only. It does not add enforcement by itself; it makes tools appear maximally safe to upstream clients.
 - If both `forceSafeToolHints` and `forceReadOnlyHints` are set, `forceSafeToolHints` takes precedence.
+- `verificationRequirement=off` disables task verification on that gateway only. The gateway still exposes downstream tools normally.
+- `verificationRequirement=optional` exposes `centian.task_*` tools but allows downstream tool calls before registration.
+- `verificationRequirement=required` preserves the existing behavior: downstream tool calls are blocked until task registration.
 
 ## `mcpServers`
 

--- a/internal/api/events_handler.go
+++ b/internal/api/events_handler.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/T4cceptor/centian/internal/persistence"
+)
+
+const (
+	defaultEventPageLimit = 100
+	maxEventPageLimit     = 200
+)
+
+// EventStore provides the read methods required by the global events API.
+type EventStore interface {
+	ListEvents(context.Context, *persistence.EventListFilter) (*persistence.EventListPage, error)
+}
+
+// EventsHandler serves the read-only global action-event API.
+type EventsHandler struct {
+	store EventStore
+}
+
+// NewEventsHandler builds an events API handler.
+func NewEventsHandler(store EventStore) *EventsHandler {
+	return &EventsHandler{store: store}
+}
+
+// RegisterRoutesWithMiddleware registers event routes with optional middleware.
+func (h *EventsHandler) RegisterRoutesWithMiddleware(mux *http.ServeMux, middleware func(http.Handler) http.Handler) {
+	if h == nil || h.store == nil || mux == nil {
+		return
+	}
+
+	register := func(pattern string, handler http.HandlerFunc) {
+		var wrapped http.Handler = handler
+		if middleware != nil {
+			wrapped = middleware(wrapped)
+		}
+		mux.Handle(pattern, wrapped)
+	}
+
+	register("GET /api/events", h.handleListEvents)
+}
+
+func (h *EventsHandler) handleListEvents(w http.ResponseWriter, r *http.Request) {
+	filter, err := eventFiltersFromQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	page, err := h.store.ListEvents(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list events")
+		return
+	}
+	if page == nil {
+		page = &persistence.EventListPage{}
+	}
+	if page.Items == nil {
+		page.Items = []persistence.EventListItem{}
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func eventFiltersFromQuery(r *http.Request) (*persistence.EventListFilter, error) {
+	query := r.URL.Query()
+
+	filter := &persistence.EventListFilter{
+		Gateway:     strings.TrimSpace(query.Get("gateway")),
+		ServerName:  strings.TrimSpace(query.Get("server")),
+		ToolName:    strings.TrimSpace(query.Get("tool")),
+		Direction:   strings.TrimSpace(query.Get("direction")),
+		MessageType: strings.TrimSpace(query.Get("messageType")),
+		RequestID:   strings.TrimSpace(query.Get("requestId")),
+		SessionID:   strings.TrimSpace(query.Get("sessionId")),
+		Limit:       defaultEventPageLimit,
+	}
+
+	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {
+		limit, err := strconv.Atoi(rawLimit)
+		if err != nil || limit <= 0 || limit > maxEventPageLimit {
+			return nil, fmt.Errorf("invalid limit")
+		}
+		filter.Limit = limit
+	}
+
+	if rawSuccess := strings.TrimSpace(query.Get("success")); rawSuccess != "" {
+		success, err := strconv.ParseBool(rawSuccess)
+		if err != nil {
+			return nil, fmt.Errorf("invalid success")
+		}
+		filter.Success = &success
+	}
+
+	cursor, hasCursor, err := persistence.ParseEventCursor(query.Get("cursor"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor")
+	}
+	if hasCursor {
+		filter.Cursor = &cursor
+	}
+
+	return filter, nil
+}

--- a/internal/api/events_handler_test.go
+++ b/internal/api/events_handler_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/T4cceptor/centian/internal/identifiers"
+	"github.com/T4cceptor/centian/internal/persistence"
+	"gotest.tools/assert"
+)
+
+type stubEventStore struct {
+	listEventsFn func(context.Context, *persistence.EventListFilter) (*persistence.EventListPage, error)
+	calls        int
+	filter       *persistence.EventListFilter
+}
+
+func (s *stubEventStore) ListEvents(ctx context.Context, filter *persistence.EventListFilter) (*persistence.EventListPage, error) {
+	s.calls++
+	s.filter = filter
+	if s.listEventsFn == nil {
+		return nil, nil
+	}
+	return s.listEventsFn(ctx, filter)
+}
+
+func TestEventsHandler_ListEvents(t *testing.T) {
+	t.Run("returns empty items instead of null", func(t *testing.T) {
+		handler := NewEventsHandler(&stubEventStore{})
+		mux := http.NewServeMux()
+		handler.RegisterRoutesWithMiddleware(mux, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/events", http.NoBody)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, rec.Code, http.StatusOK)
+
+		var page persistence.EventListPage
+		err := json.Unmarshal(rec.Body.Bytes(), &page)
+		assert.NilError(t, err)
+		assert.Assert(t, page.Items != nil)
+		assert.Equal(t, len(page.Items), 0)
+	})
+
+	t.Run("passes filters through query params", func(t *testing.T) {
+		store := &stubEventStore{
+			listEventsFn: func(context.Context, *persistence.EventListFilter) (*persistence.EventListPage, error) {
+				return &persistence.EventListPage{Items: []persistence.EventListItem{}}, nil
+			},
+		}
+		handler := NewEventsHandler(store)
+		mux := http.NewServeMux()
+		handler.RegisterRoutesWithMiddleware(mux, nil)
+
+		cursor := persistence.EventListCursor{
+			CreatedAtUnixMilli: 1_234,
+			ID:                 identifiers.New(identifiers.KindActionEvent),
+		}.Encode()
+
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/events?gateway=gw&server=server-a&tool=shell__exec&direction=[CLIENT%20-%3E%20SERVER]&messageType=request&success=true&requestId=req-1&sessionId=sid-1&cursor="+cursor+"&limit=25",
+			http.NoBody,
+		)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, rec.Code, http.StatusOK)
+		assert.Assert(t, store.filter != nil)
+		assert.Equal(t, store.filter.Gateway, "gw")
+		assert.Equal(t, store.filter.ServerName, "server-a")
+		assert.Equal(t, store.filter.ToolName, "shell__exec")
+		assert.Equal(t, store.filter.Direction, "[CLIENT -> SERVER]")
+		assert.Equal(t, store.filter.MessageType, "request")
+		assert.Equal(t, store.filter.RequestID, "req-1")
+		assert.Equal(t, store.filter.SessionID, "sid-1")
+		assert.Equal(t, store.filter.Limit, 25)
+		assert.Assert(t, store.filter.Success != nil)
+		assert.Equal(t, *store.filter.Success, true)
+		assert.Assert(t, store.filter.Cursor != nil)
+		assert.Equal(t, store.filter.Cursor.CreatedAtUnixMilli, int64(1_234))
+	})
+
+	t.Run("returns next cursor when more rows exist", func(t *testing.T) {
+		handler := NewEventsHandler(&stubEventStore{
+			listEventsFn: func(context.Context, *persistence.EventListFilter) (*persistence.EventListPage, error) {
+				return &persistence.EventListPage{
+					Items: []persistence.EventListItem{{
+						ID:                 identifiers.New(identifiers.KindActionEvent),
+						CreatedAtUnixMilli: 1_000,
+						ToolName:           "shell__exec",
+						Success:            true,
+					}},
+					NextCursor: "cursor-2",
+				}, nil
+			},
+		})
+		mux := http.NewServeMux()
+		handler.RegisterRoutesWithMiddleware(mux, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/events", http.NoBody)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, rec.Code, http.StatusOK)
+
+		var page persistence.EventListPage
+		err := json.Unmarshal(rec.Body.Bytes(), &page)
+		assert.NilError(t, err)
+		assert.Equal(t, page.NextCursor, "cursor-2")
+		assert.Equal(t, len(page.Items), 1)
+	})
+
+	t.Run("rejects invalid success values", func(t *testing.T) {
+		store := &stubEventStore{}
+		handler := NewEventsHandler(store)
+		mux := http.NewServeMux()
+		handler.RegisterRoutesWithMiddleware(mux, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/events?success=maybe", http.NoBody)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, rec.Code, http.StatusBadRequest)
+		assert.Equal(t, store.calls, 0)
+	})
+
+	t.Run("rejects invalid limits", func(t *testing.T) {
+		for _, rawLimit := range []string{"0", "201", "oops"} {
+			store := &stubEventStore{}
+			handler := NewEventsHandler(store)
+			mux := http.NewServeMux()
+			handler.RegisterRoutesWithMiddleware(mux, nil)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/events?limit="+rawLimit, http.NoBody)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			assert.Equal(t, rec.Code, http.StatusBadRequest)
+			assert.Equal(t, store.calls, 0)
+		}
+	})
+
+	t.Run("rejects invalid cursors", func(t *testing.T) {
+		store := &stubEventStore{}
+		handler := NewEventsHandler(store)
+		mux := http.NewServeMux()
+		handler.RegisterRoutesWithMiddleware(mux, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/events?cursor=Zm9v", http.NoBody)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		assert.Equal(t, rec.Code, http.StatusBadRequest)
+		assert.Equal(t, store.calls, 0)
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,14 @@ const (
 // DefaultProjectSlug is the project slug used when no explicit projects are configured.
 const DefaultProjectSlug = "default"
 
+// Gateway verification requirement values control how a gateway participates
+// in project task verification.
+const (
+	VerificationRequirementOff      = "off"
+	VerificationRequirementOptional = "optional"
+	VerificationRequirementRequired = "required"
+)
+
 // GlobalConfig represents the main configuration structure stored at ~/.centian/config.json.
 // This is the root configuration object that contains all settings for MCP servers,
 // proxy behavior, processors, and additional metadata.
@@ -557,12 +565,13 @@ func (p *ProxySettings) UIEnabled() bool {
 
 // GatewayConfig represents a logical grouping of HTTP MCP servers.
 type GatewayConfig struct {
-	AllowDynamic         bool                        `json:"allowDynamic,omitempty"`       // Allow dynamic proxy endpoints
-	AllowGatewayEndpoint bool                        `json:"setupGateway,omitempty"`       // Setup gateway endpoint with namespacing
-	ForceReadOnlyHints   *bool                       `json:"forceReadOnlyHints,omitempty"` // Override all tool annotations to readOnlyHint=true
-	ForceSafeToolHints   *bool                       `json:"forceSafeToolHints,omitempty"` // Override all tool annotations to conservative safe defaults for MCP clients
-	MCPServers           map[string]*MCPServerConfig `json:"mcpServers"`                   // HTTP MCP servers in this gateway
-	Processors           []*ProcessorConfig          `json:"processors,omitempty"`
+	AllowDynamic            bool                        `json:"allowDynamic,omitempty"`            // Allow dynamic proxy endpoints
+	AllowGatewayEndpoint    bool                        `json:"setupGateway,omitempty"`            // Setup gateway endpoint with namespacing
+	ForceReadOnlyHints      *bool                       `json:"forceReadOnlyHints,omitempty"`      // Override all tool annotations to readOnlyHint=true
+	ForceSafeToolHints      *bool                       `json:"forceSafeToolHints,omitempty"`      // Override all tool annotations to conservative safe defaults for MCP clients
+	VerificationRequirement string                      `json:"verificationRequirement,omitempty"` // Gateway task verification policy: off, optional, required
+	MCPServers              map[string]*MCPServerConfig `json:"mcpServers"`                        // HTTP MCP servers in this gateway
+	Processors              []*ProcessorConfig          `json:"processors,omitempty"`
 }
 
 // ListServers returns a slice of all available MCPServerConfigs for this GatewayConfig.
@@ -607,6 +616,15 @@ func (g *GatewayConfig) ForceReadOnlyHintsEnabled() bool {
 // overridden to conservative safe defaults for this gateway. Defaults to false.
 func (g *GatewayConfig) ForceSafeToolHintsEnabled() bool {
 	return g != nil && g.ForceSafeToolHints != nil && *g.ForceSafeToolHints
+}
+
+// NormalizedVerificationRequirement returns the configured requirement after trimming
+// and lowercasing. Empty means the gateway should use the default policy.
+func (g *GatewayConfig) NormalizedVerificationRequirement() string {
+	if g == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(g.VerificationRequirement))
 }
 
 //////// PROCESSOR CONFIG STRUCTS ///////.
@@ -866,6 +884,8 @@ func validateProjects(projects map[string]*ProjectConfig, strict bool) error {
 
 // validateFlatLayout validates the legacy flat config layout.
 func validateFlatLayout(config *GlobalConfig, strict bool) error {
+	normalizeGateways(config.Gateways)
+
 	if err := validateNameConventions(config.Gateways); err != nil {
 		return err
 	}
@@ -880,7 +900,8 @@ func validateFlatLayout(config *GlobalConfig, strict bool) error {
 	}
 
 	if strict {
-		if err := validateGateways(config.Gateways); err != nil {
+		taskVerificationEnabled := config != nil && config.Proxy != nil && config.Proxy.TaskVerificationEnabled()
+		if err := validateGateways(config.Gateways, taskVerificationEnabled); err != nil {
 			return err
 		}
 		if err := validateProcessors(config.Processors); err != nil {
@@ -913,6 +934,8 @@ func validateProjectSlug(slug string) error {
 
 // validateProjectConfig validates a single project configuration.
 func validateProjectConfig(slug string, project *ProjectConfig, strict bool) error {
+	normalizeGateways(project.Gateways)
+
 	if err := validateNameConventions(project.Gateways); err != nil {
 		return fmt.Errorf("project '%s': %w", slug, err)
 	}
@@ -927,7 +950,7 @@ func validateProjectConfig(slug string, project *ProjectConfig, strict bool) err
 	}
 
 	if strict {
-		if err := validateGateways(project.Gateways); err != nil {
+		if err := validateGateways(project.Gateways, project.TaskVerificationEnabled()); err != nil {
 			return fmt.Errorf("project '%s': %w", slug, err)
 		}
 		if err := validateProcessors(project.Processors); err != nil {
@@ -982,6 +1005,15 @@ func normalizeCapabilities(capabilities *CapabilitiesSettings) {
 	}
 }
 
+func normalizeGateways(gateways map[string]*GatewayConfig) {
+	for _, gateway := range gateways {
+		if gateway == nil {
+			continue
+		}
+		gateway.VerificationRequirement = gateway.NormalizedVerificationRequirement()
+	}
+}
+
 // validateNameConventions validates gateway and server names.
 // This is run for both strict and non-strict config validation.
 func validateNameConventions(gateways map[string]*GatewayConfig) error {
@@ -1003,7 +1035,7 @@ func validateNameConventions(gateways map[string]*GatewayConfig) error {
 
 // validateGateways validates gateway configurations without requiring any.
 // This allows empty gateway maps (for freshly initialized configs).
-func validateGateways(gateways map[string]*GatewayConfig) error {
+func validateGateways(gateways map[string]*GatewayConfig, taskVerificationEnabled bool) error {
 	if len(gateways) == 0 {
 		return fmt.Errorf("no gateways configured - at least one gateway is required")
 	}
@@ -1011,7 +1043,7 @@ func validateGateways(gateways map[string]*GatewayConfig) error {
 		if gatewayConfig == nil {
 			return fmt.Errorf("gateway '%s': config cannot be nil", gatewayName)
 		}
-		if err := validateGateway(gatewayName, *gatewayConfig); err != nil {
+		if err := validateGateway(gatewayName, *gatewayConfig, taskVerificationEnabled); err != nil {
 			return err
 		}
 		for name, server := range gatewayConfig.MCPServers {
@@ -1035,7 +1067,7 @@ func isValidHTTPURL(urlStr string) bool {
 }
 
 // validateGateway validates a gateway configuration.
-func validateGateway(name string, config GatewayConfig) error {
+func validateGateway(name string, config GatewayConfig, taskVerificationEnabled bool) error {
 	// Validate gateway name is URL compliant (used in endpoint paths).
 	if !common.IsURLCompliant(name) {
 		return fmt.Errorf("gateway '%s': name must be URL-safe (alphanumeric, dash, underscore only)", name)
@@ -1057,6 +1089,17 @@ func validateGateway(name string, config GatewayConfig) error {
 		if err := validateProcessors(config.Processors); err != nil {
 			return fmt.Errorf("gateway '%s': %w", name, err)
 		}
+	}
+
+	requirement := config.NormalizedVerificationRequirement()
+	switch requirement {
+	case "", VerificationRequirementOff:
+	case VerificationRequirementOptional, VerificationRequirementRequired:
+		if !taskVerificationEnabled {
+			return fmt.Errorf("gateway '%s': verificationRequirement %q requires project capabilities.taskVerification.enabled=true", name, requirement)
+		}
+	default:
+		return fmt.Errorf("gateway '%s': verificationRequirement %q is unsupported (expected off, optional, or required)", name, requirement)
 	}
 
 	return nil

--- a/internal/config/config_validation_test.go
+++ b/internal/config/config_validation_test.go
@@ -104,11 +104,12 @@ func TestIsValidHTTPURL(t *testing.T) {
 // TestValidateGateway tests gateway configuration validation.
 func TestValidateGateway(t *testing.T) {
 	tests := []struct {
-		name      string
-		gName     string
-		gateway   GatewayConfig
-		wantError bool
-		errorMsg  string
+		name                    string
+		gName                   string
+		gateway                 GatewayConfig
+		taskVerificationEnabled bool
+		wantError               bool
+		errorMsg                string
 	}{
 		{
 			name:  "valid gateway with stdio server",
@@ -244,6 +245,96 @@ func TestValidateGateway(t *testing.T) {
 			wantError: true,
 			errorMsg:  "name is required",
 		},
+		{
+			name:  "gateway with supported off verification requirement",
+			gName: "gateway1",
+			gateway: GatewayConfig{
+				VerificationRequirement: VerificationRequirementOff,
+				MCPServers: map[string]*MCPServerConfig{
+					"server1": {
+						Name:    "server1",
+						Command: "node",
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name:  "gateway with supported optional verification requirement",
+			gName: "gateway1",
+			gateway: GatewayConfig{
+				VerificationRequirement: VerificationRequirementOptional,
+				MCPServers: map[string]*MCPServerConfig{
+					"server1": {
+						Name:    "server1",
+						Command: "node",
+					},
+				},
+			},
+			taskVerificationEnabled: true,
+			wantError:               false,
+		},
+		{
+			name:  "gateway with supported required verification requirement",
+			gName: "gateway1",
+			gateway: GatewayConfig{
+				VerificationRequirement: VerificationRequirementRequired,
+				MCPServers: map[string]*MCPServerConfig{
+					"server1": {
+						Name:    "server1",
+						Command: "node",
+					},
+				},
+			},
+			taskVerificationEnabled: true,
+			wantError:               false,
+		},
+		{
+			name:  "gateway rejects unsupported verification requirement",
+			gName: "gateway1",
+			gateway: GatewayConfig{
+				VerificationRequirement: "recommended",
+				MCPServers: map[string]*MCPServerConfig{
+					"server1": {
+						Name:    "server1",
+						Command: "node",
+					},
+				},
+			},
+			taskVerificationEnabled: true,
+			wantError:               true,
+			errorMsg:                "verificationRequirement",
+		},
+		{
+			name:  "gateway rejects optional verification requirement when project task verification disabled",
+			gName: "gateway1",
+			gateway: GatewayConfig{
+				VerificationRequirement: VerificationRequirementOptional,
+				MCPServers: map[string]*MCPServerConfig{
+					"server1": {
+						Name:    "server1",
+						Command: "node",
+					},
+				},
+			},
+			wantError: true,
+			errorMsg:  "requires project capabilities.taskVerification.enabled=true",
+		},
+		{
+			name:  "gateway rejects required verification requirement when project task verification disabled",
+			gName: "gateway1",
+			gateway: GatewayConfig{
+				VerificationRequirement: VerificationRequirementRequired,
+				MCPServers: map[string]*MCPServerConfig{
+					"server1": {
+						Name:    "server1",
+						Command: "node",
+					},
+				},
+			},
+			wantError: true,
+			errorMsg:  "requires project capabilities.taskVerification.enabled=true",
+		},
 	}
 
 	for _, tt := range tests {
@@ -251,7 +342,7 @@ func TestValidateGateway(t *testing.T) {
 			// Given: a gateway configuration.
 
 			// When: validating the gateway.
-			err := validateGateway(tt.gName, tt.gateway)
+			err := validateGateway(tt.gName, tt.gateway, tt.taskVerificationEnabled)
 
 			// Then: verify error expectation.
 			if tt.wantError {

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -955,45 +955,7 @@ SELECT
 FROM action_events ae
 LEFT JOIN action_event_task_context ctx ON ctx.request_id = ae.request_id
 `
-	args := make([]any, 0, 16)
-	clauses := make([]string, 0, 9)
-
-	if filter.Gateway != "" {
-		clauses = append(clauses, "ae.gateway = ?")
-		args = append(args, filter.Gateway)
-	}
-	if filter.ServerName != "" {
-		clauses = append(clauses, "ae.server_name = ?")
-		args = append(args, filter.ServerName)
-	}
-	if filter.ToolName != "" {
-		clauses = append(clauses, "ae.tool_name = ?")
-		args = append(args, filter.ToolName)
-	}
-	if filter.Direction != "" {
-		clauses = append(clauses, "ae.direction = ?")
-		args = append(args, filter.Direction)
-	}
-	if filter.MessageType != "" {
-		clauses = append(clauses, "ae.message_type = ?")
-		args = append(args, filter.MessageType)
-	}
-	if filter.RequestID != "" {
-		clauses = append(clauses, "ae.request_id = ?")
-		args = append(args, filter.RequestID)
-	}
-	if filter.SessionID != "" {
-		clauses = append(clauses, "ae.session_id = ?")
-		args = append(args, filter.SessionID)
-	}
-	if filter.Success != nil {
-		clauses = append(clauses, "ae.success = ?")
-		args = append(args, *filter.Success)
-	}
-	if filter.Cursor != nil {
-		clauses = append(clauses, "(ae.created_at_unix_milli < ? OR (ae.created_at_unix_milli = ? AND ae.id < ?))")
-		args = append(args, filter.Cursor.CreatedAtUnixMilli, filter.Cursor.CreatedAtUnixMilli, filter.Cursor.ID)
-	}
+	clauses, args := buildEventListFilters(filter)
 
 	if len(clauses) > 0 {
 		query += " WHERE " + strings.Join(clauses, " AND ")
@@ -1017,30 +979,65 @@ LEFT JOIN action_event_task_context ctx ON ctx.request_id = ae.request_id
 	}
 
 	for idx := range rows {
-		row := rows[idx]
-		page.Items = append(page.Items, EventListItem{
-			ID:                  row.ID,
-			CreatedAtUnixMilli:  row.CreatedAtUnixMilli,
-			RequestID:           nullStringValue(row.RequestID),
-			SessionID:           nullStringValue(row.SessionID),
-			Transport:           nullStringValue(row.Transport),
-			Direction:           nullStringValue(row.Direction),
-			MessageType:         nullStringValue(row.MessageType),
-			Gateway:             nullStringValue(row.Gateway),
-			ServerName:          nullStringValue(row.ServerName),
-			Endpoint:            nullStringValue(row.Endpoint),
-			ToolName:            nullStringValue(row.ToolName),
-			OriginalToolName:    nullStringValue(row.OriginalToolName),
-			Success:             row.Success,
-			IsError:             row.IsError,
-			PayloadJSON:         row.PayloadJSON,
-			TaskRunID:           nullStringValue(row.TaskRunID),
-			InvocationPhasePath: nullStringValue(row.InvocationPhasePath),
-			InvocationNodeKind:  nullStringValue(row.InvocationNodeKind),
-		})
+		page.Items = append(page.Items, eventListItemFromRow(rows[idx]))
 	}
 
 	return page, nil
+}
+
+func buildEventListFilters(filter *EventListFilter) ([]string, []any) {
+	clauses := make([]string, 0, 9)
+	args := make([]any, 0, 16)
+
+	appendFilter := func(field, value string) {
+		if value == "" {
+			return
+		}
+		clauses = append(clauses, field+" = ?")
+		args = append(args, value)
+	}
+
+	appendFilter("ae.gateway", filter.Gateway)
+	appendFilter("ae.server_name", filter.ServerName)
+	appendFilter("ae.tool_name", filter.ToolName)
+	appendFilter("ae.direction", filter.Direction)
+	appendFilter("ae.message_type", filter.MessageType)
+	appendFilter("ae.request_id", filter.RequestID)
+	appendFilter("ae.session_id", filter.SessionID)
+
+	if filter.Success != nil {
+		clauses = append(clauses, "ae.success = ?")
+		args = append(args, *filter.Success)
+	}
+	if filter.Cursor != nil {
+		clauses = append(clauses, "(ae.created_at_unix_milli < ? OR (ae.created_at_unix_milli = ? AND ae.id < ?))")
+		args = append(args, filter.Cursor.CreatedAtUnixMilli, filter.Cursor.CreatedAtUnixMilli, filter.Cursor.ID)
+	}
+
+	return clauses, args
+}
+
+func eventListItemFromRow(row eventListRow) EventListItem {
+	return EventListItem{
+		ID:                  row.ID,
+		CreatedAtUnixMilli:  row.CreatedAtUnixMilli,
+		RequestID:           nullStringValue(row.RequestID),
+		SessionID:           nullStringValue(row.SessionID),
+		Transport:           nullStringValue(row.Transport),
+		Direction:           nullStringValue(row.Direction),
+		MessageType:         nullStringValue(row.MessageType),
+		Gateway:             nullStringValue(row.Gateway),
+		ServerName:          nullStringValue(row.ServerName),
+		Endpoint:            nullStringValue(row.Endpoint),
+		ToolName:            nullStringValue(row.ToolName),
+		OriginalToolName:    nullStringValue(row.OriginalToolName),
+		Success:             row.Success,
+		IsError:             row.IsError,
+		PayloadJSON:         row.PayloadJSON,
+		TaskRunID:           nullStringValue(row.TaskRunID),
+		InvocationPhasePath: nullStringValue(row.InvocationPhasePath),
+		InvocationNodeKind:  nullStringValue(row.InvocationNodeKind),
+	}
 }
 
 // TaskEvents returns all persisted task lifecycle events ordered by timestamp.

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -3,11 +3,13 @@ package persistence
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -177,6 +179,87 @@ type ActionEventRecord struct {
 	PayloadJSON        json.RawMessage
 }
 
+// EventListCursor identifies the last row included in one event page.
+type EventListCursor struct {
+	CreatedAtUnixMilli int64
+	ID                 string
+}
+
+// Encode returns the opaque string form used by the API.
+func (c EventListCursor) Encode() string {
+	return base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%d:%s", c.CreatedAtUnixMilli, c.ID)))
+}
+
+// ParseEventCursor decodes one opaque cursor value.
+func ParseEventCursor(raw string) (EventListCursor, bool, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return EventListCursor{}, false, nil
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return EventListCursor{}, false, fmt.Errorf("decode event cursor: %w", err)
+	}
+
+	timestampText, id, ok := strings.Cut(string(decoded), ":")
+	if !ok || strings.TrimSpace(timestampText) == "" || strings.TrimSpace(id) == "" {
+		return EventListCursor{}, false, fmt.Errorf("decode event cursor: invalid format")
+	}
+
+	createdAtUnixMilli, err := strconv.ParseInt(timestampText, 10, 64)
+	if err != nil {
+		return EventListCursor{}, false, fmt.Errorf("decode event cursor: invalid timestamp")
+	}
+
+	return EventListCursor{
+		CreatedAtUnixMilli: createdAtUnixMilli,
+		ID:                 id,
+	}, true, nil
+}
+
+// EventListFilter restricts the global action-event feed.
+type EventListFilter struct {
+	Gateway     string
+	ServerName  string
+	ToolName    string
+	Direction   string
+	MessageType string
+	RequestID   string
+	SessionID   string
+	Success     *bool
+	Cursor      *EventListCursor
+	Limit       int
+}
+
+// EventListItem is one row in the global action-event feed.
+type EventListItem struct {
+	ID                  string          `json:"id"`
+	CreatedAtUnixMilli  int64           `json:"createdAtUnixMilli"`
+	RequestID           string          `json:"requestId,omitempty"`
+	SessionID           string          `json:"sessionId,omitempty"`
+	Transport           string          `json:"transport,omitempty"`
+	Direction           string          `json:"direction,omitempty"`
+	MessageType         string          `json:"messageType,omitempty"`
+	Gateway             string          `json:"gateway,omitempty"`
+	ServerName          string          `json:"serverName,omitempty"`
+	Endpoint            string          `json:"endpoint,omitempty"`
+	ToolName            string          `json:"toolName,omitempty"`
+	OriginalToolName    string          `json:"originalToolName,omitempty"`
+	Success             bool            `json:"success"`
+	IsError             bool            `json:"isError"`
+	PayloadJSON         json.RawMessage `json:"payloadJson,omitempty"`
+	TaskRunID           string          `json:"taskRunId,omitempty"`
+	InvocationPhasePath string          `json:"invocationPhasePath,omitempty"`
+	InvocationNodeKind  string          `json:"invocationNodeKind,omitempty"`
+}
+
+// EventListPage is the paginated response model for the global action-event feed.
+type EventListPage struct {
+	Items      []EventListItem `json:"items"`
+	NextCursor string          `json:"nextCursor,omitempty"`
+}
+
 type schemaVersionRow struct {
 	bun.BaseModel `bun:"table:event_store_schema"`
 	Name          string `bun:",pk"`
@@ -227,6 +310,27 @@ type taskRunEventRow struct {
 	Gateway                sql.NullString
 	ServerName             sql.NullString
 	Endpoint               sql.NullString
+}
+
+type eventListRow struct {
+	ID                  string
+	CreatedAtUnixMilli  int64
+	RequestID           sql.NullString
+	SessionID           sql.NullString
+	Transport           sql.NullString
+	Direction           sql.NullString
+	MessageType         sql.NullString
+	Gateway             sql.NullString
+	ServerName          sql.NullString
+	Endpoint            sql.NullString
+	ToolName            sql.NullString
+	OriginalToolName    sql.NullString
+	Success             bool
+	IsError             bool
+	PayloadJSON         json.RawMessage
+	TaskRunID           sql.NullString
+	InvocationPhasePath sql.NullString
+	InvocationNodeKind  sql.NullString
 }
 
 // Store persists task and action events to SQLite using Bun.
@@ -815,6 +919,128 @@ ORDER BY created_at_unix_milli ASC, id ASC
 		})
 	}
 	return events, nil
+}
+
+// ListEvents returns paginated action events ordered newest-first.
+func (s *Store) ListEvents(ctx context.Context, filter *EventListFilter) (*EventListPage, error) {
+	if filter == nil {
+		filter = &EventListFilter{}
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	rows := make([]eventListRow, 0, limit+1)
+	query := `
+SELECT
+	ae.id,
+	ae.created_at_unix_milli,
+	ae.request_id,
+	ae.session_id,
+	ae.transport,
+	ae.direction,
+	ae.message_type,
+	ae.gateway,
+	ae.server_name,
+	ae.endpoint,
+	ae.tool_name,
+	ae.original_tool_name,
+	ae.success,
+	ae.is_error,
+	ae.payload_json,
+	ctx.task_run_id,
+	ctx.invocation_phase_path,
+	ctx.invocation_node_kind
+FROM action_events ae
+LEFT JOIN action_event_task_context ctx ON ctx.request_id = ae.request_id
+`
+	args := make([]any, 0, 16)
+	clauses := make([]string, 0, 9)
+
+	if filter.Gateway != "" {
+		clauses = append(clauses, "ae.gateway = ?")
+		args = append(args, filter.Gateway)
+	}
+	if filter.ServerName != "" {
+		clauses = append(clauses, "ae.server_name = ?")
+		args = append(args, filter.ServerName)
+	}
+	if filter.ToolName != "" {
+		clauses = append(clauses, "ae.tool_name = ?")
+		args = append(args, filter.ToolName)
+	}
+	if filter.Direction != "" {
+		clauses = append(clauses, "ae.direction = ?")
+		args = append(args, filter.Direction)
+	}
+	if filter.MessageType != "" {
+		clauses = append(clauses, "ae.message_type = ?")
+		args = append(args, filter.MessageType)
+	}
+	if filter.RequestID != "" {
+		clauses = append(clauses, "ae.request_id = ?")
+		args = append(args, filter.RequestID)
+	}
+	if filter.SessionID != "" {
+		clauses = append(clauses, "ae.session_id = ?")
+		args = append(args, filter.SessionID)
+	}
+	if filter.Success != nil {
+		clauses = append(clauses, "ae.success = ?")
+		args = append(args, *filter.Success)
+	}
+	if filter.Cursor != nil {
+		clauses = append(clauses, "(ae.created_at_unix_milli < ? OR (ae.created_at_unix_milli = ? AND ae.id < ?))")
+		args = append(args, filter.Cursor.CreatedAtUnixMilli, filter.Cursor.CreatedAtUnixMilli, filter.Cursor.ID)
+	}
+
+	if len(clauses) > 0 {
+		query += " WHERE " + strings.Join(clauses, " AND ")
+	}
+	query += " ORDER BY ae.created_at_unix_milli DESC, ae.id DESC LIMIT ?"
+	args = append(args, limit+1)
+
+	if err := s.db.NewRaw(query, args...).Scan(ctx, &rows); err != nil {
+		return nil, err
+	}
+
+	page := &EventListPage{
+		Items: make([]EventListItem, 0, min(limit, len(rows))),
+	}
+	if len(rows) > limit {
+		page.NextCursor = EventListCursor{
+			CreatedAtUnixMilli: rows[limit-1].CreatedAtUnixMilli,
+			ID:                 rows[limit-1].ID,
+		}.Encode()
+		rows = rows[:limit]
+	}
+
+	for idx := range rows {
+		row := rows[idx]
+		page.Items = append(page.Items, EventListItem{
+			ID:                  row.ID,
+			CreatedAtUnixMilli:  row.CreatedAtUnixMilli,
+			RequestID:           nullStringValue(row.RequestID),
+			SessionID:           nullStringValue(row.SessionID),
+			Transport:           nullStringValue(row.Transport),
+			Direction:           nullStringValue(row.Direction),
+			MessageType:         nullStringValue(row.MessageType),
+			Gateway:             nullStringValue(row.Gateway),
+			ServerName:          nullStringValue(row.ServerName),
+			Endpoint:            nullStringValue(row.Endpoint),
+			ToolName:            nullStringValue(row.ToolName),
+			OriginalToolName:    nullStringValue(row.OriginalToolName),
+			Success:             row.Success,
+			IsError:             row.IsError,
+			PayloadJSON:         row.PayloadJSON,
+			TaskRunID:           nullStringValue(row.TaskRunID),
+			InvocationPhasePath: nullStringValue(row.InvocationPhasePath),
+			InvocationNodeKind:  nullStringValue(row.InvocationNodeKind),
+		})
+	}
+
+	return page, nil
 }
 
 // TaskEvents returns all persisted task lifecycle events ordered by timestamp.

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -979,7 +979,7 @@ LEFT JOIN action_event_task_context ctx ON ctx.request_id = ae.request_id
 	}
 
 	for idx := range rows {
-		page.Items = append(page.Items, eventListItemFromRow(rows[idx]))
+		page.Items = append(page.Items, eventListItemFromRow(&rows[idx]))
 	}
 
 	return page, nil
@@ -1017,7 +1017,7 @@ func buildEventListFilters(filter *EventListFilter) ([]string, []any) {
 	return clauses, args
 }
 
-func eventListItemFromRow(row eventListRow) EventListItem {
+func eventListItemFromRow(row *eventListRow) EventListItem {
 	return EventListItem{
 		ID:                  row.ID,
 		CreatedAtUnixMilli:  row.CreatedAtUnixMilli,

--- a/internal/persistence/store_test.go
+++ b/internal/persistence/store_test.go
@@ -959,9 +959,155 @@ func TestGetTaskRunEventsReturnsTaskOnlyAndEmptyForUnknownRun(t *testing.T) {
 	assert.Equal(t, len(missingEvents), 0)
 }
 
+func TestListEventsAppliesFiltersAndExposesTaskContext(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "events.sqlite"))
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	seedActionContext(t, store, taskverification.ActionEventTaskContext{
+		RequestID:           "req-1",
+		TaskRunID:           identifiers.New(identifiers.KindTaskRun),
+		InvocationPhasePath: taskverification.TaskPhasePlanning,
+		InvocationNodeKind:  taskverification.WorkflowNodeKindPlanning,
+		CreatedAtUnixMilli:  3_000,
+	})
+	seedActionEvent(t, store, &ActionEventRecord{
+		ID:                 identifiers.New(identifiers.KindActionEvent),
+		SchemaVersion:      schemaVersion,
+		CreatedAtUnixMilli: 3_000,
+		RequestID:          "req-1",
+		SessionID:          "sid-1",
+		Transport:          "http",
+		Direction:          string(common.DirectionClientToServer),
+		MessageType:        string(common.MessageTypeRequest),
+		Gateway:            "gw",
+		ServerName:         "server-a",
+		Endpoint:           "/mcp/gw",
+		ToolName:           "shell__exec",
+		OriginalToolName:   "shell__exec",
+		Success:            true,
+		IsError:            false,
+		PayloadJSON:        json.RawMessage(`{"arguments":{"command":"pwd"}}`),
+	})
+	seedActionEvent(t, store, &ActionEventRecord{
+		ID:                 identifiers.New(identifiers.KindActionEvent),
+		SchemaVersion:      schemaVersion,
+		CreatedAtUnixMilli: 2_000,
+		RequestID:          "req-2",
+		SessionID:          "sid-2",
+		Transport:          "stdio",
+		Direction:          string(common.DirectionServerToClient),
+		MessageType:        string(common.MessageTypeResponse),
+		Gateway:            "gw",
+		ServerName:         "server-b",
+		Endpoint:           "/mcp/gw",
+		ToolName:           "git__search",
+		OriginalToolName:   "git__search",
+		Success:            false,
+		IsError:            true,
+		PayloadJSON:        json.RawMessage(`{"error":"boom"}`),
+	})
+
+	page, err := store.ListEvents(context.Background(), &EventListFilter{
+		Gateway:     "gw",
+		ServerName:  "server-a",
+		ToolName:    "shell__exec",
+		Direction:   string(common.DirectionClientToServer),
+		MessageType: string(common.MessageTypeRequest),
+		RequestID:   "req-1",
+		SessionID:   "sid-1",
+		Success:     boolPointer(true),
+		Limit:       10,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(page.Items), 1)
+	assert.Equal(t, page.Items[0].RequestID, "req-1")
+	assert.Equal(t, page.Items[0].TaskRunID != "", true)
+	assert.Equal(t, page.Items[0].InvocationPhasePath, string(taskverification.TaskPhasePlanning))
+	assert.Equal(t, page.Items[0].InvocationNodeKind, string(taskverification.WorkflowNodeKindPlanning))
+
+	unfiltered, err := store.ListEvents(context.Background(), &EventListFilter{Limit: 10})
+	assert.NilError(t, err)
+	assert.Equal(t, len(unfiltered.Items), 2)
+	assert.Equal(t, unfiltered.Items[0].RequestID, "req-1")
+	assert.Equal(t, unfiltered.Items[1].RequestID, "req-2")
+	assert.Equal(t, unfiltered.Items[1].TaskRunID, "")
+}
+
+func TestListEventsPaginatesWithStableCursorOrdering(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "events.sqlite"))
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	for _, event := range []*ActionEventRecord{
+		{
+			ID:                 "ae_0000000003000_0000000003",
+			SchemaVersion:      schemaVersion,
+			CreatedAtUnixMilli: 3_000,
+			RequestID:          "req-3",
+			ToolName:           "tool-c",
+			Success:            true,
+		},
+		{
+			ID:                 "ae_0000000003000_0000000002",
+			SchemaVersion:      schemaVersion,
+			CreatedAtUnixMilli: 3_000,
+			RequestID:          "req-2",
+			ToolName:           "tool-b",
+			Success:            true,
+		},
+		{
+			ID:                 "ae_0000000003000_0000000001",
+			SchemaVersion:      schemaVersion,
+			CreatedAtUnixMilli: 3_000,
+			RequestID:          "req-1",
+			ToolName:           "tool-a",
+			Success:            true,
+		},
+		{
+			ID:                 "ae_0000000002000_0000000001",
+			SchemaVersion:      schemaVersion,
+			CreatedAtUnixMilli: 2_000,
+			RequestID:          "req-0",
+			ToolName:           "tool-z",
+			Success:            true,
+		},
+	} {
+		seedActionEvent(t, store, event)
+	}
+
+	firstPage, err := store.ListEvents(context.Background(), &EventListFilter{Limit: 2})
+	assert.NilError(t, err)
+	assert.Equal(t, len(firstPage.Items), 2)
+	assert.Equal(t, firstPage.Items[0].ID, "ae_0000000003000_0000000003")
+	assert.Equal(t, firstPage.Items[1].ID, "ae_0000000003000_0000000002")
+	assert.Assert(t, firstPage.NextCursor != "")
+
+	cursor, hasCursor, err := ParseEventCursor(firstPage.NextCursor)
+	assert.NilError(t, err)
+	assert.Equal(t, hasCursor, true)
+	secondPage, err := store.ListEvents(context.Background(), &EventListFilter{
+		Limit:  2,
+		Cursor: &cursor,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(secondPage.Items), 2)
+	assert.Equal(t, secondPage.Items[0].ID, "ae_0000000003000_0000000001")
+	assert.Equal(t, secondPage.Items[1].ID, "ae_0000000002000_0000000001")
+	assert.Equal(t, secondPage.NextCursor, "")
+}
+
 func seedTaskEvent(t *testing.T, store *Store, event *taskverification.TaskEvent) {
 	t.Helper()
 	assert.NilError(t, store.AppendTaskEvent(event))
+}
+
+func boolPointer(value bool) *bool {
+	return &value
 }
 
 func seedActionContext(t *testing.T, store *Store, ctx taskverification.ActionEventTaskContext) {

--- a/internal/proxy/proxy_auth_tools.go
+++ b/internal/proxy/proxy_auth_tools.go
@@ -65,15 +65,7 @@ func (p *CentianEndpoint) testToolsEnabled() bool {
 }
 
 func (p *CentianEndpoint) taskVerificationToolsEnabled() bool {
-	if p == nil {
-		return false
-	}
-	if p.project != nil && p.project.Config != nil {
-		return p.project.Config.TaskVerificationEnabled()
-	}
-	// Fallback: check legacy server config for backwards compatibility with tests.
-	return p.server != nil && p.server.Config != nil && p.server.Config.Proxy != nil &&
-		p.server.Config.Proxy.TaskVerificationEnabled()
+	return p.taskVerificationPolicy().exposesTaskTools()
 }
 
 func (p *CentianEndpoint) registerStaticProxyTools(session *UpstreamSession, server *mcp.Server) {

--- a/internal/proxy/proxy_setup.go
+++ b/internal/proxy/proxy_setup.go
@@ -376,6 +376,10 @@ func (c *CentianServer) registerProjectHTTPRoutes(project *CentianProject) {
 		return wrapWithAPIKeyAuth(c, project.Slug, next)
 	})
 
+	centapi.NewEventsHandler(project.PersistenceStore).RegisterRoutesWithMiddleware(c.Mux, func(next http.Handler) http.Handler {
+		return wrapWithAPIKeyAuth(c, project.Slug, next)
+	})
+
 	centapi.NewBenchmarkHandler(benchmarks.NewReadService(project.PersistenceStore)).RegisterRoutesWithMiddleware(c.Mux, func(next http.Handler) http.Handler {
 		return wrapWithAPIKeyAuth(c, project.Slug, next)
 	})

--- a/internal/proxy/proxy_task_verification_policy.go
+++ b/internal/proxy/proxy_task_verification_policy.go
@@ -1,0 +1,47 @@
+package proxy
+
+import "github.com/T4cceptor/centian/internal/config"
+
+type gatewayTaskVerificationPolicy struct {
+	requirement string
+}
+
+func (p gatewayTaskVerificationPolicy) exposesTaskTools() bool {
+	return p.requirement != config.VerificationRequirementOff
+}
+
+func (p gatewayTaskVerificationPolicy) requiresRegistration() bool {
+	return p.requirement == config.VerificationRequirementRequired
+}
+
+func (p gatewayTaskVerificationPolicy) enforcesActiveTaskGovernance() bool {
+	return p.requirement != config.VerificationRequirementOff
+}
+
+func (p *CentianEndpoint) taskVerificationPolicy() gatewayTaskVerificationPolicy {
+	if p == nil {
+		return gatewayTaskVerificationPolicy{requirement: config.VerificationRequirementOff}
+	}
+
+	if !p.projectTaskVerificationEnabled() {
+		return gatewayTaskVerificationPolicy{requirement: config.VerificationRequirementOff}
+	}
+
+	requirement := config.VerificationRequirementRequired
+	if p.config != nil && p.config.NormalizedVerificationRequirement() != "" {
+		requirement = p.config.NormalizedVerificationRequirement()
+	}
+
+	return gatewayTaskVerificationPolicy{requirement: requirement}
+}
+
+func (p *CentianEndpoint) projectTaskVerificationEnabled() bool {
+	if p == nil {
+		return false
+	}
+	if p.project != nil && p.project.Config != nil {
+		return p.project.Config.TaskVerificationEnabled()
+	}
+	return p.server != nil && p.server.Config != nil && p.server.Config.Proxy != nil &&
+		p.server.Config.Proxy.TaskVerificationEnabled()
+}

--- a/internal/proxy/proxy_taskverification_tools_test.go
+++ b/internal/proxy/proxy_taskverification_tools_test.go
@@ -19,14 +19,29 @@ import (
 )
 
 func newTaskToolTestProxy(t *testing.T, templateContent string) (*CentianEndpoint, *UpstreamSession) {
-	return newTaskToolTestProxyWithEnabled(t, templateContent, true)
+	return newTaskToolTestProxyWithRequirement(t, templateContent, true, "")
 }
 
 func newTaskToolTestProxyWithEnabled(t *testing.T, templateContent string, enabled bool) (*CentianEndpoint, *UpstreamSession) {
-	return newTaskToolTestProxyWithTimeout(t, templateContent, enabled, 0)
+	return newTaskToolTestProxyWithRequirement(t, templateContent, enabled, "")
 }
 
-func newTaskToolTestProxyWithTimeout(t *testing.T, templateContent string, enabled bool, idleTimeoutSeconds int) (*CentianEndpoint, *UpstreamSession) {
+func newTaskToolTestProxyWithRequirement(
+	t *testing.T,
+	templateContent string,
+	enabled bool,
+	requirement string,
+) (*CentianEndpoint, *UpstreamSession) {
+	return newTaskToolTestProxyWithTimeout(t, templateContent, enabled, requirement, 0)
+}
+
+func newTaskToolTestProxyWithTimeout(
+	t *testing.T,
+	templateContent string,
+	enabled bool,
+	requirement string,
+	idleTimeoutSeconds int,
+) (*CentianEndpoint, *UpstreamSession) {
 	t.Helper()
 
 	t.Setenv("HOME", t.TempDir())
@@ -61,7 +76,9 @@ func newTaskToolTestProxyWithTimeout(t *testing.T, templateContent string, enabl
 			Logger:           logger,
 			TaskVerification: taskverification.NewServiceWithOptions(templateDir, workingDir, taskverification.ServiceOptions{}),
 		},
-		config:           &config.GatewayConfig{},
+		config: &config.GatewayConfig{
+			VerificationRequirement: requirement,
+		},
 		upstreamSessions: make(map[string]*UpstreamSession),
 		downstreamPools:  make(map[string]*DownstreamSessionPool),
 	}
@@ -171,6 +188,145 @@ func TestNewUpstreamServerRegistersTaskVerificationTools(t *testing.T) {
 		taskResumeTool,
 		taskStartStepTool,
 	})
+}
+
+func TestGatewayVerificationRequirementControlsTaskToolExposure(t *testing.T) {
+	tests := []struct {
+		name        string
+		requirement string
+		aggregated  bool
+		expected    []string
+	}{
+		{
+			name:        "off hides task tools on single endpoint",
+			requirement: config.VerificationRequirementOff,
+			expected:    []string{"github__search"},
+		},
+		{
+			name:        "optional exposes task tools on single endpoint",
+			requirement: config.VerificationRequirementOptional,
+			expected: []string{
+				taskCompleteOnboardingTool,
+				taskCompletePlanningTool,
+				taskCompleteStepTool,
+				taskFailTool,
+				taskListTemplatesTool,
+				taskRegisterTool,
+				taskRestartTool,
+				taskResumeTool,
+				taskStartStepTool,
+				"github__search",
+			},
+		},
+		{
+			name:        "required exposes task tools on aggregated endpoint",
+			requirement: config.VerificationRequirementRequired,
+			aggregated:  true,
+			expected: []string{
+				taskCompleteOnboardingTool,
+				taskCompletePlanningTool,
+				taskCompleteStepTool,
+				taskFailTool,
+				taskListTemplatesTool,
+				taskRegisterTool,
+				taskRestartTool,
+				taskResumeTool,
+				taskStartStepTool,
+				"server-a___github__search",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, session := newTaskToolTestProxyWithRequirement(t, basicTaskTemplate(), true, tt.requirement)
+			endpoint.isAggregatedProxy = tt.aggregated
+			attachTaskToolDownstream(t, endpoint, session, "github__search")
+
+			clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+			defer cleanup()
+
+			assert.DeepEqual(t, listToolNames(t, clientSession), tt.expected)
+		})
+	}
+}
+
+func TestGatewayVerificationRequirementControlsPreRegistrationGovernance(t *testing.T) {
+	tests := []struct {
+		name        string
+		requirement string
+		wantBlocked bool
+	}{
+		{
+			name:        "off allows downstream calls before task registration",
+			requirement: config.VerificationRequirementOff,
+		},
+		{
+			name:        "optional allows downstream calls before task registration",
+			requirement: config.VerificationRequirementOptional,
+		},
+		{
+			name:        "required blocks downstream calls before task registration",
+			requirement: config.VerificationRequirementRequired,
+			wantBlocked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, session := newTaskToolTestProxyWithRequirement(t, basicTaskTemplate(), true, tt.requirement)
+			downstream := attachTaskToolDownstream(t, endpoint, session, "github__search")
+
+			clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+			defer cleanup()
+
+			result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+				Name:      "github__search",
+				Arguments: map[string]any{"query": "issue"},
+			})
+			assert.NilError(t, err)
+			assert.Assert(t, result != nil)
+
+			if tt.wantBlocked {
+				assert.Assert(t, result.IsError)
+				structured := result.StructuredContent.(map[string]any)
+				assert.Equal(t, structured["reason"], governanceDeniedRegistrationNeeded)
+				assert.Assert(t, downstream.CapturedRequest == nil)
+				return
+			}
+
+			assert.Assert(t, !result.IsError)
+			assert.Assert(t, downstream.CapturedRequest != nil)
+		})
+	}
+}
+
+func TestGatewayVerificationOptionalEnforcesWorkflowGovernanceAfterTaskRegistration(t *testing.T) {
+	endpoint, session := newTaskToolTestProxyWithRequirement(t, basicTaskTemplate(), true, config.VerificationRequirementOptional)
+	downstream := attachTaskToolDownstream(t, endpoint, session, "github__search")
+
+	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
+	defer cleanup()
+
+	_, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: taskRegisterTool,
+		Arguments: map[string]any{
+			"templateId": "task",
+		},
+	})
+	assert.NilError(t, err)
+
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "github__search",
+		Arguments: map[string]any{"query": "issue"},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, result != nil)
+	assert.Assert(t, result.IsError)
+
+	structured := result.StructuredContent.(map[string]any)
+	assert.Equal(t, structured["reason"], governanceDeniedNoPatternMatch)
+	assert.Assert(t, downstream.CapturedRequest == nil)
 }
 
 func TestTaskToolFlowAndRestartFail(t *testing.T) {
@@ -1378,7 +1534,7 @@ func TestWorkflowNodeToolGovernanceDeniesFailedTask(t *testing.T) {
 }
 
 func TestTaskIdleTimeoutDeniesDownstreamToolsAndRecordsEvent(t *testing.T) {
-	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, 1)
+	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, "", 1)
 	downstream := attachTaskToolDownstream(t, endpoint, session, "shell__exec")
 
 	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
@@ -1420,7 +1576,7 @@ func TestTaskIdleTimeoutDeniesDownstreamToolsAndRecordsEvent(t *testing.T) {
 }
 
 func TestTaskActivityRefreshesIdleTimeoutForTaskAndDownstreamCalls(t *testing.T) {
-	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, 1)
+	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, "", 1)
 	attachTaskToolDownstream(t, endpoint, session, "shell__exec")
 
 	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})
@@ -1459,7 +1615,7 @@ func TestTaskActivityRefreshesIdleTimeoutForTaskAndDownstreamCalls(t *testing.T)
 }
 
 func TestTaskResumeRequiresTimedOutRunAndPreservesWorkflowProgress(t *testing.T) {
-	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, 1)
+	endpoint, session := newTaskToolTestProxyWithTimeout(t, basicTaskTemplate(), true, "", 1)
 	downstream := attachTaskToolDownstream(t, endpoint, session, "shell__exec")
 
 	clientSession, cleanup := connectUpstreamTestClient(t, session, &mcp.ClientOptions{})

--- a/internal/proxy/proxy_tool_governance.go
+++ b/internal/proxy/proxy_tool_governance.go
@@ -24,14 +24,18 @@ func (p *CentianEndpoint) enforceWorkflowNodeToolGovernance(session *UpstreamSes
 		return nil, false
 	}
 
+	policy := p.taskVerificationPolicy()
 	session.taskMu.Lock()
 	defer session.taskMu.Unlock()
 
 	run := session.taskRun
 	if run == nil {
-		if p.taskVerificationToolsEnabled() {
+		if policy.requiresRegistration() {
 			return governanceDeniedResult(callCtx, taskverification.TaskPhaseInitialization, "", "", nil, governanceDeniedRegistrationNeeded, p.server.TaskVerification.WorkingDir), true
 		}
+		return nil, false
+	}
+	if !policy.enforcesActiveTaskGovernance() {
 		return nil, false
 	}
 	if run.Status != taskverification.TaskStatusActive {

--- a/web/src/api/events.ts
+++ b/web/src/api/events.ts
@@ -1,0 +1,85 @@
+import { loadStoredApiAuth, unauthorizedAuthHeaderHint } from "./api-auth";
+import { ApiError } from "./task-runs";
+
+export type EventListFilters = {
+  gateway?: string;
+  server?: string;
+  tool?: string;
+  direction?: string;
+  messageType?: string;
+  success?: boolean;
+  requestId?: string;
+  sessionId?: string;
+  cursor?: string;
+  limit?: number;
+};
+
+export type EventListItem = {
+  id: string;
+  createdAtUnixMilli: number;
+  requestId?: string;
+  sessionId?: string;
+  transport?: string;
+  direction?: string;
+  messageType?: string;
+  gateway?: string;
+  serverName?: string;
+  endpoint?: string;
+  toolName?: string;
+  originalToolName?: string;
+  success: boolean;
+  isError: boolean;
+  payloadJson?: unknown;
+  taskRunId?: string;
+  invocationPhasePath?: string;
+  invocationNodeKind?: string;
+};
+
+export type EventListPage = {
+  items: EventListItem[];
+  nextCursor?: string;
+};
+
+async function requestJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const headers = new Headers();
+  const storedAuth = loadStoredApiAuth();
+  if (storedAuth) {
+    headers.set(storedAuth.headerName, storedAuth.apiKey);
+  }
+
+  const response = await fetch(url, { signal, headers });
+  if (!response.ok) {
+    const authHeaderName =
+      response.headers && typeof response.headers.get === "function"
+        ? (response.headers.get(unauthorizedAuthHeaderHint) ?? undefined)
+        : undefined;
+    throw new ApiError(response.status, undefined, authHeaderName);
+  }
+  return (await response.json()) as T;
+}
+
+function buildQuery(filters: EventListFilters = {}): string {
+  const params = new URLSearchParams();
+  if (filters.gateway) params.set("gateway", filters.gateway);
+  if (filters.server) params.set("server", filters.server);
+  if (filters.tool) params.set("tool", filters.tool);
+  if (filters.direction) params.set("direction", filters.direction);
+  if (filters.messageType) params.set("messageType", filters.messageType);
+  if (typeof filters.success === "boolean") params.set("success", String(filters.success));
+  if (filters.requestId) params.set("requestId", filters.requestId);
+  if (filters.sessionId) params.set("sessionId", filters.sessionId);
+  if (filters.cursor) params.set("cursor", filters.cursor);
+  if (typeof filters.limit === "number" && Number.isFinite(filters.limit) && filters.limit > 0) {
+    params.set("limit", String(filters.limit));
+  }
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+export async function fetchEvents(filters: EventListFilters = {}, signal?: AbortSignal): Promise<EventListPage> {
+  const page = await requestJSON<EventListPage>(`/api/events${buildQuery(filters)}`, signal);
+  return {
+    items: Array.isArray(page?.items) ? page.items : [],
+    nextCursor: typeof page?.nextCursor === "string" && page.nextCursor ? page.nextCursor : undefined,
+  };
+}

--- a/web/src/routes.test.tsx
+++ b/web/src/routes.test.tsx
@@ -405,6 +405,9 @@ describe("event list", () => {
     expect(await screen.findByText("shell__exec")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Events" })).toBeInTheDocument();
     expect(screen.getByText("Observed MCP events")).toBeInTheDocument();
+    const header = screen.getByText("Time").closest(".event-list__header");
+    expect(header).not.toBeNull();
+    expect(within(header as HTMLElement).getByText("Request")).toBeInTheDocument();
   });
 
   it("reflects URL filters in the request and active chips", async () => {
@@ -468,35 +471,55 @@ describe("event list", () => {
     expect(await screen.findByText("tool-new")).toBeInTheDocument();
   });
 
-  it("expands rows to show payload and related task links", async () => {
+  it("expands rows to show payload, related task links, and session quick filters", async () => {
     const user = userEvent.setup();
-    globalThis.fetch = vi.fn(() =>
-      Promise.resolve(
-        createFetchResponse({
-          items: [
-            {
-              id: "ae_1742947200123_0000000001",
-              createdAtUnixMilli: 1742947200123,
-              toolName: "shell__exec",
-              originalToolName: "shell__exec",
-              success: true,
-              isError: false,
-              requestId: "req-1",
-              sessionId: "sid-1",
-              endpoint: "/mcp/gw",
-              transport: "http",
-              taskRunId: "tr_1742947200123_0000000001",
-              invocationPhasePath: "planning.review",
-              payloadJson: {
-                arguments: {
-                  command: "pwd",
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/events") {
+        return Promise.resolve(
+          createFetchResponse({
+            items: [
+              {
+                id: "ae_1742947200123_0000000001",
+                createdAtUnixMilli: 1742947200123,
+                toolName: "shell__exec",
+                originalToolName: "shell__exec",
+                success: true,
+                isError: false,
+                requestId: "req-1",
+                sessionId: "sid-1",
+                endpoint: "/mcp/gw",
+                transport: "http",
+                taskRunId: "tr_1742947200123_0000000001",
+                invocationPhasePath: "planning.review",
+                payloadJson: {
+                  arguments: {
+                    command: "pwd",
+                  },
                 },
               },
-            },
-          ],
-        }),
-      ),
-    ) as typeof fetch;
+            ],
+          }),
+        );
+      }
+      if (url === "/api/events?sessionId=sid-1") {
+        return Promise.resolve(
+          createFetchResponse({
+            items: [
+              {
+                id: "ae_1742947200123_0000000001",
+                createdAtUnixMilli: 1742947200123,
+                toolName: "shell__exec",
+                success: true,
+                isError: false,
+                sessionId: "sid-1",
+              },
+            ],
+          }),
+        );
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    }) as typeof fetch;
 
     renderApp(["/events"]);
 
@@ -509,6 +532,8 @@ describe("event list", () => {
     );
     expect(screen.getByDisplayValue(/"command": "pwd"/)).toBeInTheDocument();
     expect(screen.getByText("Planning / Review")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Filter session" }));
+    expect(await screen.findByText("Session: sid-1")).toBeInTheDocument();
   });
 });
 

--- a/web/src/routes.test.tsx
+++ b/web/src/routes.test.tsx
@@ -405,9 +405,8 @@ describe("event list", () => {
     expect(await screen.findByText("shell__exec")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Events" })).toBeInTheDocument();
     expect(screen.getByText("Observed MCP events")).toBeInTheDocument();
-    const header = screen.getByText("Time").closest(".event-list__header");
-    expect(header).not.toBeNull();
-    expect(within(header as HTMLElement).getByText("Request")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Sort by Time/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Sort by Request/i })).toBeInTheDocument();
   });
 
   it("reflects URL filters in the request and active chips", async () => {
@@ -469,6 +468,55 @@ describe("event list", () => {
 
     await user.click(screen.getByRole("button", { name: "Newest" }));
     expect(await screen.findByText("tool-new")).toBeInTheDocument();
+  });
+
+  it("sorts the visible event page by column like the benchmark overview", async () => {
+    const user = userEvent.setup();
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        createFetchResponse({
+          items: [
+            {
+              id: "ae_1742947200123_0000000002",
+              createdAtUnixMilli: 1742947200123,
+              toolName: "zeta__tool",
+              gateway: "gw",
+              serverName: "server-z",
+              success: true,
+              isError: false,
+              requestId: "req-z",
+            },
+            {
+              id: "ae_1742947200123_0000000001",
+              createdAtUnixMilli: 1742947200122,
+              toolName: "alpha__tool",
+              gateway: "gw",
+              serverName: "server-a",
+              success: false,
+              isError: true,
+              requestId: "req-a",
+            },
+          ],
+        }),
+      ),
+    ) as typeof fetch;
+
+    const { container } = renderApp(["/events"]);
+
+    await screen.findByText("zeta__tool");
+    let toolNodes = container.querySelectorAll(".event-card__tool");
+    expect(toolNodes[0]?.textContent).toBe("zeta__tool");
+    expect(toolNodes[1]?.textContent).toBe("alpha__tool");
+
+    await user.click(screen.getByRole("button", { name: "Sort by Tool" }));
+    toolNodes = container.querySelectorAll(".event-card__tool");
+    expect(toolNodes[0]?.textContent).toBe("alpha__tool");
+    expect(toolNodes[1]?.textContent).toBe("zeta__tool");
+
+    await user.click(screen.getByRole("button", { name: "Sort by Tool (asc)" }));
+    toolNodes = container.querySelectorAll(".event-card__tool");
+    expect(toolNodes[0]?.textContent).toBe("zeta__tool");
+    expect(toolNodes[1]?.textContent).toBe("alpha__tool");
   });
 
   it("expands rows to show payload, related task links, and session quick filters", async () => {

--- a/web/src/routes.test.tsx
+++ b/web/src/routes.test.tsx
@@ -376,6 +376,142 @@ describe("task run list", () => {
   });
 });
 
+describe("event list", () => {
+  it("renders the events route and primary nav", async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        createFetchResponse({
+          items: [
+            {
+              id: "ae_1742947200123_0000000001",
+              createdAtUnixMilli: 1742947200123,
+              toolName: "shell__exec",
+              gateway: "gw",
+              serverName: "server-a",
+              direction: "[CLIENT -> SERVER]",
+              messageType: "request",
+              success: true,
+              isError: false,
+              requestId: "req-1",
+            },
+          ],
+          nextCursor: "cursor-2",
+        }),
+      ),
+    ) as typeof fetch;
+
+    renderApp(["/events"]);
+
+    expect(await screen.findByText("shell__exec")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Events" })).toBeInTheDocument();
+    expect(screen.getByText("Observed MCP events")).toBeInTheDocument();
+  });
+
+  it("reflects URL filters in the request and active chips", async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve(createFetchResponse({ items: [] }))) as typeof fetch;
+
+    renderApp(["/events?gateway=gw&server=server-a&success=false"]);
+
+    expect(await screen.findByText("No matching events")).toBeInTheDocument();
+    expect(globalThis.fetch).toHaveBeenCalledWith("/api/events?gateway=gw&server=server-a&success=false", expect.anything());
+    expect(screen.getByText("Gateway: gw")).toBeInTheDocument();
+    expect(screen.getByText("Server: server-a")).toBeInTheDocument();
+    expect(screen.getByText("Success: false")).toBeInTheDocument();
+  });
+
+  it("paginates older events and returns to newest", async () => {
+    const user = userEvent.setup();
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/events") {
+        return Promise.resolve(
+          createFetchResponse({
+            items: [
+              {
+                id: "ae_1742947200123_0000000003",
+                createdAtUnixMilli: 1742947200123,
+                toolName: "tool-new",
+                success: true,
+                isError: false,
+              },
+            ],
+            nextCursor: "cursor-2",
+          }),
+        );
+      }
+      if (url === "/api/events?cursor=cursor-2") {
+        return Promise.resolve(
+          createFetchResponse({
+            items: [
+              {
+                id: "ae_1742947200123_0000000001",
+                createdAtUnixMilli: 1742947100123,
+                toolName: "tool-old",
+                success: true,
+                isError: false,
+              },
+            ],
+          }),
+        );
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    }) as typeof fetch;
+
+    renderApp(["/events"]);
+
+    expect(await screen.findByText("tool-new")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Older" }));
+    expect(await screen.findByText("tool-old")).toBeInTheDocument();
+    expect(screen.getByText("Older page")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Newest" }));
+    expect(await screen.findByText("tool-new")).toBeInTheDocument();
+  });
+
+  it("expands rows to show payload and related task links", async () => {
+    const user = userEvent.setup();
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        createFetchResponse({
+          items: [
+            {
+              id: "ae_1742947200123_0000000001",
+              createdAtUnixMilli: 1742947200123,
+              toolName: "shell__exec",
+              originalToolName: "shell__exec",
+              success: true,
+              isError: false,
+              requestId: "req-1",
+              sessionId: "sid-1",
+              endpoint: "/mcp/gw",
+              transport: "http",
+              taskRunId: "tr_1742947200123_0000000001",
+              invocationPhasePath: "planning.review",
+              payloadJson: {
+                arguments: {
+                  command: "pwd",
+                },
+              },
+            },
+          ],
+        }),
+      ),
+    ) as typeof fetch;
+
+    renderApp(["/events"]);
+
+    await user.click(await screen.findByRole("button", { name: /shell__exec/i }));
+
+    expect(screen.getByText(/Related task:/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "tr_1742947200123_0000000001" })).toHaveAttribute(
+      "href",
+      "/tasks/tr_1742947200123_0000000001",
+    );
+    expect(screen.getByDisplayValue(/"command": "pwd"/)).toBeInTheDocument();
+    expect(screen.getByText("Planning / Review")).toBeInTheDocument();
+  });
+});
+
 describe("task run detail", () => {
   it("shows a loading state before the event api resolves", async () => {
     const pending = deferred<Response>();

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -5,6 +5,7 @@ import { BenchmarkRunDetailPage } from "./ui/benchmark-run-detail-page";
 import { BenchmarkSessionDetailPage } from "./ui/benchmark-session-detail-page";
 import { BenchmarkSuiteListPage } from "./ui/benchmark-suite-list-page";
 import { BenchmarkSuitePage } from "./ui/benchmark-suite-page";
+import { EventListPage } from "./ui/event-list-page";
 import { ErrorBoundary } from "./ui/error-boundary";
 import { TaskRunDetailPage } from "./ui/task-run-detail-page";
 import { TaskRunListPage } from "./ui/task-run-list-page";
@@ -17,6 +18,7 @@ export function AppRoutes() {
           <Route path="/" element={<Navigate to="/tasks" replace />} />
           <Route path="/tasks" element={<TaskRunListPage />} />
           <Route path="/tasks/:runID" element={<TaskRunDetailPage />} />
+          <Route path="/events" element={<EventListPage />} />
           <Route path="/benchmarks" element={<BenchmarkSuiteListPage />} />
           <Route path="/benchmarks/:suiteID" element={<BenchmarkSuitePage />} />
           <Route path="/benchmarks/:suiteID/sessions/:sessionID" element={<BenchmarkSessionDetailPage />} />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -307,6 +307,197 @@ code,
   text-transform: uppercase;
 }
 
+.event-page {
+  display: grid;
+  gap: 18px;
+}
+
+.event-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: end;
+  gap: 16px;
+}
+
+.event-toolbar h2,
+.event-toolbar__subtitle {
+  margin: 0;
+}
+
+.event-toolbar__subtitle {
+  margin-top: 8px;
+  color: var(--text-dim);
+}
+
+.event-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.event-filter-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid rgba(140, 230, 216, 0.14);
+  border-radius: 16px;
+  background: rgba(9, 18, 28, 0.6);
+}
+
+.event-filter-field {
+  display: grid;
+  gap: 6px;
+}
+
+.event-filter-field span,
+.event-card__meta-label {
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.event-filter-field input,
+.event-filter-field select,
+.event-pagination__button {
+  min-height: 40px;
+  border: 1px solid rgba(140, 230, 216, 0.16);
+  border-radius: 12px;
+  background: rgba(6, 13, 20, 0.92);
+  color: var(--text-main);
+  font: inherit;
+}
+
+.event-filter-field input,
+.event-filter-field select {
+  padding: 0 12px;
+}
+
+.event-pagination__button {
+  padding: 0 14px;
+  cursor: pointer;
+}
+
+.event-pagination__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.event-filter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 12px;
+}
+
+.event-list {
+  display: grid;
+  gap: 12px;
+}
+
+.event-card {
+  border: 1px solid rgba(140, 230, 216, 0.14);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(9, 18, 28, 0.78), rgba(6, 13, 20, 0.92));
+}
+
+.event-card__summary {
+  width: 100%;
+  display: grid;
+  grid-template-columns:
+    minmax(0, 0.9fr)
+    minmax(0, 1fr)
+    minmax(0, 1fr)
+    minmax(0, 1fr)
+    minmax(100px, 0.7fr)
+    minmax(100px, 0.7fr)
+    minmax(0, 1.1fr);
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.event-card__summary:hover,
+.event-card__summary:focus-visible {
+  outline: none;
+}
+
+.event-card__timestamp {
+  display: grid;
+  gap: 2px;
+  color: var(--text-muted);
+  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.76rem;
+}
+
+.event-card__tool,
+.event-card__server,
+.event-card__identity {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-card__direction,
+.event-card__message {
+  color: var(--text-dim);
+  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.76rem;
+}
+
+.event-card__detail {
+  display: grid;
+  gap: 16px;
+  padding: 0 18px 18px;
+  border-top: 1px solid rgba(140, 230, 216, 0.12);
+}
+
+.event-card__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+
+.event-card__meta p,
+.event-card__task-link {
+  margin: 0;
+}
+
+.event-card__payload {
+  min-width: 0;
+}
+
+.event-card__payload-text {
+  width: 100%;
+  max-width: 100%;
+  min-height: 180px;
+  max-height: 60vh;
+  margin-top: 8px;
+  padding: 14px;
+  box-sizing: border-box;
+  overflow: auto;
+  resize: vertical;
+  border: 1px solid rgba(140, 230, 216, 0.14);
+  border-radius: 14px;
+  background: rgba(3, 8, 14, 0.88);
+  color: var(--text-main);
+  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.74rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .benchmark-page {
   display: grid;
   gap: 20px;
@@ -1612,6 +1803,7 @@ code,
 @media (max-width: 980px) {
   .app-header,
   .task-run-list__toolbar,
+  .event-toolbar,
   .task-run-detail__header,
   .task-run-detail__header-actions,
   .timeline-event__body,
@@ -1629,6 +1821,10 @@ code,
   }
 
   .task-run-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .event-card__summary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1677,6 +1873,10 @@ code,
   }
 
   .task-run-row {
+    grid-template-columns: 1fr;
+  }
+
+  .event-card__summary {
     grid-template-columns: 1fr;
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -398,14 +398,8 @@ code,
   gap: 12px;
 }
 
-.event-card {
-  border: 1px solid rgba(140, 230, 216, 0.14);
-  border-radius: 16px;
-  background: linear-gradient(180deg, rgba(9, 18, 28, 0.78), rgba(6, 13, 20, 0.92));
-}
-
+.event-list__header,
 .event-card__summary {
-  width: 100%;
   display: grid;
   grid-template-columns:
     minmax(0, 0.9fr)
@@ -417,6 +411,24 @@ code,
     minmax(0, 1.1fr);
   gap: 16px;
   align-items: center;
+}
+
+.event-list__header {
+  padding: 0 18px 4px;
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.event-card {
+  border: 1px solid rgba(140, 230, 216, 0.14);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(9, 18, 28, 0.78), rgba(6, 13, 20, 0.92));
+}
+
+.event-card__summary {
+  width: 100%;
   padding: 18px;
   border: 0;
   background: transparent;
@@ -467,9 +479,41 @@ code,
   gap: 14px;
 }
 
+.event-card__meta-item {
+  min-width: 0;
+}
+
 .event-card__meta p,
 .event-card__task-link {
   margin: 0;
+}
+
+.event-card__meta-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.event-card__meta-value--id {
+  color: var(--text-main);
+  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.86rem;
+}
+
+.event-card__meta-action-row {
+  display: grid;
+  gap: 10px;
+}
+
+.event-card__filter-button {
+  width: fit-content;
+  padding: 8px 12px;
+  border: 1px solid rgba(140, 230, 216, 0.18);
+  border-radius: 999px;
+  background: rgba(9, 18, 28, 0.78);
+  color: var(--accent-strong);
+  font: inherit;
+  cursor: pointer;
 }
 
 .event-card__payload {
@@ -1817,6 +1861,10 @@ code,
   }
 
   .task-run-table__header {
+    display: none;
+  }
+
+  .event-list__header {
     display: none;
   }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -395,7 +395,7 @@ code,
 
 .event-list {
   display: grid;
-  gap: 12px;
+  gap: 8px;
 }
 
 .event-list__header,
@@ -414,22 +414,22 @@ code,
 }
 
 .event-list__header {
-  padding: 0 18px 4px;
+  padding: 0 14px 2px;
   color: var(--text-muted);
-  font-size: 0.76rem;
+  font-size: 0.72rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .event-card {
   border: 1px solid rgba(140, 230, 216, 0.14);
-  border-radius: 16px;
+  border-radius: 14px;
   background: linear-gradient(180deg, rgba(9, 18, 28, 0.78), rgba(6, 13, 20, 0.92));
 }
 
 .event-card__summary {
   width: 100%;
-  padding: 18px;
+  padding: 12px 14px;
   border: 0;
   background: transparent;
   color: inherit;
@@ -443,11 +443,11 @@ code,
 }
 
 .event-card__timestamp {
-  display: grid;
-  gap: 2px;
   color: var(--text-muted);
   font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
-  font-size: 0.76rem;
+  font-size: 0.72rem;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .event-card__tool,
@@ -457,13 +457,21 @@ code,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: 1.2;
 }
 
 .event-card__direction,
 .event-card__message {
   color: var(--text-dim);
   font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
-  font-size: 0.76rem;
+  font-size: 0.72rem;
+  line-height: 1.2;
+}
+
+.event-card__summary .status-badge {
+  min-width: 74px;
+  padding: 3px 8px;
+  font-size: 0.68rem;
 }
 
 .event-card__detail {

--- a/web/src/ui/app-shell.tsx
+++ b/web/src/ui/app-shell.tsx
@@ -5,10 +5,13 @@ import { Link, useLocation } from "react-router-dom";
 export function AppShell({ children }: PropsWithChildren) {
   const location = useLocation();
   const benchmarkSection = location.pathname.startsWith("/benchmarks");
-  const title = benchmarkSection ? "Benchmarks" : "Task Runs";
+  const eventSection = location.pathname.startsWith("/events");
+  const title = benchmarkSection ? "Benchmarks" : eventSection ? "Events" : "Task Runs";
   const subtitle = benchmarkSection
     ? "Inspect persisted benchmark suites, sessions, scorecards, and comparisons."
-    : "Inspect task workflow progress, current phase, and run volume.";
+    : eventSection
+      ? "Inspect all persisted MCP action events across the proxy."
+      : "Inspect task workflow progress, current phase, and run volume.";
 
   return (
     <div className="app-shell">
@@ -20,8 +23,11 @@ export function AppShell({ children }: PropsWithChildren) {
             <p className="app-header__eyebrow">Centian Monitor</p>
             <h1>{title}</h1>
             <nav className="app-header__nav" aria-label="Primary">
-              <Link className={!benchmarkSection ? "app-header__nav-link app-header__nav-link--active" : "app-header__nav-link"} to="/tasks">
+              <Link className={!benchmarkSection && !eventSection ? "app-header__nav-link app-header__nav-link--active" : "app-header__nav-link"} to="/tasks">
                 Tasks
+              </Link>
+              <Link className={eventSection ? "app-header__nav-link app-header__nav-link--active" : "app-header__nav-link"} to="/events">
+                Events
               </Link>
               <Link className={benchmarkSection ? "app-header__nav-link app-header__nav-link--active" : "app-header__nav-link"} to="/benchmarks">
                 Benchmarks

--- a/web/src/ui/event-list-page.tsx
+++ b/web/src/ui/event-list-page.tsx
@@ -334,6 +334,15 @@ export function EventListPage() {
         </div>
       ) : (
         <div className="event-list" role="list">
+          <div className="event-list__header" aria-hidden="true">
+            <span>Time</span>
+            <span>Tool</span>
+            <span>Server</span>
+            <span>Direction</span>
+            <span>Type</span>
+            <span>Status</span>
+            <span>Request</span>
+          </div>
           {items.map((item) => {
             const expanded = expandedEventID === item.id;
             const timestampParts = formatTimestampCompact(item.createdAtUnixMilli);
@@ -359,36 +368,53 @@ export function EventListPage() {
                     <span className={statusClass}>{item.success ? "success" : "failed"}</span>
                   </span>
                   <span className="event-card__identity" title={identityLabel}>
-                    {identityLabel}
+                    {formatEventIdentity(identityLabel)}
                   </span>
                 </button>
 
                 {expanded ? (
                   <div className="event-card__detail">
                     <div className="event-card__meta">
-                      <div>
+                      <div className="event-card__meta-item">
                         <p className="event-card__meta-label">Request ID</p>
-                        <p>{item.requestId ?? "—"}</p>
+                        <p className="event-card__meta-value event-card__meta-value--id">{item.requestId ?? "—"}</p>
                       </div>
-                      <div>
+                      <div className="event-card__meta-item">
                         <p className="event-card__meta-label">Session ID</p>
-                        <p>{item.sessionId ?? "—"}</p>
+                        <div className="event-card__meta-action-row">
+                          <p className="event-card__meta-value event-card__meta-value--id">{item.sessionId ?? "—"}</p>
+                          {item.sessionId ? (
+                            <button
+                              type="button"
+                              className="event-card__filter-button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                const next = new URLSearchParams(searchParams);
+                                next.set("sessionId", item.sessionId!);
+                                next.delete("cursor");
+                                setSearchParams(next);
+                              }}
+                            >
+                              Filter session
+                            </button>
+                          ) : null}
+                        </div>
                       </div>
-                      <div>
+                      <div className="event-card__meta-item">
                         <p className="event-card__meta-label">Endpoint</p>
-                        <p>{item.endpoint ?? "—"}</p>
+                        <p className="event-card__meta-value">{item.endpoint ?? "—"}</p>
                       </div>
-                      <div>
+                      <div className="event-card__meta-item">
                         <p className="event-card__meta-label">Transport</p>
-                        <p>{item.transport ?? "—"}</p>
+                        <p className="event-card__meta-value">{item.transport ?? "—"}</p>
                       </div>
-                      <div>
+                      <div className="event-card__meta-item">
                         <p className="event-card__meta-label">Original Tool</p>
-                        <p>{item.originalToolName && item.originalToolName !== item.toolName ? item.originalToolName : "—"}</p>
+                        <p className="event-card__meta-value">{item.originalToolName && item.originalToolName !== item.toolName ? item.originalToolName : "—"}</p>
                       </div>
-                      <div>
+                      <div className="event-card__meta-item">
                         <p className="event-card__meta-label">Invocation Phase</p>
-                        <p>{item.invocationPhasePath ? humanizePhase(item.invocationPhasePath) : "—"}</p>
+                        <p className="event-card__meta-value">{item.invocationPhasePath ? humanizePhase(item.invocationPhasePath) : "—"}</p>
                       </div>
                     </div>
 
@@ -470,4 +496,14 @@ function formatPayloadJSON(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function formatEventIdentity(value: string): string {
+  if (!value || value === "—") {
+    return "—";
+  }
+  if (value.length <= 22) {
+    return value;
+  }
+  return `${value.slice(0, 8)}…${value.slice(-8)}`;
 }

--- a/web/src/ui/event-list-page.tsx
+++ b/web/src/ui/event-list-page.tsx
@@ -7,6 +7,12 @@ import { ApiAuthCard } from "./api-auth-card";
 import { formatTimestamp, formatTimestampCompact, humanizePhase } from "./format";
 
 type LoadState = "loading" | "ready" | "error" | "unauthorized";
+type EventSortColumn = "time" | "tool" | "server" | "direction" | "messageType" | "status" | "request";
+type SortDirection = "asc" | "desc";
+type EventSortState = {
+  column: EventSortColumn;
+  direction: SortDirection;
+};
 type FilterFormState = {
   gateway: string;
   server: string;
@@ -29,6 +35,16 @@ const defaultFilterForm: FilterFormState = {
   sessionId: "",
 };
 
+const eventColumns: Array<{ key: EventSortColumn; label: string }> = [
+  { key: "time", label: "Time" },
+  { key: "tool", label: "Tool" },
+  { key: "server", label: "Server" },
+  { key: "direction", label: "Direction" },
+  { key: "messageType", label: "Type" },
+  { key: "status", label: "Status" },
+  { key: "request", label: "Request" },
+];
+
 export function EventListPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [items, setItems] = useState<EventListItem[]>([]);
@@ -39,9 +55,11 @@ export function EventListPage() {
   const [reloadToken, setReloadToken] = useState(0);
   const [expandedEventID, setExpandedEventID] = useState<string>();
   const [filterForm, setFilterForm] = useState<FilterFormState>(defaultFilterForm);
+  const [sortState, setSortState] = useState<EventSortState>({ column: "time", direction: "desc" });
 
   const filters = eventFiltersFromSearchParams(searchParams);
   const activeFilters = buildActiveFilterChips(filters);
+  const sortedItems = [...items].sort((left, right) => compareEvents(left, right, sortState));
 
   useEffect(() => {
     setFilterForm({
@@ -334,18 +352,44 @@ export function EventListPage() {
         </div>
       ) : (
         <div className="event-list" role="list">
-          <div className="event-list__header" aria-hidden="true">
-            <span>Time</span>
-            <span>Tool</span>
-            <span>Server</span>
-            <span>Direction</span>
-            <span>Type</span>
-            <span>Status</span>
-            <span>Request</span>
+          <div className="event-list__header" role="row">
+            {eventColumns.map((column) => {
+              const isActive = sortState.column === column.key;
+              const ariaSort = isActive ? (sortState.direction === "asc" ? "ascending" : "descending") : "none";
+              return (
+                <span key={column.key} role="columnheader" aria-sort={ariaSort}>
+                  <button
+                    type="button"
+                    className={isActive ? "benchmark-sort-button benchmark-sort-button--active" : "benchmark-sort-button"}
+                    aria-label={`Sort by ${column.label}${isActive ? ` (${sortState.direction})` : ""}`}
+                    onClick={() => {
+                      setSortState((current) => {
+                        if (current.column === column.key) {
+                          return {
+                            column: column.key,
+                            direction: current.direction === "asc" ? "desc" : "asc",
+                          };
+                        }
+                        return {
+                          column: column.key,
+                          direction: defaultEventSortDirection(column.key),
+                        };
+                      });
+                    }}
+                  >
+                    <span>{column.label}</span>
+                    <span className="benchmark-sort-button__indicator" aria-hidden="true">
+                      {isActive ? (sortState.direction === "asc" ? "▲" : "▼") : "↕"}
+                    </span>
+                  </button>
+                </span>
+              );
+            })}
           </div>
-          {items.map((item) => {
+          {sortedItems.map((item) => {
             const expanded = expandedEventID === item.id;
             const timestampParts = formatTimestampCompact(item.createdAtUnixMilli);
+            const compactTimestamp = `${timestampParts.date} ${timestampParts.time}`;
             const statusClass = item.success ? "status-badge status-badge--success" : "status-badge status-badge--failed";
             const identityLabel = item.requestId ?? item.sessionId ?? "—";
 
@@ -356,10 +400,7 @@ export function EventListPage() {
                   className="event-card__summary"
                   onClick={() => setExpandedEventID(expanded ? undefined : item.id)}
                 >
-                  <span className="event-card__timestamp" title={formatTimestamp(item.createdAtUnixMilli)}>
-                    <span>{timestampParts.date}</span>
-                    <span>{timestampParts.time}</span>
-                  </span>
+                  <span className="event-card__timestamp" title={formatTimestamp(item.createdAtUnixMilli)}>{compactTimestamp}</span>
                   <span className="event-card__tool">{item.toolName ?? item.originalToolName ?? "Unknown tool"}</span>
                   <span className="event-card__server">{[item.gateway, item.serverName].filter(Boolean).join(" / ") || "—"}</span>
                   <span className="event-card__direction">{item.direction ?? "—"}</span>
@@ -506,4 +547,67 @@ function formatEventIdentity(value: string): string {
     return value;
   }
   return `${value.slice(0, 8)}…${value.slice(-8)}`;
+}
+
+function defaultEventSortDirection(column: EventSortColumn): SortDirection {
+  switch (column) {
+    case "time":
+      return "desc";
+    default:
+      return "asc";
+  }
+}
+
+function compareEvents(left: EventListItem, right: EventListItem, sortState: EventSortState): number {
+  const directionMultiplier = sortState.direction === "asc" ? 1 : -1;
+  const primaryComparison = comparePrimaryEventColumn(left, right, sortState.column) * directionMultiplier;
+  if (primaryComparison !== 0) {
+    return primaryComparison;
+  }
+
+  const timeComparison = compareNumbers(right.createdAtUnixMilli, left.createdAtUnixMilli);
+  if (timeComparison !== 0) {
+    return timeComparison;
+  }
+
+  return right.id.localeCompare(left.id);
+}
+
+function comparePrimaryEventColumn(left: EventListItem, right: EventListItem, column: EventSortColumn): number {
+  switch (column) {
+    case "time":
+      return compareNumbers(left.createdAtUnixMilli, right.createdAtUnixMilli);
+    case "tool":
+      return compareStrings(left.toolName ?? left.originalToolName ?? "", right.toolName ?? right.originalToolName ?? "");
+    case "server":
+      return compareStrings(serverLabel(left), serverLabel(right));
+    case "direction":
+      return compareStrings(left.direction ?? "", right.direction ?? "");
+    case "messageType":
+      return compareStrings(left.messageType ?? "", right.messageType ?? "");
+    case "status":
+      return compareNumbers(eventStatusRank(left), eventStatusRank(right));
+    case "request":
+      return compareStrings(eventIdentityValue(left), eventIdentityValue(right));
+  }
+}
+
+function compareNumbers(left: number, right: number): number {
+  return left - right;
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function serverLabel(item: EventListItem): string {
+  return [item.gateway, item.serverName].filter(Boolean).join(" / ");
+}
+
+function eventStatusRank(item: EventListItem): number {
+  return item.success ? 1 : 0;
+}
+
+function eventIdentityValue(item: EventListItem): string {
+  return item.requestId ?? item.sessionId ?? "";
 }

--- a/web/src/ui/event-list-page.tsx
+++ b/web/src/ui/event-list-page.tsx
@@ -1,0 +1,473 @@
+import { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+import { type EventListFilters, type EventListItem, fetchEvents } from "../api/events";
+import { ApiError } from "../api/task-runs";
+import { ApiAuthCard } from "./api-auth-card";
+import { formatTimestamp, formatTimestampCompact, humanizePhase } from "./format";
+
+type LoadState = "loading" | "ready" | "error" | "unauthorized";
+type FilterFormState = {
+  gateway: string;
+  server: string;
+  tool: string;
+  direction: string;
+  messageType: string;
+  success: string;
+  requestId: string;
+  sessionId: string;
+};
+
+const defaultFilterForm: FilterFormState = {
+  gateway: "",
+  server: "",
+  tool: "",
+  direction: "",
+  messageType: "",
+  success: "",
+  requestId: "",
+  sessionId: "",
+};
+
+export function EventListPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [items, setItems] = useState<EventListItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string>();
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [authHeaderName, setAuthHeaderName] = useState<string>();
+  const [reloadToken, setReloadToken] = useState(0);
+  const [expandedEventID, setExpandedEventID] = useState<string>();
+  const [filterForm, setFilterForm] = useState<FilterFormState>(defaultFilterForm);
+
+  const filters = eventFiltersFromSearchParams(searchParams);
+  const activeFilters = buildActiveFilterChips(filters);
+
+  useEffect(() => {
+    setFilterForm({
+      gateway: filters.gateway ?? "",
+      server: filters.server ?? "",
+      tool: filters.tool ?? "",
+      direction: filters.direction ?? "",
+      messageType: filters.messageType ?? "",
+      success: typeof filters.success === "boolean" ? String(filters.success) : "",
+      requestId: filters.requestId ?? "",
+      sessionId: filters.sessionId ?? "",
+    });
+  }, [
+    filters.direction,
+    filters.gateway,
+    filters.messageType,
+    filters.requestId,
+    filters.server,
+    filters.sessionId,
+    filters.success,
+    filters.tool,
+  ]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoadState("loading");
+    setErrorMessage("");
+
+    void fetchEvents(filters, controller.signal)
+      .then((page) => {
+        setItems(page.items);
+        setNextCursor(page.nextCursor);
+        setExpandedEventID(undefined);
+        setLoadState("ready");
+      })
+      .catch((error: unknown) => {
+        if ((error as Error)?.name === "AbortError") {
+          return;
+        }
+        if (error instanceof ApiError && error.status === 401) {
+          setAuthHeaderName(error.authHeaderName);
+          setErrorMessage("Enter a Centian API key to read persisted MCP events.");
+          setLoadState("unauthorized");
+          return;
+        }
+        setErrorMessage("Unable to load MCP events right now.");
+        setLoadState("error");
+      });
+
+    return () => controller.abort();
+  }, [filters.cursor, filters.direction, filters.gateway, filters.limit, filters.messageType, filters.requestId, filters.server, filters.sessionId, filters.success, filters.tool, reloadToken]);
+
+  useEffect(() => {
+    if (loadState !== "ready" || filters.cursor) {
+      return;
+    }
+
+    let inFlight = false;
+    let controller: AbortController | null = null;
+
+    const poll = () => {
+      if (inFlight || document.visibilityState === "hidden") {
+        return;
+      }
+
+      inFlight = true;
+      controller = new AbortController();
+      void fetchEvents(filters, controller.signal)
+        .then((page) => {
+          setItems(page.items);
+          setNextCursor(page.nextCursor);
+        })
+        .catch((error: unknown) => {
+          if ((error as Error)?.name === "AbortError") {
+            return;
+          }
+          if (error instanceof ApiError && error.status === 401) {
+            setAuthHeaderName(error.authHeaderName);
+            setErrorMessage("Enter a Centian API key to read persisted MCP events.");
+            setLoadState("unauthorized");
+          }
+        })
+        .finally(() => {
+          inFlight = false;
+          controller = null;
+        });
+    };
+
+    const timer = window.setInterval(poll, 2000);
+    return () => {
+      window.clearInterval(timer);
+      controller?.abort();
+    };
+  }, [filters.cursor, filters.direction, filters.gateway, filters.limit, filters.messageType, filters.requestId, filters.server, filters.sessionId, filters.success, filters.tool, loadState]);
+
+  if (loadState === "loading") {
+    return (
+      <div className="state-card" data-testid="event-list-loading">
+        <p className="state-card__eyebrow">Syncing</p>
+        <h2>Loading MCP events…</h2>
+        <p>Pulling the latest persisted proxy activity from the Centian API.</p>
+      </div>
+    );
+  }
+
+  if (loadState === "error") {
+    return (
+      <div className="state-card state-card--error" role="alert">
+        <p className="state-card__eyebrow">Link Loss</p>
+        <h2>Event feed unavailable</h2>
+        <p>{errorMessage}</p>
+      </div>
+    );
+  }
+
+  if (loadState === "unauthorized") {
+    return (
+      <ApiAuthCard
+        eyebrow="Access Required"
+        title="Event feed is protected"
+        body={errorMessage}
+        authHeaderName={authHeaderName}
+        onSaved={() => setReloadToken((value) => value + 1)}
+      />
+    );
+  }
+
+  return (
+    <div className="event-page">
+      <div className="event-toolbar">
+        <div>
+          <p className="state-card__eyebrow">Global Feed</p>
+          <h2>Observed MCP events</h2>
+          <p className="event-toolbar__subtitle">Newest first across all proxied traffic.</p>
+        </div>
+        <div className="event-toolbar__actions">
+          <p className="task-run-list__count">{items.length} visible events</p>
+          <button
+            type="button"
+            className="task-run-filter-clear"
+            onClick={() => {
+              const next = new URLSearchParams(searchParams);
+              next.delete("cursor");
+              setSearchParams(next);
+            }}
+          >
+            Newest
+          </button>
+          <button
+            type="button"
+            className="event-pagination__button"
+            disabled={!nextCursor}
+            onClick={() => {
+              if (!nextCursor) {
+                return;
+              }
+              const next = new URLSearchParams(searchParams);
+              next.set("cursor", nextCursor);
+              setSearchParams(next);
+            }}
+          >
+            Older
+          </button>
+        </div>
+      </div>
+
+      <form
+        className="event-filter-panel"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const next = new URLSearchParams(searchParams);
+          setOrDelete(next, "gateway", filterForm.gateway);
+          setOrDelete(next, "server", filterForm.server);
+          setOrDelete(next, "tool", filterForm.tool);
+          setOrDelete(next, "direction", filterForm.direction);
+          setOrDelete(next, "messageType", filterForm.messageType);
+          setOrDelete(next, "success", filterForm.success);
+          setOrDelete(next, "requestId", filterForm.requestId);
+          setOrDelete(next, "sessionId", filterForm.sessionId);
+          next.delete("cursor");
+          setSearchParams(next);
+        }}
+      >
+        <label className="event-filter-field">
+          <span>Gateway</span>
+          <input
+            value={filterForm.gateway}
+            onChange={(event) => setFilterForm((current) => ({ ...current, gateway: event.target.value }))}
+          />
+        </label>
+        <label className="event-filter-field">
+          <span>Server</span>
+          <input
+            value={filterForm.server}
+            onChange={(event) => setFilterForm((current) => ({ ...current, server: event.target.value }))}
+          />
+        </label>
+        <label className="event-filter-field">
+          <span>Tool</span>
+          <input
+            value={filterForm.tool}
+            onChange={(event) => setFilterForm((current) => ({ ...current, tool: event.target.value }))}
+          />
+        </label>
+        <label className="event-filter-field">
+          <span>Direction</span>
+          <select
+            value={filterForm.direction}
+            onChange={(event) => setFilterForm((current) => ({ ...current, direction: event.target.value }))}
+          >
+            <option value="">All directions</option>
+            <option value="[CLIENT -> SERVER]">Client to server</option>
+            <option value="[SERVER -> CLIENT]">Server to client</option>
+            <option value="[CENTIAN -> CLIENT]">Centian to client</option>
+          </select>
+        </label>
+        <label className="event-filter-field">
+          <span>Message Type</span>
+          <select
+            value={filterForm.messageType}
+            onChange={(event) => setFilterForm((current) => ({ ...current, messageType: event.target.value }))}
+          >
+            <option value="">All message types</option>
+            <option value="request">Request</option>
+            <option value="response">Response</option>
+            <option value="system">System</option>
+          </select>
+        </label>
+        <label className="event-filter-field">
+          <span>Success</span>
+          <select
+            value={filterForm.success}
+            onChange={(event) => setFilterForm((current) => ({ ...current, success: event.target.value }))}
+          >
+            <option value="">All outcomes</option>
+            <option value="true">Success</option>
+            <option value="false">Failure</option>
+          </select>
+        </label>
+        <label className="event-filter-field">
+          <span>Request ID</span>
+          <input
+            value={filterForm.requestId}
+            onChange={(event) => setFilterForm((current) => ({ ...current, requestId: event.target.value }))}
+          />
+        </label>
+        <label className="event-filter-field">
+          <span>Session ID</span>
+          <input
+            value={filterForm.sessionId}
+            onChange={(event) => setFilterForm((current) => ({ ...current, sessionId: event.target.value }))}
+          />
+        </label>
+        <div className="event-filter-actions">
+          <button type="submit" className="event-pagination__button">
+            Apply
+          </button>
+          <button
+            type="button"
+            className="task-run-filter-clear"
+            onClick={() => {
+              setFilterForm(defaultFilterForm);
+              setSearchParams(new URLSearchParams());
+            }}
+          >
+            Clear
+          </button>
+        </div>
+      </form>
+
+      {activeFilters.length > 0 ? (
+        <div className="task-run-filter-bar" aria-label="Active event filters">
+          {activeFilters.map((filter) => (
+            <span key={filter.key} className="task-run-filter-chip">
+              {filter.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {items.length === 0 ? (
+        <div className="state-card">
+          <p className="state-card__eyebrow">Quiet Channel</p>
+          <h2>{activeFilters.length > 0 ? "No matching events" : "No persisted events yet"}</h2>
+          <p>
+            {activeFilters.length > 0
+              ? "No persisted MCP events match the active filters."
+              : "Proxy activity will appear here once the event store records MCP traffic."}
+          </p>
+        </div>
+      ) : (
+        <div className="event-list" role="list">
+          {items.map((item) => {
+            const expanded = expandedEventID === item.id;
+            const timestampParts = formatTimestampCompact(item.createdAtUnixMilli);
+            const statusClass = item.success ? "status-badge status-badge--success" : "status-badge status-badge--failed";
+            const identityLabel = item.requestId ?? item.sessionId ?? "—";
+
+            return (
+              <article key={item.id} className="event-card" role="listitem">
+                <button
+                  type="button"
+                  className="event-card__summary"
+                  onClick={() => setExpandedEventID(expanded ? undefined : item.id)}
+                >
+                  <span className="event-card__timestamp" title={formatTimestamp(item.createdAtUnixMilli)}>
+                    <span>{timestampParts.date}</span>
+                    <span>{timestampParts.time}</span>
+                  </span>
+                  <span className="event-card__tool">{item.toolName ?? item.originalToolName ?? "Unknown tool"}</span>
+                  <span className="event-card__server">{[item.gateway, item.serverName].filter(Boolean).join(" / ") || "—"}</span>
+                  <span className="event-card__direction">{item.direction ?? "—"}</span>
+                  <span className="event-card__message">{item.messageType ?? "—"}</span>
+                  <span className="event-card__status">
+                    <span className={statusClass}>{item.success ? "success" : "failed"}</span>
+                  </span>
+                  <span className="event-card__identity" title={identityLabel}>
+                    {identityLabel}
+                  </span>
+                </button>
+
+                {expanded ? (
+                  <div className="event-card__detail">
+                    <div className="event-card__meta">
+                      <div>
+                        <p className="event-card__meta-label">Request ID</p>
+                        <p>{item.requestId ?? "—"}</p>
+                      </div>
+                      <div>
+                        <p className="event-card__meta-label">Session ID</p>
+                        <p>{item.sessionId ?? "—"}</p>
+                      </div>
+                      <div>
+                        <p className="event-card__meta-label">Endpoint</p>
+                        <p>{item.endpoint ?? "—"}</p>
+                      </div>
+                      <div>
+                        <p className="event-card__meta-label">Transport</p>
+                        <p>{item.transport ?? "—"}</p>
+                      </div>
+                      <div>
+                        <p className="event-card__meta-label">Original Tool</p>
+                        <p>{item.originalToolName && item.originalToolName !== item.toolName ? item.originalToolName : "—"}</p>
+                      </div>
+                      <div>
+                        <p className="event-card__meta-label">Invocation Phase</p>
+                        <p>{item.invocationPhasePath ? humanizePhase(item.invocationPhasePath) : "—"}</p>
+                      </div>
+                    </div>
+
+                    {item.taskRunId ? (
+                      <p className="event-card__task-link">
+                        Related task: <Link to={`/tasks/${item.taskRunId}`}>{item.taskRunId}</Link>
+                      </p>
+                    ) : null}
+
+                    <div className="event-card__payload">
+                      <p className="event-card__meta-label">Payload</p>
+                      <textarea
+                        className="event-card__payload-text"
+                        readOnly
+                        spellCheck={false}
+                        aria-label={`Payload for ${item.toolName ?? item.id}`}
+                        value={formatPayloadJSON(item.payloadJson)}
+                      />
+                    </div>
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function eventFiltersFromSearchParams(searchParams: URLSearchParams): EventListFilters {
+  const rawSuccess = searchParams.get("success")?.trim();
+  const rawLimit = searchParams.get("limit")?.trim();
+
+  return {
+    gateway: searchParams.get("gateway")?.trim() || undefined,
+    server: searchParams.get("server")?.trim() || undefined,
+    tool: searchParams.get("tool")?.trim() || undefined,
+    direction: searchParams.get("direction")?.trim() || undefined,
+    messageType: searchParams.get("messageType")?.trim() || undefined,
+    success: rawSuccess === "true" ? true : rawSuccess === "false" ? false : undefined,
+    requestId: searchParams.get("requestId")?.trim() || undefined,
+    sessionId: searchParams.get("sessionId")?.trim() || undefined,
+    cursor: searchParams.get("cursor")?.trim() || undefined,
+    limit: rawLimit && Number(rawLimit) > 0 ? Number(rawLimit) : undefined,
+  };
+}
+
+function buildActiveFilterChips(filters: EventListFilters): Array<{ key: string; label: string }> {
+  const chips: Array<{ key: string; label: string }> = [];
+  if (filters.gateway) chips.push({ key: "gateway", label: `Gateway: ${filters.gateway}` });
+  if (filters.server) chips.push({ key: "server", label: `Server: ${filters.server}` });
+  if (filters.tool) chips.push({ key: "tool", label: `Tool: ${filters.tool}` });
+  if (filters.direction) chips.push({ key: "direction", label: `Direction: ${filters.direction}` });
+  if (filters.messageType) chips.push({ key: "messageType", label: `Type: ${filters.messageType}` });
+  if (typeof filters.success === "boolean") chips.push({ key: "success", label: `Success: ${String(filters.success)}` });
+  if (filters.requestId) chips.push({ key: "requestId", label: `Request: ${filters.requestId}` });
+  if (filters.sessionId) chips.push({ key: "sessionId", label: `Session: ${filters.sessionId}` });
+  if (filters.cursor) chips.push({ key: "cursor", label: "Older page" });
+  return chips;
+}
+
+function setOrDelete(params: URLSearchParams, key: string, value: string) {
+  const normalized = value.trim();
+  if (normalized) {
+    params.set(key, normalized);
+    return;
+  }
+  params.delete(key);
+}
+
+function formatPayloadJSON(value: unknown): string {
+  if (value === undefined) {
+    return "No payload recorded.";
+  }
+  try {
+    const formatted = JSON.stringify(value, null, 2);
+    return formatted ?? "No payload recorded.";
+  } catch {
+    return String(value);
+  }
+}


### PR DESCRIPTION
## Description

This PR is the first step to allow visualization of MCP events beyond the task verification capability.

While task verification is the main focal point for centian, visualizing agent actions beyond it serves the purpose of understanding how agents interact with their surroundings given no constraints of a specific task or process.

What this PR does:
- introduces "Events" page in the frontend, available under `/ui/events`
- introduces a unified MCP event API endpoint to query events
- added filter mechanisms via query parameter for this API endpoint, allowing for MCP event filters for an initial set of fields
- linking events to task runs and sessions in the UI

## Related Issues

Closes #138

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes are described below)
- [x] Code has been linted and formatted
