### PR TITLE
Introduce PrincipalProvider abstraction and token format with embedded credential IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Major
+- Introduced a `PrincipalProvider` authentication abstraction and an `Authorizer` authorization seam. Authentication now resolves a token to a first-class `Principal` (with a stable, persisted `pr_` id), and the proxy keys request identity, downstream-pool reuse, and authorization off that principal. The file-based provider (backed by `~/.centian/api_keys.json`) is the only implementation for now; SQL/external providers and RBAC roles are designed as additive follow-ups.
+- Replaced the O(n) bcrypt scan on every authenticated request with an O(1) credential-id lookup plus a single bcrypt verification.
+
+### Breaking changes
+- **API key token format changed** to `sk-<credentialId>.<secret>`, and only the secret is bcrypt-hashed. Existing `api_keys.json` keys are invalidated; regenerate them with `centian auth new-key`. Pre-principal tokens are rejected with a clear "regenerate" error.
+- **Stored key entries gain a persisted `principal_id`** field; keys created before this change must be regenerated to receive one.
+- **Processor `AuthContext.principal_id` changed** from a gateway-scoped `sha256(keyID:gateway)` hex value to the stable, gateway-independent `pr_` principal id (`key_id` remains the credential id).
+- **Persisted downstream OAuth bindings are orphaned on upgrade** because they were keyed on the old `auth:<keyId>` identity; affected downstreams must be re-authorized.
+
 ## v0.4.3 - 2026-06-01
 
 ### Major

--- a/docs/HTTP_PROXY_SETUP.md
+++ b/docs/HTTP_PROXY_SETUP.md
@@ -50,7 +50,11 @@ centian auth new-key
 
 This prints the API key once and writes the hashed entry to `~/.centian/api_keys.json`.
 
-The file stores bcrypt hashes plus metadata, not plaintext keys. The on-disk shape is:
+The printed key has the form `sk-<credentialId>.<secret>`, where `<credentialId>`
+matches the entry `id` and lets the proxy look the credential up in O(1) before
+verifying the secret. Only the secret is bcrypt-hashed; the file never stores the
+plaintext key. Each entry also records a stable `principal_id` (`pr_...`) that the
+credential resolves to. The on-disk shape is:
 
 ```json
 {
@@ -58,11 +62,15 @@ The file stores bcrypt hashes plus metadata, not plaintext keys. The on-disk sha
     {
       "id": "key_0123456789abcdef",
       "hash": "$2a$10$...",
+      "principal_id": "pr_1712050200000_abcdefghij",
       "created_at": "2026-04-02T10:30:00Z"
     }
   ]
 }
 ```
+
+> Keys created before the token-format change are no longer valid and must be
+> regenerated with `centian auth new-key`.
 
 If you disable auth for local testing, set `"auth": false` in your config instead.
 

--- a/internal/auth/apikeys.go
+++ b/internal/auth/apikeys.go
@@ -52,6 +52,7 @@ type APIKeyEntry struct {
 	ID          string   `json:"id"`
 	Hash        string   `json:"hash"`
 	PrincipalID string   `json:"principal_id,omitempty"`
+	Name        string   `json:"name,omitempty"` // Human-friendly principal name (optional)
 	CreatedAt   string   `json:"created_at"`
 	Gateways    []string `json:"gateways,omitempty"`
 	Projects    []string `json:"projects,omitempty"` // Allowed project slugs (empty = allow all, "*" = allow all)
@@ -62,9 +63,14 @@ func (e *APIKeyEntry) toPrincipal() *Principal {
 	if e == nil {
 		return nil
 	}
+	displayName := e.Name
+	if displayName == "" {
+		// Fall back to the credential id when no human-friendly name was provided.
+		displayName = e.ID
+	}
 	return &Principal{
 		ID:           e.PrincipalID,
-		DisplayName:  e.ID,
+		DisplayName:  displayName,
 		CredentialID: e.ID,
 		Gateways:     append([]string(nil), e.Gateways...),
 		Projects:     append([]string(nil), e.Projects...),

--- a/internal/auth/apikeys.go
+++ b/internal/auth/apikeys.go
@@ -15,6 +15,15 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/T4cceptor/centian/internal/config"
+	"github.com/T4cceptor/centian/internal/identifiers"
+)
+
+const (
+	// apiKeyTokenPrefix is the stable, human-recognizable prefix on every token.
+	apiKeyTokenPrefix = "sk-"
+	// tokenSeparator splits the public credential id from the secret. It is
+	// outside the base64url alphabet so it cannot appear inside the secret.
+	tokenSeparator = "."
 )
 
 var (
@@ -34,18 +43,42 @@ type APIKeyFile struct {
 }
 
 // APIKeyEntry represents a stored API key hash and metadata.
+//
+// ID is the credential id embedded (public) in the token; Hash is the bcrypt of
+// the token's secret portion only. PrincipalID is the stable principal identity
+// this credential resolves to and must be persisted (never regenerated on load)
+// so downstream pool reuse and OAuth bindings stay stable across restarts.
 type APIKeyEntry struct {
-	ID        string   `json:"id"`
-	Hash      string   `json:"hash"`
-	CreatedAt string   `json:"created_at"`
-	Gateways  []string `json:"gateways,omitempty"`
-	Projects  []string `json:"projects,omitempty"` // Allowed project slugs (empty = allow all, "*" = allow all)
+	ID          string   `json:"id"`
+	Hash        string   `json:"hash"`
+	PrincipalID string   `json:"principal_id,omitempty"`
+	CreatedAt   string   `json:"created_at"`
+	Gateways    []string `json:"gateways,omitempty"`
+	Projects    []string `json:"projects,omitempty"` // Allowed project slugs (empty = allow all, "*" = allow all)
+}
+
+// toPrincipal maps a stored credential entry to its resolved Principal.
+func (e *APIKeyEntry) toPrincipal() *Principal {
+	if e == nil {
+		return nil
+	}
+	return &Principal{
+		ID:           e.PrincipalID,
+		DisplayName:  e.ID,
+		CredentialID: e.ID,
+		Gateways:     append([]string(nil), e.Gateways...),
+		Projects:     append([]string(nil), e.Projects...),
+	}
 }
 
 // APIKeyStore stores API keys loaded from disk for quick validation.
+//
+// Deprecated: superseded by the FilePrincipalProvider. Retained until the proxy
+// is fully migrated to PrincipalProvider, then removed.
 type APIKeyStore struct {
 	path    string
 	entries []APIKeyEntry
+	index   map[string]*APIKeyEntry // keyed by credential id for O(1) lookup
 }
 
 // DefaultAPIKeysPath returns the default path to the API keys file (~/.centian/api_keys.json).
@@ -77,69 +110,76 @@ func LoadAPIKeys(path string) (*APIKeyStore, error) {
 		return nil, fmt.Errorf("%w: %s", ErrAPIKeysEmpty, path)
 	}
 
-	for _, entry := range file.Keys {
+	index := make(map[string]*APIKeyEntry, len(file.Keys))
+	for i := range file.Keys {
+		entry := &file.Keys[i]
 		if strings.TrimSpace(entry.Hash) == "" {
 			return nil, fmt.Errorf("%w: empty hash", ErrAPIKeysInvalid)
 		}
+		index[entry.ID] = entry
 	}
 
 	return &APIKeyStore{
 		path:    path,
 		entries: file.Keys,
+		index:   index,
 	}, nil
 }
 
-// Lookup returns the matching API key entry for the provided plaintext key.
+// Lookup returns the matching API key entry for the provided token.
+// It resolves the credential id embedded in the token to a single entry (O(1))
+// and verifies the secret with one bcrypt comparison.
 func (s *APIKeyStore) Lookup(key string) (*APIKeyEntry, bool) {
 	if s == nil {
 		return nil, false
 	}
-	for i := range s.entries {
-		entry := &s.entries[i]
-		if err := bcrypt.CompareHashAndPassword([]byte(entry.Hash), []byte(key)); err == nil {
-			return entry, true
-		}
+	credID, secret, err := parseToken(key)
+	if err != nil {
+		return nil, false
 	}
-	return nil, false
+	entry, ok := s.index[credID]
+	if !ok {
+		return nil, false
+	}
+	if bcrypt.CompareHashAndPassword([]byte(entry.Hash), []byte(secret)) != nil {
+		return nil, false
+	}
+	return entry, true
+}
+
+// parseToken splits a token of the form "sk-<credId>.<secret>" into its parts.
+// Tokens without the embedded credential id (the pre-principal format) are
+// rejected with ErrLegacyTokenFormat.
+func parseToken(token string) (credID, secret string, err error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(token), apiKeyTokenPrefix)
+	sepIndex := strings.Index(trimmed, tokenSeparator)
+	if sepIndex < 0 {
+		return "", "", ErrLegacyTokenFormat
+	}
+	credID = trimmed[:sepIndex]
+	secret = trimmed[sepIndex+len(tokenSeparator):]
+	if credID == "" || secret == "" {
+		return "", "", ErrLegacyTokenFormat
+	}
+	return credID, secret, nil
 }
 
 // AllowsGateway checks whether this key is allowed to access the given gateway.
-//
-// Backward compatibility:
-// - Empty Gateway lists are treated as allow-all.
-// - "*" is treated as allow-all.
+// Empty list or "*" means allow-all (see allowMatch).
 func (e *APIKeyEntry) AllowsGateway(gateway string) bool {
 	if e == nil {
 		return false
 	}
-	if len(e.Gateways) == 0 {
-		return true
-	}
-	for _, gw := range e.Gateways {
-		if gw == "*" || strings.EqualFold(strings.TrimSpace(gw), strings.TrimSpace(gateway)) {
-			return true
-		}
-	}
-	return false
+	return allowMatch(e.Gateways, gateway)
 }
 
 // AllowsProject checks whether this key is allowed to access the given project.
-//
-// - Empty Projects list is treated as allow-all.
-// - "*" is treated as allow-all.
+// Empty list or "*" means allow-all (see allowMatch).
 func (e *APIKeyEntry) AllowsProject(project string) bool {
 	if e == nil {
 		return false
 	}
-	if len(e.Projects) == 0 {
-		return true
-	}
-	for _, p := range e.Projects {
-		if p == "*" || strings.EqualFold(strings.TrimSpace(p), strings.TrimSpace(project)) {
-			return true
-		}
-	}
-	return false
+	return allowMatch(e.Projects, project)
 }
 
 // Validate returns true if the provided API key exists in the store.
@@ -220,33 +260,49 @@ func AppendAPIKey(path string, entry *APIKeyEntry) (*APIKeyFile, error) {
 	return file, nil
 }
 
-// GenerateAPIKey creates a new API key string with a stable prefix.
-func GenerateAPIKey() (string, error) {
-	tokenBytes := make([]byte, 32)
-	if _, err := rand.Read(tokenBytes); err != nil {
-		return "", fmt.Errorf("failed to generate api key: %w", err)
-	}
-	token := base64.RawURLEncoding.EncodeToString(tokenBytes)
-	return "sk-" + token, nil
+// GeneratedKey holds the material produced when minting a new API key. Only the
+// Token is shown to the user (once); CredID and Secret are used to build the
+// stored entry (the credential id is public, the secret is bcrypt-hashed).
+type GeneratedKey struct {
+	Token  string
+	CredID string
+	Secret string
 }
 
-// NewAPIKeyEntry hashes a plaintext API key and returns a stored entry.
-func NewAPIKeyEntry(plainKey string) (APIKeyEntry, error) {
-	if strings.TrimSpace(plainKey) == "" {
-		return APIKeyEntry{}, fmt.Errorf("%w: empty api key", ErrAPIKeysInvalid)
+// GenerateAPIKey mints a new API key token of the form "sk-<credId>.<secret>".
+func GenerateAPIKey() (GeneratedKey, error) {
+	credID, err := generateKeyID()
+	if err != nil {
+		return GeneratedKey{}, err
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(plainKey), bcrypt.DefaultCost)
+	secretBytes := make([]byte, 32)
+	if _, err := rand.Read(secretBytes); err != nil {
+		return GeneratedKey{}, fmt.Errorf("failed to generate api key: %w", err)
+	}
+	secret := base64.RawURLEncoding.EncodeToString(secretBytes)
+	return GeneratedKey{
+		Token:  apiKeyTokenPrefix + credID + tokenSeparator + secret,
+		CredID: credID,
+		Secret: secret,
+	}, nil
+}
+
+// NewAPIKeyEntry builds a stored entry from generated key material. The secret
+// (not the whole token) is bcrypt-hashed, and a fresh persisted principal id is
+// assigned so the credential resolves to a stable principal across restarts.
+func NewAPIKeyEntry(gen GeneratedKey) (APIKeyEntry, error) {
+	if strings.TrimSpace(gen.Secret) == "" || strings.TrimSpace(gen.CredID) == "" {
+		return APIKeyEntry{}, fmt.Errorf("%w: empty api key material", ErrAPIKeysInvalid)
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(gen.Secret), bcrypt.DefaultCost)
 	if err != nil {
 		return APIKeyEntry{}, fmt.Errorf("failed to hash api key: %w", err)
 	}
-	id, err := generateKeyID()
-	if err != nil {
-		return APIKeyEntry{}, err
-	}
 	return APIKeyEntry{
-		ID:        id,
-		Hash:      string(hash),
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		ID:          gen.CredID,
+		Hash:        string(hash),
+		PrincipalID: identifiers.New(identifiers.KindPrincipal),
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
 	}, nil
 }
 

--- a/internal/auth/apikeys_test.go
+++ b/internal/auth/apikeys_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/crypto/bcrypt"
@@ -31,12 +32,12 @@ func TestLoadDefaultAPIKeys(t *testing.T) {
 	path, err := DefaultAPIKeysPath()
 	assert.NilError(t, err)
 
-	plain := "sk-test-default"
+	secret := "default-secret"
 	file := &APIKeyFile{
 		Keys: []APIKeyEntry{
 			{
 				ID:        "key_1",
-				Hash:      hashKey(t, plain),
+				Hash:      hashKey(t, secret),
 				CreatedAt: "2025-01-01T00:00:00Z",
 			},
 		},
@@ -46,11 +47,11 @@ func TestLoadDefaultAPIKeys(t *testing.T) {
 	// When: loading API keys from the default path
 	store, err := LoadDefaultAPIKeys()
 
-	// Then: the key should validate and path should match
+	// Then: the key should validate via its token and path should match
 	assert.NilError(t, err)
 	assert.Equal(t, store.Path(), path)
 	assert.Equal(t, store.Count(), 1)
-	if _, ok := store.Lookup(plain); !ok {
+	if _, ok := store.Lookup(tokenFor("key_1", secret)); !ok {
 		t.Fatalf("expected key to validate")
 	}
 }
@@ -72,13 +73,18 @@ func TestPath(t *testing.T) {
 func TestGenerateAPIKey(t *testing.T) {
 	// Given: GenerateAPIKey method
 	// When: calling GenerateAPIKey
-	new_key, err := GenerateAPIKey()
+	gen, err := GenerateAPIKey()
 
-	// Then: no error, and key is as expected
+	// Then: token has the sk- prefix, embeds the credential id, and round-trips
 	assert.NilError(t, err)
-	sk_prefix := new_key[:3]
-	assert.Assert(t, sk_prefix == "sk-")
-	assert.Assert(t, len(new_key) == 46)
+	assert.Assert(t, strings.HasPrefix(gen.Token, "sk-"))
+	assert.Assert(t, gen.CredID != "" && gen.Secret != "")
+	assert.Equal(t, gen.Token, tokenFor(gen.CredID, gen.Secret))
+
+	credID, secret, perr := parseToken(gen.Token)
+	assert.NilError(t, perr)
+	assert.Equal(t, credID, gen.CredID)
+	assert.Equal(t, secret, gen.Secret)
 }
 
 func TestLoadAPIKeys_NotFound(t *testing.T) {
@@ -95,49 +101,52 @@ func TestLoadAPIKeys_NotFound(t *testing.T) {
 }
 
 func TestLoadAPIKeys_ObjectFormat(t *testing.T) {
-	// Given: a JSON object with hashed keys
-	hash1 := hashKey(t, "key-1")
-	hash2 := hashKey(t, "key-2")
-	path := writeTempFile(t, `{"keys":[{"id":"key_1","hash":"`+hash1+`","created_at":"2025-01-01T00:00:00Z"},{"id":"key_2","hash":"`+hash2+`","created_at":"2025-01-02T00:00:00Z"}]}`)
+	// Given: a JSON object with two hashed keys
+	path := writeTempFile(t, `{"keys":[`+
+		entryJSON(t, "key_1", "secret-1")+`,`+
+		entryJSON(t, "key_2", "secret-2")+`]}`)
 
 	// When: loading API keys from the file
 	store, err := LoadAPIKeys(path)
 
-	// Then: keys should validate
+	// Then: both tokens should validate, unknown ones should not
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if store.Count() != 2 {
 		t.Fatalf("expected 2 keys, got %d", store.Count())
 	}
-	if _, ok := store.Lookup("key-1"); !ok {
-		t.Fatalf("expected key-1 to be present")
+	if _, ok := store.Lookup(tokenFor("key_1", "secret-1")); !ok {
+		t.Fatalf("expected key_1 to be present")
 	}
-	if _, ok := store.Lookup("key-2"); !ok {
-		t.Fatalf("expected keys to be present")
+	if _, ok := store.Lookup(tokenFor("key_2", "secret-2")); !ok {
+		t.Fatalf("expected key_2 to be present")
 	}
-	if _, ok := store.Lookup("missing"); ok {
-		t.Fatalf("expected missing key to be invalid")
+	if _, ok := store.Lookup(tokenFor("key_2", "wrong-secret")); ok {
+		t.Fatalf("expected wrong secret to be invalid")
+	}
+	if _, ok := store.Lookup(tokenFor("key_missing", "secret-1")); ok {
+		t.Fatalf("expected missing credential id to be invalid")
 	}
 }
 
 func TestAPIKeyStoreLookup(t *testing.T) {
 	// Given: a store with one API key
-	plain := "lookup-key"
-	path := writeTempFile(t, `{"keys":[{"id":"key_lookup","hash":"`+hashKey(t, plain)+`","created_at":"2025-01-01T00:00:00Z"}]}`)
+	secret := "lookup-secret"
+	path := writeTempFile(t, `{"keys":[`+entryJSON(t, "key_lookup", secret)+`]}`)
 	store, err := LoadAPIKeys(path)
 	assert.NilError(t, err)
 
-	// When: looking up the valid key
-	entry, ok := store.Lookup(plain)
+	// When: looking up the valid token
+	entry, ok := store.Lookup(tokenFor("key_lookup", secret))
 
 	// Then: the matching entry is returned
 	assert.Assert(t, ok)
 	assert.Assert(t, entry != nil)
 	assert.Equal(t, entry.ID, "key_lookup")
 
-	// When: looking up an invalid key
-	entry, ok = store.Lookup("missing")
+	// When: looking up a legacy-format token (no embedded credential id)
+	entry, ok = store.Lookup("sk-legacyformat")
 
 	// Then: no entry is returned
 	assert.Assert(t, !ok)
@@ -171,12 +180,13 @@ func TestLoadAPIKeys_Empty(t *testing.T) {
 }
 
 func TestAppendAPIKey(t *testing.T) {
-	// Given: an empty api key file
+	// Given: an empty api key file and freshly minted key material
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "api_keys.json")
 
-	plain := "sk-test-key"
-	entry, err := NewAPIKeyEntry(plain)
+	gen, err := GenerateAPIKey()
+	assert.NilError(t, err)
+	entry, err := NewAPIKeyEntry(gen)
 	if err != nil {
 		t.Fatalf("failed to create entry: %v", err)
 	}
@@ -186,29 +196,37 @@ func TestAppendAPIKey(t *testing.T) {
 		t.Fatalf("failed to append api key: %v", err)
 	}
 
-	// Then: the key should validate
+	// Then: the original token should validate, and a principal id is persisted
 	store, err := LoadAPIKeys(path)
 	if err != nil {
 		t.Fatalf("failed to load api keys: %v", err)
 	}
-	if _, ok := store.Lookup(plain); !ok {
+	if _, ok := store.Lookup(gen.Token); !ok {
 		t.Fatalf("expected key to validate")
 	}
+	assert.Assert(t, strings.HasPrefix(entry.PrincipalID, "pr_"))
 }
 
 func TestResolve(t *testing.T) {
-	plain := "sk-test-resolve"
-	path := writeTempFile(t, `{"keys":[{"id":"key_resolve","hash":"`+hashKey(t, plain)+`","created_at":"2025-01-01T00:00:00Z"}]}`)
+	secret := "resolve-secret"
+	path := writeTempFile(t, `{"keys":[`+entryJSON(t, "key_resolve", secret)+`]}`)
 	store, err := LoadAPIKeys(path)
 	assert.NilError(t, err)
 
-	entry, ok := store.Lookup(plain)
+	entry, ok := store.Lookup(tokenFor("key_resolve", secret))
 	assert.Assert(t, ok)
 	assert.Assert(t, entry != nil)
 	assert.Equal(t, entry.ID, "key_resolve")
 
-	_, ok = store.Lookup("sk-missing")
+	_, ok = store.Lookup(tokenFor("key_resolve", "wrong"))
 	assert.Assert(t, !ok)
+}
+
+func TestParseTokenRejectsLegacyFormat(t *testing.T) {
+	// Given: a pre-principal token without an embedded credential id
+	// When/Then: parsing it returns ErrLegacyTokenFormat
+	_, _, err := parseToken("sk-justasecretnodot")
+	assert.Assert(t, errors.Is(err, ErrLegacyTokenFormat))
 }
 
 func TestAPIKeyEntryAllowsGateway(t *testing.T) {
@@ -247,4 +265,15 @@ func hashKey(t *testing.T, plain string) string {
 		t.Fatalf("failed to hash key: %v", err)
 	}
 	return string(hash)
+}
+
+// tokenFor builds a token for the given credential id and secret.
+func tokenFor(credID, secret string) string {
+	return apiKeyTokenPrefix + credID + tokenSeparator + secret
+}
+
+// entryJSON builds a stored-entry JSON fragment whose hash matches the secret.
+func entryJSON(t *testing.T, credID, secret string) string {
+	t.Helper()
+	return `{"id":"` + credID + `","hash":"` + hashKey(t, secret) + `","created_at":"2025-01-01T00:00:00Z"}`
 }

--- a/internal/auth/authorizer.go
+++ b/internal/auth/authorizer.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// This file defines the Authorizer seam and its default implementation. The
+// authorization decision is centralized here so the inline allowlist behavior
+// can later be extended (roles, policies, tenant isolation) without touching the
+// call sites. For now DirectGrantAuthorizer replicates the historical
+// per-credential allowlist semantics exactly.
+
+// ErrUnauthorized is returned by an Authorizer when a principal is not permitted
+// to access a resource.
+var ErrUnauthorized = errors.New("principal not authorized for resource")
+
+// Action identifies the kind of operation being authorized. A single access
+// action suffices for the current scope; the resource type distinguishes
+// gateways from projects.
+type Action string
+
+// ActionAccess is the only action modelled today (access a resource).
+const ActionAccess Action = "access"
+
+// Resource types understood by the default authorizer.
+const (
+	ResourceTypeGateway = "gateway"
+	ResourceTypeProject = "project"
+)
+
+// Resource identifies the target of an authorization decision.
+type Resource struct {
+	Type string
+	ID   string
+}
+
+// GatewayResource builds a gateway-scoped resource.
+func GatewayResource(name string) Resource {
+	return Resource{Type: ResourceTypeGateway, ID: name}
+}
+
+// ProjectResource builds a project-scoped resource.
+func ProjectResource(slug string) Resource {
+	return Resource{Type: ResourceTypeProject, ID: slug}
+}
+
+// Authorizer decides whether a principal may perform an action on a resource.
+type Authorizer interface {
+	Authorize(ctx context.Context, p *Principal, action Action, resource Resource) error
+}
+
+// DirectGrantAuthorizer authorizes using the principal's inline direct grants
+// (the Gateways/Projects allowlists). It is stateless and safe for concurrent use.
+type DirectGrantAuthorizer struct{}
+
+// Authorize permits access when the principal's relevant grant list allows the
+// resource id. Roles are not consulted (none exist yet).
+func (DirectGrantAuthorizer) Authorize(_ context.Context, p *Principal, _ Action, resource Resource) error {
+	if p == nil {
+		return ErrUnauthorized
+	}
+	switch resource.Type {
+	case ResourceTypeGateway:
+		if allowMatch(p.Gateways, resource.ID) {
+			return nil
+		}
+	case ResourceTypeProject:
+		if allowMatch(p.Projects, resource.ID) {
+			return nil
+		}
+	}
+	return ErrUnauthorized
+}
+
+// allowMatch reports whether an allowlist grants the target.
+//
+// Backward-compatible semantics (a literal lift of the former
+// APIKeyEntry.AllowsGateway/AllowsProject logic):
+//   - an empty list means allow-all,
+//   - a "*" entry means allow-all,
+//   - otherwise a case-insensitive, trimmed equality match is required.
+func allowMatch(allowlist []string, target string) bool {
+	if len(allowlist) == 0 {
+		return true
+	}
+	for _, entry := range allowlist {
+		if entry == "*" || strings.EqualFold(strings.TrimSpace(entry), strings.TrimSpace(target)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/authorizer_test.go
+++ b/internal/auth/authorizer_test.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+// Given: a DirectGrantAuthorizer and principals with various grant lists
+// When: authorizing gateway/project access
+// Then: empty list = allow-all, "*" = allow-all, otherwise case-insensitive match,
+// and unknown resource types / nil principals are denied.
+func TestDirectGrantAuthorizer(t *testing.T) {
+	authz := DirectGrantAuthorizer{}
+	ctx := context.Background()
+
+	t.Run("empty allowlist allows all gateways", func(t *testing.T) {
+		p := &Principal{ID: "pr_1", Gateways: nil}
+		assert.NilError(t, authz.Authorize(ctx, p, ActionAccess, GatewayResource("default")))
+		assert.NilError(t, authz.Authorize(ctx, p, ActionAccess, GatewayResource("other")))
+	})
+
+	t.Run("wildcard allows all gateways", func(t *testing.T) {
+		p := &Principal{ID: "pr_1", Gateways: []string{"*"}}
+		assert.NilError(t, authz.Authorize(ctx, p, ActionAccess, GatewayResource("anything")))
+	})
+
+	t.Run("explicit gateway list enforced case-insensitively", func(t *testing.T) {
+		p := &Principal{ID: "pr_1", Gateways: []string{"Alpha"}}
+		assert.NilError(t, authz.Authorize(ctx, p, ActionAccess, GatewayResource("alpha")))
+		assert.Assert(t, errors.Is(authz.Authorize(ctx, p, ActionAccess, GatewayResource("beta")), ErrUnauthorized))
+	})
+
+	t.Run("project grants are independent of gateway grants", func(t *testing.T) {
+		p := &Principal{ID: "pr_1", Gateways: []string{"alpha"}, Projects: []string{"acme"}}
+		assert.NilError(t, authz.Authorize(ctx, p, ActionAccess, ProjectResource("acme")))
+		assert.Assert(t, errors.Is(authz.Authorize(ctx, p, ActionAccess, ProjectResource("other")), ErrUnauthorized))
+		// gateway list must not leak into project decisions
+		assert.Assert(t, errors.Is(authz.Authorize(ctx, p, ActionAccess, ProjectResource("alpha")), ErrUnauthorized))
+	})
+
+	t.Run("nil principal is denied", func(t *testing.T) {
+		assert.Assert(t, errors.Is(authz.Authorize(ctx, nil, ActionAccess, GatewayResource("default")), ErrUnauthorized))
+	})
+
+	t.Run("unknown resource type is denied", func(t *testing.T) {
+		p := &Principal{ID: "pr_1"}
+		assert.Assert(t, errors.Is(authz.Authorize(ctx, p, ActionAccess, Resource{Type: "secret", ID: "x"}), ErrUnauthorized))
+	})
+}

--- a/internal/auth/file_provider.go
+++ b/internal/auth/file_provider.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// FilePrincipalProvider is the file-based PrincipalProvider. It reads the same
+// ~/.centian/api_keys.json store and resolves tokens to principals using an
+// in-memory credential-id index (O(1) lookup + a single bcrypt verify).
+type FilePrincipalProvider struct {
+	path  string
+	mu    sync.RWMutex
+	index map[string]*APIKeyEntry
+}
+
+// NewFilePrincipalProvider creates a provider backed by the given key file path.
+func NewFilePrincipalProvider(path string) *FilePrincipalProvider {
+	return &FilePrincipalProvider{path: path}
+}
+
+// DefaultFilePrincipalProvider creates a provider backed by the default key file.
+func DefaultFilePrincipalProvider() (*FilePrincipalProvider, error) {
+	path, err := DefaultAPIKeysPath()
+	if err != nil {
+		return nil, err
+	}
+	return NewFilePrincipalProvider(path), nil
+}
+
+// Setup reads and indexes the key file. It mirrors the historical load
+// semantics: a missing file yields ErrAPIKeysNotFound and an empty file yields
+// ErrAPIKeysEmpty, so callers can surface the same guidance as before.
+func (p *FilePrincipalProvider) Setup(_ context.Context) error {
+	file, err := ReadAPIKeyFile(p.path)
+	if err != nil {
+		return err
+	}
+	if len(file.Keys) == 0 {
+		return fmt.Errorf("%w: %s", ErrAPIKeysEmpty, p.path)
+	}
+
+	index := make(map[string]*APIKeyEntry, len(file.Keys))
+	for i := range file.Keys {
+		entry := &file.Keys[i]
+		if strings.TrimSpace(entry.Hash) == "" {
+			return fmt.Errorf("%w: empty hash", ErrAPIKeysInvalid)
+		}
+		index[entry.ID] = entry
+	}
+
+	p.mu.Lock()
+	p.index = index
+	p.mu.Unlock()
+	return nil
+}
+
+// GetPrincipal resolves a token to its principal. Unknown credential ids or
+// secret mismatches return ErrPrincipalNotFound; pre-principal tokens return
+// ErrLegacyTokenFormat.
+func (p *FilePrincipalProvider) GetPrincipal(_ context.Context, token string) (*Principal, error) {
+	credID, secret, err := parseToken(token)
+	if err != nil {
+		return nil, err
+	}
+
+	p.mu.RLock()
+	entry, ok := p.index[credID]
+	p.mu.RUnlock()
+	if !ok {
+		return nil, ErrPrincipalNotFound
+	}
+	if bcrypt.CompareHashAndPassword([]byte(entry.Hash), []byte(secret)) != nil {
+		return nil, ErrPrincipalNotFound
+	}
+	return entry.toPrincipal(), nil
+}
+
+// Count returns the number of indexed credentials (for startup logging).
+func (p *FilePrincipalProvider) Count() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.index)
+}
+
+// Path returns the key file path the provider reads from.
+func (p *FilePrincipalProvider) Path() string {
+	return p.path
+}
+
+// Close releases provider resources. The file provider holds none.
+func (p *FilePrincipalProvider) Close() error {
+	return nil
+}

--- a/internal/auth/file_provider_test.go
+++ b/internal/auth/file_provider_test.go
@@ -85,6 +85,17 @@ func TestFilePrincipalProviderIDStableAcrossReload(t *testing.T) {
 	assert.Equal(t, p1.ID, p2.ID)
 }
 
+// Given: entries with and without a human-friendly name
+// When: resolving them to principals
+// Then: DisplayName uses the name when present and falls back to the credential id.
+func TestFilePrincipalProviderDisplayName(t *testing.T) {
+	named := APIKeyEntry{ID: "key_named", Hash: hashKey(t, "s"), PrincipalID: "pr_named", Name: "CI deploy bot"}
+	unnamed := APIKeyEntry{ID: "key_unnamed", Hash: hashKey(t, "s"), PrincipalID: "pr_unnamed"}
+
+	assert.Equal(t, named.toPrincipal().DisplayName, "CI deploy bot")
+	assert.Equal(t, unnamed.toPrincipal().DisplayName, "key_unnamed")
+}
+
 // Given: missing or empty key files
 // When: setting up the provider
 // Then: the historical sentinel errors are preserved.

--- a/internal/auth/file_provider_test.go
+++ b/internal/auth/file_provider_test.go
@@ -19,7 +19,7 @@ func writeProviderFile(t *testing.T, entry APIKeyEntry) string {
 
 // Given: a file provider over one credential
 // When: resolving its token
-// Then: the mapped principal carries the persisted id, credential id, and grants
+// Then: the mapped principal carries the persisted id, credential id, and grants.
 func TestFilePrincipalProviderGetPrincipal(t *testing.T) {
 	entry := APIKeyEntry{
 		ID:          "key_abc",
@@ -42,7 +42,7 @@ func TestFilePrincipalProviderGetPrincipal(t *testing.T) {
 
 // Given: a file provider
 // When: presenting a wrong secret, unknown credential id, or legacy-format token
-// Then: the appropriate sentinel error is returned (and the index is O(1))
+// Then: the appropriate sentinel error is returned (and the index is O(1)).
 func TestFilePrincipalProviderRejections(t *testing.T) {
 	entry := APIKeyEntry{ID: "key_abc", Hash: hashKey(t, "the-secret"), PrincipalID: "pr_x"}
 	provider := NewFilePrincipalProvider(writeProviderFile(t, entry))
@@ -87,7 +87,7 @@ func TestFilePrincipalProviderIDStableAcrossReload(t *testing.T) {
 
 // Given: missing or empty key files
 // When: setting up the provider
-// Then: the historical sentinel errors are preserved
+// Then: the historical sentinel errors are preserved.
 func TestFilePrincipalProviderSetupErrors(t *testing.T) {
 	missing := NewFilePrincipalProvider(filepath.Join(t.TempDir(), "nope.json"))
 	assert.Assert(t, errors.Is(missing.Setup(context.Background()), ErrAPIKeysNotFound))

--- a/internal/auth/file_provider_test.go
+++ b/internal/auth/file_provider_test.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+// writeProviderFile writes a key file with a single entry and returns its path.
+func writeProviderFile(t *testing.T, entry APIKeyEntry) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "api_keys.json")
+	assert.NilError(t, WriteAPIKeyFile(path, &APIKeyFile{Keys: []APIKeyEntry{entry}}))
+	return path
+}
+
+// Given: a file provider over one credential
+// When: resolving its token
+// Then: the mapped principal carries the persisted id, credential id, and grants
+func TestFilePrincipalProviderGetPrincipal(t *testing.T) {
+	entry := APIKeyEntry{
+		ID:          "key_abc",
+		Hash:        hashKey(t, "the-secret"),
+		PrincipalID: "pr_0000000000000_principal0",
+		Gateways:    []string{"alpha"},
+		Projects:    []string{"acme"},
+	}
+	provider := NewFilePrincipalProvider(writeProviderFile(t, entry))
+	assert.NilError(t, provider.Setup(context.Background()))
+	t.Cleanup(func() { _ = provider.Close() })
+
+	principal, err := provider.GetPrincipal(context.Background(), tokenFor("key_abc", "the-secret"))
+	assert.NilError(t, err)
+	assert.Equal(t, principal.ID, "pr_0000000000000_principal0")
+	assert.Equal(t, principal.CredentialID, "key_abc")
+	assert.DeepEqual(t, principal.Gateways, []string{"alpha"})
+	assert.DeepEqual(t, principal.Projects, []string{"acme"})
+}
+
+// Given: a file provider
+// When: presenting a wrong secret, unknown credential id, or legacy-format token
+// Then: the appropriate sentinel error is returned (and the index is O(1))
+func TestFilePrincipalProviderRejections(t *testing.T) {
+	entry := APIKeyEntry{ID: "key_abc", Hash: hashKey(t, "the-secret"), PrincipalID: "pr_x"}
+	provider := NewFilePrincipalProvider(writeProviderFile(t, entry))
+	assert.NilError(t, provider.Setup(context.Background()))
+
+	_, err := provider.GetPrincipal(context.Background(), tokenFor("key_abc", "wrong"))
+	assert.Assert(t, errors.Is(err, ErrPrincipalNotFound))
+
+	_, err = provider.GetPrincipal(context.Background(), tokenFor("key_missing", "the-secret"))
+	assert.Assert(t, errors.Is(err, ErrPrincipalNotFound))
+
+	_, err = provider.GetPrincipal(context.Background(), "sk-legacytokenwithoutdot")
+	assert.Assert(t, errors.Is(err, ErrLegacyTokenFormat))
+}
+
+// Given: a key file with a persisted principal id
+// When: the provider is set up twice (simulating a restart)
+// Then: the resolved Principal.ID is identical across reloads.
+//
+// This guards the OAuth-binding/pool-identity stability requirement: the
+// principal id must never be regenerated on load.
+func TestFilePrincipalProviderIDStableAcrossReload(t *testing.T) {
+	gen, err := GenerateAPIKey()
+	assert.NilError(t, err)
+	entry, err := NewAPIKeyEntry(gen)
+	assert.NilError(t, err)
+	path := writeProviderFile(t, entry)
+
+	first := NewFilePrincipalProvider(path)
+	assert.NilError(t, first.Setup(context.Background()))
+	p1, err := first.GetPrincipal(context.Background(), gen.Token)
+	assert.NilError(t, err)
+
+	second := NewFilePrincipalProvider(path)
+	assert.NilError(t, second.Setup(context.Background()))
+	p2, err := second.GetPrincipal(context.Background(), gen.Token)
+	assert.NilError(t, err)
+
+	assert.Assert(t, p1.ID != "")
+	assert.Equal(t, p1.ID, p2.ID)
+}
+
+// Given: missing or empty key files
+// When: setting up the provider
+// Then: the historical sentinel errors are preserved
+func TestFilePrincipalProviderSetupErrors(t *testing.T) {
+	missing := NewFilePrincipalProvider(filepath.Join(t.TempDir(), "nope.json"))
+	assert.Assert(t, errors.Is(missing.Setup(context.Background()), ErrAPIKeysNotFound))
+
+	emptyPath := writeTempFile(t, `{"keys":[]}`)
+	empty := NewFilePrincipalProvider(emptyPath)
+	assert.Assert(t, errors.Is(empty.Setup(context.Background()), ErrAPIKeysEmpty))
+}

--- a/internal/auth/principal.go
+++ b/internal/auth/principal.go
@@ -1,0 +1,38 @@
+package auth
+
+// This file defines the Principal model: the first-class actor identity that
+// authentication resolves to and that authorization, routing, and downstream
+// pool reuse all key off. A Principal is decoupled from the concrete credential
+// mechanism (today an API key, later SQL/external providers) so those backends
+// can be added without touching consumers.
+
+// Principal is the resolved actor for an authenticated request.
+//
+// ID is a stable, persisted identifier (identifiers.KindPrincipal, "pr_..."). It
+// must remain stable across restarts for the same credential because it becomes
+// the downstream pool identity key and the OAuth binding principal id; a fresh id
+// per load would silently orphan persisted OAuth downstream bindings.
+//
+// Gateways and Projects are direct grants (an inline allowlist) carried straight
+// from the credential. Empty list means allow-all; a "*" entry also means
+// allow-all. Roles are intentionally not modelled yet; they are an additive
+// follow-up behind the Authorizer seam.
+type Principal struct {
+	ID           string
+	DisplayName  string
+	CredentialID string
+	Gateways     []string
+	Projects     []string
+}
+
+// Clone returns a deep copy safe to store per-session without aliasing the
+// provider's cached grants.
+func (p *Principal) Clone() *Principal {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	clone.Gateways = append([]string(nil), p.Gateways...)
+	clone.Projects = append([]string(nil), p.Projects...)
+	return &clone
+}

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+// This file defines the PrincipalProvider seam. Authentication is expressed as
+// "resolve a token to a Principal"; the concrete backend (file-based today, SQL
+// or external IdP later) is hidden behind this interface so consumers never
+// depend on the credential storage mechanism.
+
+var (
+	// ErrPrincipalNotFound is returned when a token does not resolve to any
+	// principal (unknown credential id or secret mismatch). Callers map this to
+	// an unauthorized response.
+	ErrPrincipalNotFound = errors.New("principal not found for token")
+
+	// ErrLegacyTokenFormat is returned when a token uses the pre-principal format
+	// (no embedded credential id). Such tokens are no longer supported; the
+	// operator must regenerate them with `centian auth new-key`.
+	ErrLegacyTokenFormat = errors.New("legacy token format is no longer supported; regenerate with `centian auth new-key`")
+)
+
+// PrincipalProvider resolves authentication tokens to principals.
+//
+// Setup is called once at startup to initialize the backend (e.g. read and index
+// the key file, open a DB connection). GetPrincipal resolves one token per
+// request and must be safe for concurrent use after Setup. Close releases any
+// resources held by the provider.
+type PrincipalProvider interface {
+	Setup(ctx context.Context) error
+	GetPrincipal(ctx context.Context, token string) (*Principal, error)
+	Close() error
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -61,7 +61,7 @@ func handleAuthNewKeyCommand(_ context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to resolve api key path: %w", err)
 	}
 
-	key, err := auth.GenerateAPIKey()
+	gen, err := auth.GenerateAPIKey()
 	if err != nil {
 		return err
 	}
@@ -71,12 +71,12 @@ func handleAuthNewKeyCommand(_ context.Context, cmd *cli.Command) error {
 	if pErr != nil {
 		return pErr
 	}
-	_, pErr = fmt.Fprintln(os.Stdout, key)
+	_, pErr = fmt.Fprintln(os.Stdout, gen.Token)
 	if pErr != nil {
 		return pErr
 	}
 
-	entry, err := auth.NewAPIKeyEntry(key)
+	entry, err := auth.NewAPIKeyEntry(gen)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -15,8 +15,11 @@
 package cli
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -44,11 +47,17 @@ The key is printed once to the console, then hashed with bcrypt and stored in:
 
 Use --projects to restrict the key to specific projects (comma-separated slugs).
 Omit the flag to allow all projects.
+
+Use --name to label the key's principal. If omitted, you are prompted for one.
 `,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "projects",
 			Usage: "Comma-separated list of project slugs this key is allowed to access (empty = all)",
+		},
+		&cli.StringFlag{
+			Name:  "name",
+			Usage: "Human-friendly name for this key's principal (prompted if omitted)",
 		},
 	},
 	Action: handleAuthNewKeyCommand,
@@ -59,6 +68,14 @@ func handleAuthNewKeyCommand(_ context.Context, cmd *cli.Command) error {
 	path, err := auth.DefaultAPIKeysPath()
 	if err != nil {
 		return fmt.Errorf("failed to resolve api key path: %w", err)
+	}
+
+	name := strings.TrimSpace(cmd.String("name"))
+	if name == "" {
+		name, err = promptLine(os.Stdin, os.Stdout, "Enter a name for this key (optional): ")
+		if err != nil {
+			return err
+		}
 	}
 
 	gen, err := auth.GenerateAPIKey()
@@ -80,6 +97,7 @@ func handleAuthNewKeyCommand(_ context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
+	entry.Name = name
 
 	if projects := cmd.String("projects"); projects != "" {
 		entry.Projects = parseCommaSeparated(projects)
@@ -87,6 +105,13 @@ func handleAuthNewKeyCommand(_ context.Context, cmd *cli.Command) error {
 
 	if _, err := auth.AppendAPIKey(path, &entry); err != nil {
 		return err
+	}
+
+	if entry.Name != "" {
+		_, pErr = fmt.Fprintf(os.Stdout, "Name: %s\n", entry.Name)
+		if pErr != nil {
+			return pErr
+		}
 	}
 
 	if len(entry.Projects) > 0 {
@@ -101,6 +126,20 @@ func handleAuthNewKeyCommand(_ context.Context, cmd *cli.Command) error {
 		return pErr
 	}
 	return nil
+}
+
+// promptLine writes a label to out and reads a single trimmed line from in.
+// An EOF (e.g. non-interactive/piped input with no data) yields an empty string
+// rather than an error, so the name simply remains unset.
+func promptLine(in io.Reader, out io.Writer, label string) (string, error) {
+	if _, err := fmt.Fprint(out, label); err != nil {
+		return "", err
+	}
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
 }
 
 // parseCommaSeparated splits a comma-separated string into trimmed, non-empty parts.

--- a/internal/cli/auth_prompt_test.go
+++ b/internal/cli/auth_prompt_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+// Given: input containing a name line
+// When: prompting for a line
+// Then: the label is written and the trimmed name is returned.
+func TestPromptLineReadsTrimmedInput(t *testing.T) {
+	var out bytes.Buffer
+	name, err := promptLine(strings.NewReader("  CI deploy bot \n"), &out, "Enter a name: ")
+
+	assert.NilError(t, err)
+	assert.Equal(t, name, "CI deploy bot")
+	assert.Equal(t, out.String(), "Enter a name: ")
+}
+
+// Given: empty (EOF) input, as with a non-interactive invocation
+// When: prompting for a line
+// Then: an empty string is returned without error.
+func TestPromptLineEmptyOnEOF(t *testing.T) {
+	var out bytes.Buffer
+	name, err := promptLine(strings.NewReader(""), &out, "Enter a name: ")
+
+	assert.NilError(t, err)
+	assert.Equal(t, name, "")
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -334,6 +334,7 @@ func createDefaultAPIKey() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create api key entry: %w", err)
 	}
+	entry.Name = "default"
 	path, err := auth.DefaultAPIKeysPath()
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve api key path: %w", err)

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -326,11 +326,11 @@ func applyQuickstartConfig(cfg *config.GlobalConfig) {
 
 // createDefaultAPIKey generates and persists one default API key for a fresh setup.
 func createDefaultAPIKey() (string, error) {
-	key, err := auth.GenerateAPIKey()
+	gen, err := auth.GenerateAPIKey()
 	if err != nil {
 		return "", fmt.Errorf("failed to generate api key: %w", err)
 	}
-	entry, err := auth.NewAPIKeyEntry(key)
+	entry, err := auth.NewAPIKeyEntry(gen)
 	if err != nil {
 		return "", fmt.Errorf("failed to create api key entry: %w", err)
 	}
@@ -341,7 +341,7 @@ func createDefaultAPIKey() (string, error) {
 	if _, err := auth.AppendAPIKey(path, &entry); err != nil {
 		return "", fmt.Errorf("failed to persist api key: %w", err)
 	}
-	return key, nil
+	return gen.Token, nil
 }
 
 // handleQuickstart finalizes quickstart setup and prints ready-to-paste client snippets.

--- a/internal/identifiers/identifiers.go
+++ b/internal/identifiers/identifiers.go
@@ -29,6 +29,7 @@ const (
 	KindSession      Kind = "sid"
 	KindServer       Kind = "srv"
 	KindOAuthPending Kind = "op"
+	KindPrincipal    Kind = "pr"
 )
 
 type parsedID struct {
@@ -52,6 +53,7 @@ var knownKinds = map[Kind]struct{}{
 	KindSession:      {},
 	KindServer:       {},
 	KindOAuthPending: {},
+	KindPrincipal:    {},
 }
 
 // New returns a canonical internal ID for the provided kind.

--- a/internal/identifiers/identifiers_test.go
+++ b/internal/identifiers/identifiers_test.go
@@ -24,6 +24,7 @@ func TestNewGeneratesCanonicalIDsForAllKinds(t *testing.T) {
 		KindSession,
 		KindServer,
 		KindOAuthPending,
+		KindPrincipal,
 	}
 
 	for _, kind := range kinds {

--- a/internal/proxy/auth_context.go
+++ b/internal/proxy/auth_context.go
@@ -16,7 +16,8 @@ type AuthData struct {
 	Project        string
 	Gateway        string
 	Headers        http.Header
-	KeyEntry       *auth.APIKeyEntry
+	Principal      *auth.Principal
+	CredentialID   string
 }
 
 // Clone creates a deep copy of AuthData to ensure immutability when attached to contexts.
@@ -28,23 +29,13 @@ func (a *AuthData) Clone() *AuthData {
 	if a.Headers != nil {
 		headersCopy = a.Headers.Clone()
 	}
-	var keyEntryCopy *auth.APIKeyEntry
-	if a.KeyEntry != nil {
-		entry := *a.KeyEntry
-		if entry.Gateways != nil {
-			entry.Gateways = append([]string(nil), entry.Gateways...)
-		}
-		if entry.Projects != nil {
-			entry.Projects = append([]string(nil), entry.Projects...)
-		}
-		keyEntryCopy = &entry
-	}
 	return &AuthData{
 		AuthHeaderName: a.AuthHeaderName,
 		Project:        a.Project,
 		Gateway:        a.Gateway,
 		Headers:        headersCopy,
-		KeyEntry:       keyEntryCopy,
+		Principal:      a.Principal.Clone(),
+		CredentialID:   a.CredentialID,
 	}
 }
 

--- a/internal/proxy/handle_tool_call_test.go
+++ b/internal/proxy/handle_tool_call_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/T4cceptor/centian/internal/auth"
 	"github.com/T4cceptor/centian/internal/common"
 	"github.com/T4cceptor/centian/internal/config"
 	"github.com/T4cceptor/centian/internal/logging"
@@ -298,18 +299,19 @@ func TestHandleToolCall_ProcessorReceivesAuthContextFromMiddlewareSession(t *tes
 	proxy.connectionFactory = func(_ string, _ *config.MCPServerConfig) DownstreamConnectionInterface {
 		return mockDownstream
 	}
-	proxy.server.APIKeys = createTestAPIKeyStore(t)
+	proxy.server.Principals = createTestAPIKeyStore(t)
+	proxy.server.Authorizer = auth.DirectGrantAuthorizer{}
 	proxy.server.AuthHeader = "Authorization"
 	proxy.server.Config = &config.GlobalConfig{Version: "1.0.0"}
 
-	handler := apiKeyMiddlewareWithHeader(proxy.server.APIKeys, proxy.server.AuthHeader, "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(proxy.server.Principals, proxy.server.Authorizer, proxy.server.AuthHeader, "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		server := proxy.GetOrCreateServerForRequest(r)
 		assert.Assert(t, server != nil)
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-a/test-server", http.NoBody)
-	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Authorization", "Bearer "+testToken)
 	request.Header.Set("Mcp-Session-Id", "sess-auth")
 	recorder := httptest.NewRecorder()
 
@@ -326,8 +328,8 @@ func TestHandleToolCall_ProcessorReceivesAuthContextFromMiddlewareSession(t *tes
 	assert.Assert(t, session.authData != nil)
 	assert.Equal(t, session.authData.AuthHeaderName, "Authorization")
 	assert.Equal(t, session.authData.Gateway, "gateway-a")
-	assert.Assert(t, session.authData.KeyEntry != nil)
-	assert.Equal(t, session.authData.KeyEntry.ID, "key_test")
+	assert.Assert(t, session.authData.Principal != nil)
+	assert.Equal(t, session.authData.Principal.CredentialID, "key_test")
 
 	req := &mcp.CallToolRequest{
 		Params: &mcp.CallToolParamsRaw{
@@ -349,8 +351,8 @@ func TestHandleToolCall_ProcessorReceivesAuthContextFromMiddlewareSession(t *tes
 	assert.Equal(t, mockProcessor.lastInput.Auth.AuthHeader, "Authorization")
 	assert.Equal(t, mockProcessor.lastInput.Auth.InternalSessionID, "sess-auth")
 	assert.Equal(t, mockProcessor.lastInput.Auth.TransportSessionID, "sess-auth")
-	assert.Equal(t, mockProcessor.lastInput.Auth.PrincipalID, getPrincipalID("key_test", "gateway-a"))
-	assert.Equal(t, mockProcessor.lastInput.Auth.CredentialFingerprint, getCredentialFingerprint("plain-key"))
+	assert.Equal(t, mockProcessor.lastInput.Auth.PrincipalID, testPrincipalID)
+	assert.Equal(t, mockProcessor.lastInput.Auth.CredentialFingerprint, getCredentialFingerprint(testToken))
 	assert.Equal(t, mockDownstream.CapturedToolName, "test-tool")
 	assert.Equal(t, mockDownstream.CapturedArgs["hello"], "world")
 }

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -169,9 +169,9 @@ func (h *DefaultAuthHandler) buildAuthContext(callCtx CallContext) *common.AuthC
 		InternalSessionID: callCtx.GetSessionID(),
 	}
 
-	if authData.KeyEntry != nil {
-		authCtx.KeyID = authData.KeyEntry.ID
-		authCtx.PrincipalID = getPrincipalID(authData.KeyEntry.ID, authData.Gateway)
+	if authData.Principal != nil {
+		authCtx.KeyID = authData.Principal.CredentialID
+		authCtx.PrincipalID = authData.Principal.ID
 	}
 
 	token := ""

--- a/internal/proxy/handlers_test.go
+++ b/internal/proxy/handlers_test.go
@@ -36,8 +36,8 @@ func newHandlerTestCallContext() *ToolCallContext {
 		authData: &AuthData{
 			AuthHeaderName: "Authorization",
 			Gateway:        "gateway-a",
-			Headers:        http.Header{"Authorization": []string{"Bearer plain-key"}},
-			KeyEntry:       &auth.APIKeyEntry{ID: "key_1"},
+			Headers:        http.Header{"Authorization": []string{"Bearer sk-key_1.secret"}},
+			Principal:      &auth.Principal{ID: "pr_1", CredentialID: "key_1"},
 		},
 	}
 }
@@ -219,7 +219,7 @@ func TestDefaultAuthHandlerAttachPartAndApply(t *testing.T) {
 	err := handler.Apply(callCtx, output)
 	assert.NilError(t, err)
 	assert.Assert(t, callCtx.GetAuthData() != nil)
-	assert.Equal(t, callCtx.GetAuthData().KeyEntry.ID, "key_1")
+	assert.Equal(t, callCtx.GetAuthData().Principal.CredentialID, "key_1")
 }
 
 func TestToolCallContextToLogEntry(t *testing.T) {

--- a/internal/proxy/proxy_event_processor_test.go
+++ b/internal/proxy/proxy_event_processor_test.go
@@ -47,7 +47,7 @@ func newMockCallContext() *mockCallContext {
 			AuthHeaderName: "Authorization",
 			Gateway:        "gateway-a",
 			Headers:        http.Header{"Authorization": []string{"Bearer test-token"}},
-			KeyEntry:       &auth.APIKeyEntry{ID: "key_1"},
+			Principal:      &auth.Principal{ID: "pr_1", CredentialID: "key_1"},
 		},
 		handlers:           map[string]CallContextHandler{},
 		serverName:         "server-a",

--- a/internal/proxy/proxy_http.go
+++ b/internal/proxy/proxy_http.go
@@ -246,9 +246,9 @@ func cloneRequestBody(r *http.Request) []byte {
 	return bodyBytes
 }
 
-func apiKeyMiddlewareWithHeader(store *centauth.APIKeyStore, headerName, projectSlug string, next http.Handler) http.Handler {
+func principalAuthMiddleware(provider centauth.PrincipalProvider, authorizer centauth.Authorizer, headerName, projectSlug string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if store == nil {
+		if provider == nil {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -260,33 +260,37 @@ func apiKeyMiddlewareWithHeader(store *centauth.APIKeyStore, headerName, project
 			return
 		}
 
-		entry, ok := store.Lookup(token)
-		if !ok {
+		principal, err := provider.GetPrincipal(r.Context(), token)
+		if err != nil {
 			writeUnauthorized(w, headerName)
-			common.LogWarn("Unauthorized request: invalid auth token from %s", r.RemoteAddr)
+			common.LogWarn("Unauthorized request: %v from %s", err, r.RemoteAddr)
 			return
 		}
 
 		gatewayName := getGatewayFromPath(r.URL.Path)
-		if !entry.AllowsGateway(gatewayName) {
-			writeUnauthorized(w, headerName)
-			common.LogWarn("Unauthorized request: key '%s' not allowed for gateway '%s' from %s", entry.ID, gatewayName, r.RemoteAddr)
-			return
+		if authorizer != nil {
+			if err := authorizer.Authorize(r.Context(), principal, centauth.ActionAccess, centauth.GatewayResource(gatewayName)); err != nil {
+				writeUnauthorized(w, headerName)
+				common.LogWarn("Unauthorized request: principal '%s' not allowed for gateway '%s' from %s", principal.ID, gatewayName, r.RemoteAddr)
+				return
+			}
+			if projectSlug != "" {
+				if err := authorizer.Authorize(r.Context(), principal, centauth.ActionAccess, centauth.ProjectResource(projectSlug)); err != nil {
+					writeUnauthorized(w, headerName)
+					common.LogWarn("Unauthorized request: principal '%s' not allowed for project '%s' from %s", principal.ID, projectSlug, r.RemoteAddr)
+					return
+				}
+			}
 		}
 
-		if projectSlug != "" && !entry.AllowsProject(projectSlug) {
-			writeUnauthorized(w, headerName)
-			common.LogWarn("Unauthorized request: key '%s' not allowed for project '%s' from %s", entry.ID, projectSlug, r.RemoteAddr)
-			return
-		}
-
-		ctx := withRequestIdentity(r.Context(), "auth:"+entry.ID)
+		ctx := withRequestIdentity(r.Context(), principal.ID)
 		authData := &AuthData{
 			AuthHeaderName: headerName,
 			Project:        projectSlug,
 			Gateway:        gatewayName,
 			Headers:        r.Header.Clone(),
-			KeyEntry:       entry,
+			Principal:      principal,
+			CredentialID:   principal.CredentialID,
 		}
 		ctx = withAuthData(ctx, authData)
 		next.ServeHTTP(w, r.WithContext(ctx))
@@ -294,7 +298,7 @@ func apiKeyMiddlewareWithHeader(store *centauth.APIKeyStore, headerName, project
 }
 
 func wrapWithAPIKeyAuth(server *CentianServer, projectSlug string, handler http.Handler) http.Handler {
-	if server == nil || server.APIKeys == nil || handler == nil {
+	if server == nil || server.Principals == nil || handler == nil {
 		return handler
 	}
 
@@ -302,7 +306,7 @@ func wrapWithAPIKeyAuth(server *CentianServer, projectSlug string, handler http.
 	if headerName == "" {
 		headerName = strings.Clone(config.DefaultAuthHeader)
 	}
-	return apiKeyMiddlewareWithHeader(server.APIKeys, headerName, projectSlug, handler)
+	return principalAuthMiddleware(server.Principals, server.Authorizer, headerName, projectSlug, handler)
 }
 
 func getGatewayFromPath(requestPath string) string {
@@ -316,11 +320,6 @@ func getGatewayFromPath(requestPath string) string {
 
 func getCredentialFingerprint(token string) string {
 	hash := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(hash[:])
-}
-
-func getPrincipalID(keyID, gateway string) string {
-	hash := sha256.Sum256([]byte(strings.TrimSpace(keyID) + ":" + strings.TrimSpace(gateway)))
 	return hex.EncodeToString(hash[:])
 }
 

--- a/internal/proxy/proxy_server_setup_test.go
+++ b/internal/proxy/proxy_server_setup_test.go
@@ -231,9 +231,8 @@ func TestCentianServerSetup_FiltersProjectsByAPIKeyScope(t *testing.T) {
 	uiEnabled := true
 	taskVerificationEnabled := true
 	t.Setenv("HOME", t.TempDir())
-	entry, err := auth.NewAPIKeyEntry("plain-key")
+	entry, err := auth.NewAPIKeyEntry(auth.GeneratedKey{CredID: "key_research", Secret: "secret"})
 	assert.NilError(t, err)
-	entry.ID = "key_research"
 	entry.Projects = []string{"research"}
 	defaultPath, err := auth.DefaultAPIKeysPath()
 	assert.NilError(t, err)
@@ -262,7 +261,7 @@ func TestCentianServerSetup_FiltersProjectsByAPIKeyScope(t *testing.T) {
 	assert.NilError(t, server.Setup())
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/api/projects", http.NoBody)
-	req.Header.Set(config.DefaultAuthHeader, "Bearer plain-key")
+	req.Header.Set(config.DefaultAuthHeader, "Bearer sk-key_research.secret")
 	rec := httptest.NewRecorder()
 	server.Mux.ServeHTTP(rec, req)
 
@@ -282,9 +281,8 @@ func TestCentianServerSetup_ProjectsAPIAllowAllKeySeesAllProjects(t *testing.T) 
 	uiEnabled := true
 	taskVerificationEnabled := true
 	t.Setenv("HOME", t.TempDir())
-	entry, err := auth.NewAPIKeyEntry("plain-key")
+	entry, err := auth.NewAPIKeyEntry(auth.GeneratedKey{CredID: "key_all", Secret: "secret"})
 	assert.NilError(t, err)
-	entry.ID = "key_all"
 	entry.Projects = []string{"*"}
 	defaultPath, err := auth.DefaultAPIKeysPath()
 	assert.NilError(t, err)
@@ -313,7 +311,7 @@ func TestCentianServerSetup_ProjectsAPIAllowAllKeySeesAllProjects(t *testing.T) 
 	assert.NilError(t, server.Setup())
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/api/projects", http.NoBody)
-	req.Header.Set(config.DefaultAuthHeader, "Bearer plain-key")
+	req.Header.Set(config.DefaultAuthHeader, "Bearer sk-key_all.secret")
 	rec := httptest.NewRecorder()
 	server.Mux.ServeHTTP(rec, req)
 
@@ -395,9 +393,8 @@ func TestCentianServerSetup_ProtectsAPIRoutesButLeavesUIReachable(t *testing.T) 
 	authEnabled := true
 	uiEnabled := true
 	t.Setenv("HOME", t.TempDir())
-	entry, err := auth.NewAPIKeyEntry("plain-key")
+	entry, err := auth.NewAPIKeyEntry(auth.GeneratedKey{CredID: "key_test", Secret: "secret"})
 	assert.NilError(t, err)
-	entry.ID = "key_test"
 	defaultPath, err := auth.DefaultAPIKeysPath()
 	assert.NilError(t, err)
 	assert.NilError(t, auth.WriteAPIKeyFile(defaultPath, &auth.APIKeyFile{Keys: []auth.APIKeyEntry{entry}}))

--- a/internal/proxy/proxy_server_unit_test.go
+++ b/internal/proxy/proxy_server_unit_test.go
@@ -59,7 +59,7 @@ func TestWriteUnauthorized_CustomHeader(t *testing.T) {
 func TestAPIKeyMiddlewareWithHeader_NoStore(t *testing.T) {
 	// Given: a handler and nil API key store
 	called := false
-	handler := apiKeyMiddlewareWithHeader(nil, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(nil, nil, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -79,7 +79,7 @@ func TestAPIKeyMiddlewareWithHeader_WithStore(t *testing.T) {
 	store := createTestAPIKeyStore(t)
 
 	called := false
-	handler := apiKeyMiddlewareWithHeader(store, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(store, auth.DirectGrantAuthorizer{}, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -106,7 +106,7 @@ func TestAPIKeyMiddlewareWithHeader_WithStore(t *testing.T) {
 	// When: request has valid token
 	recorder = httptest.NewRecorder()
 	request = httptest.NewRequest(http.MethodGet, "/", http.NoBody)
-	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Authorization", "Bearer sk-key_test.test-secret")
 	handler.ServeHTTP(recorder, request)
 
 	// Then: handler is called
@@ -119,7 +119,7 @@ func TestAPIKeyMiddlewareWithHeader_AttachesIdentityToContext(t *testing.T) {
 	store := createTestAPIKeyStore(t)
 
 	var identity string
-	handler := apiKeyMiddlewareWithHeader(store, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(store, auth.DirectGrantAuthorizer{}, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		identity, _ = requestIdentityFromContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -127,7 +127,7 @@ func TestAPIKeyMiddlewareWithHeader_AttachesIdentityToContext(t *testing.T) {
 	// When: request has valid token
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
-	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Authorization", "Bearer sk-key_test.test-secret")
 	handler.ServeHTTP(recorder, request)
 
 	// Then: identity is attached to the request context
@@ -142,7 +142,8 @@ func TestRegisterHandler_WithAuthMiddleware(t *testing.T) {
 		name:     "gateway",
 		endpoint: "/mcp/gateway",
 		server: &CentianServer{
-			APIKeys:    store,
+			Principals: store,
+			Authorizer: auth.DirectGrantAuthorizer{},
 			AuthHeader: "Authorization",
 		},
 	}
@@ -162,21 +163,21 @@ func TestRegisterHandler_WithAuthMiddleware(t *testing.T) {
 func TestAPIKeyMiddlewareWithHeader_AttachesAuthData(t *testing.T) {
 	store := createTestAPIKeyStore(t)
 	called := false
-	handler := apiKeyMiddlewareWithHeader(store, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(store, auth.DirectGrantAuthorizer{}, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		authData := getAuthData(r.Context())
 		assert.Assert(t, authData != nil)
 		assert.Equal(t, authData.AuthHeaderName, "Authorization")
 		assert.Equal(t, authData.Gateway, "gateway-a")
 		assert.Assert(t, authData.Headers != nil)
-		assert.Assert(t, authData.KeyEntry != nil)
-		assert.Equal(t, authData.KeyEntry.ID, "key_test")
+		assert.Assert(t, authData.Principal != nil)
+		assert.Equal(t, authData.Principal.CredentialID, "key_test")
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-a", http.NoBody)
-	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Authorization", "Bearer sk-key_test.test-secret")
 	handler.ServeHTTP(recorder, request)
 
 	assert.Assert(t, called)
@@ -184,16 +185,16 @@ func TestAPIKeyMiddlewareWithHeader_AttachesAuthData(t *testing.T) {
 }
 
 func TestAPIKeyMiddlewareWithHeader_EnforcesGatewayScope(t *testing.T) {
-	store := createScopedAPIKeyStore(t, "plain-key", []string{"gateway-a"})
+	store := createScopedAPIKeyStore(t, []string{"gateway-a"})
 	called := false
-	handler := apiKeyMiddlewareWithHeader(store, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(store, auth.DirectGrantAuthorizer{}, "Authorization", "", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-b", http.NoBody)
-	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Authorization", "Bearer sk-key_test.test-secret")
 	handler.ServeHTTP(recorder, request)
 
 	assert.Assert(t, !called)
@@ -202,10 +203,10 @@ func TestAPIKeyMiddlewareWithHeader_EnforcesGatewayScope(t *testing.T) {
 
 func TestAPIKeyMiddlewareWithHeader_EnforcesProjectScope(t *testing.T) {
 	// Given: an API key scoped to "project-a"
-	store := createProjectScopedAPIKeyStore(t, "plain-key", []string{"project-a"})
+	store := createProjectScopedAPIKeyStore(t, []string{"project-a"})
 
 	called := false
-	handler := apiKeyMiddlewareWithHeader(store, "Authorization", "project-b", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(store, auth.DirectGrantAuthorizer{}, "Authorization", "project-b", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -213,7 +214,7 @@ func TestAPIKeyMiddlewareWithHeader_EnforcesProjectScope(t *testing.T) {
 	// When: requesting with a key not allowed for project-b
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-a", http.NoBody)
-	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Authorization", "Bearer sk-key_test.test-secret")
 	handler.ServeHTTP(recorder, request)
 
 	// Then: request is rejected
@@ -223,10 +224,10 @@ func TestAPIKeyMiddlewareWithHeader_EnforcesProjectScope(t *testing.T) {
 
 func TestAPIKeyMiddlewareWithHeader_AllowsMatchingProject(t *testing.T) {
 	// Given: an API key scoped to "project-a"
-	store := createProjectScopedAPIKeyStore(t, "plain-key", []string{"project-a"})
+	store := createProjectScopedAPIKeyStore(t, []string{"project-a"})
 
 	called := false
-	handler := apiKeyMiddlewareWithHeader(store, "Authorization", "project-a", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(store, auth.DirectGrantAuthorizer{}, "Authorization", "project-a", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		authData := getAuthData(r.Context())
 		assert.Assert(t, authData != nil)
@@ -237,7 +238,7 @@ func TestAPIKeyMiddlewareWithHeader_AllowsMatchingProject(t *testing.T) {
 	// When: requesting with a key allowed for project-a
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-a", http.NoBody)
-	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Authorization", "Bearer sk-key_test.test-secret")
 	handler.ServeHTTP(recorder, request)
 
 	// Then: request is allowed and AuthData contains the project
@@ -250,7 +251,7 @@ func TestAPIKeyMiddlewareWithHeader_EmptyProjectsAllowsAll(t *testing.T) {
 	store := createTestAPIKeyStore(t)
 
 	called := false
-	handler := apiKeyMiddlewareWithHeader(store, "Authorization", "any-project", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := principalAuthMiddleware(store, auth.DirectGrantAuthorizer{}, "Authorization", "any-project", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -258,7 +259,7 @@ func TestAPIKeyMiddlewareWithHeader_EmptyProjectsAllowsAll(t *testing.T) {
 	// When: requesting for any project
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "http://example.com/mcp/gateway-a", http.NoBody)
-	request.Header.Set("Authorization", "Bearer plain-key")
+	request.Header.Set("Authorization", "Bearer sk-key_test.test-secret")
 	handler.ServeHTTP(recorder, request)
 
 	// Then: request is allowed (empty projects = allow all)
@@ -313,7 +314,7 @@ func TestGetServerForRequest_ReusesPooledDownstreamForSameIdentity(t *testing.T)
 			return conn
 		},
 		server: &CentianServer{
-			APIKeys:    createTestAPIKeyStore(t),
+			Principals: createTestAPIKeyStore(t),
 			AuthHeader: "Authorization",
 			Config:     &config.GlobalConfig{Version: "1.0.0"},
 		},
@@ -355,7 +356,7 @@ func TestGetServerForRequest_UsesSeparatePoolsForDifferentAuthIdentities(t *test
 			return conn
 		},
 		server: &CentianServer{
-			APIKeys:    createTestAPIKeyStore(t),
+			Principals: createTestAPIKeyStore(t),
 			AuthHeader: "Authorization",
 			Config:     &config.GlobalConfig{Version: "1.0.0"},
 		},
@@ -489,7 +490,7 @@ func TestGetServerForRequest_DoesNotReusePoolWhenForwardedAuthChanges(t *testing
 			return conn
 		},
 		server: &CentianServer{
-			APIKeys:    createTestAPIKeyStore(t),
+			Principals: createTestAPIKeyStore(t),
 			AuthHeader: "X-Centian-Auth",
 			Config:     &config.GlobalConfig{Version: "1.0.0"},
 		},
@@ -546,7 +547,7 @@ func TestGetServerForRequest_RetriesFailedDownstreamsForLaterSessions(t *testing
 			return conn
 		},
 		server: &CentianServer{
-			APIKeys:    createTestAPIKeyStore(t),
+			Principals: createTestAPIKeyStore(t),
 			AuthHeader: "Authorization",
 			Config:     &config.GlobalConfig{Version: "1.0.0"},
 		},
@@ -616,7 +617,7 @@ func TestGetServerForRequest_RetriesTransientFailureInBackground(t *testing.T) {
 			return conn
 		},
 		server: &CentianServer{
-			APIKeys:    createTestAPIKeyStore(t),
+			Principals: createTestAPIKeyStore(t),
 			AuthHeader: "Authorization",
 			Config:     &config.GlobalConfig{Version: "1.0.0"},
 		},
@@ -665,7 +666,7 @@ func TestGetServerForRequest_DoesNotRetryPermanentFailures(t *testing.T) {
 			return conn
 		},
 		server: &CentianServer{
-			APIKeys:    createTestAPIKeyStore(t),
+			Principals: createTestAPIKeyStore(t),
 			AuthHeader: "Authorization",
 			Config:     &config.GlobalConfig{Version: "1.0.0"},
 		},
@@ -734,7 +735,7 @@ func TestGetServerForRequest_DoesNotRetryAuthorizationFailures(t *testing.T) {
 					return conn
 				},
 				server: &CentianServer{
-					APIKeys:    createTestAPIKeyStore(t),
+					Principals: createTestAPIKeyStore(t),
 					AuthHeader: "Authorization",
 					Config:     &config.GlobalConfig{Version: "1.0.0"},
 				},
@@ -800,7 +801,7 @@ func TestInvalidatePooledDownstream_CancelsActiveRetry(t *testing.T) {
 			return conn
 		},
 		server: &CentianServer{
-			APIKeys:    createTestAPIKeyStore(t),
+			Principals: createTestAPIKeyStore(t),
 			AuthHeader: "Authorization",
 			Config:     &config.GlobalConfig{Version: "1.0.0"},
 		},
@@ -881,7 +882,7 @@ func TestGetServerForRequest_DoesNotSpawnDuplicateRetryWorker(t *testing.T) {
 			return conn
 		},
 		server: &CentianServer{
-			APIKeys:    createTestAPIKeyStore(t),
+			Principals: createTestAPIKeyStore(t),
 			AuthHeader: "Authorization",
 			Config:     &config.GlobalConfig{Version: "1.0.0"},
 		},
@@ -1003,42 +1004,40 @@ func (c *closeErrorDownstreamConnection) Close() error {
 	return c.closeErr
 }
 
-func createTestAPIKeyStore(t *testing.T) *auth.APIKeyStore {
-	t.Helper()
-	entry, err := auth.NewAPIKeyEntry("plain-key")
-	assert.NilError(t, err)
-	entry.ID = "key_test"
-	path := filepath.Join(t.TempDir(), "api_keys.json")
-	assert.NilError(t, auth.WriteAPIKeyFile(path, &auth.APIKeyFile{Keys: []auth.APIKeyEntry{entry}}))
-	store, err := auth.LoadAPIKeys(path)
-	assert.NilError(t, err)
-	return store
+// Shared test credential material in the new sk-<credId>.<secret> format.
+const (
+	testCredID      = "key_test"
+	testSecret      = "test-secret"
+	testToken       = "sk-" + testCredID + "." + testSecret
+	testPrincipalID = "pr_0000000000000_principal0"
+)
+
+func createTestAPIKeyStore(t *testing.T) auth.PrincipalProvider {
+	return newTestPrincipalProvider(t, nil, nil)
 }
 
-func createScopedAPIKeyStore(t *testing.T, plain string, gateways []string) *auth.APIKeyStore {
+func createScopedAPIKeyStore(t *testing.T, gateways []string) auth.PrincipalProvider {
+	return newTestPrincipalProvider(t, gateways, nil)
+}
+
+func createProjectScopedAPIKeyStore(t *testing.T, projects []string) auth.PrincipalProvider {
+	return newTestPrincipalProvider(t, nil, projects)
+}
+
+// newTestPrincipalProvider builds a file-backed provider with a single
+// credential ("key_test") resolving to a deterministic principal id.
+func newTestPrincipalProvider(t *testing.T, gateways, projects []string) auth.PrincipalProvider {
 	t.Helper()
-	entry, err := auth.NewAPIKeyEntry(plain)
+	entry, err := auth.NewAPIKeyEntry(auth.GeneratedKey{Token: testToken, CredID: testCredID, Secret: testSecret})
 	assert.NilError(t, err)
-	entry.ID = "key_test"
+	entry.PrincipalID = testPrincipalID
 	entry.Gateways = gateways
-	path := filepath.Join(t.TempDir(), "api_keys.json")
-	assert.NilError(t, auth.WriteAPIKeyFile(path, &auth.APIKeyFile{Keys: []auth.APIKeyEntry{entry}}))
-	store, err := auth.LoadAPIKeys(path)
-	assert.NilError(t, err)
-	return store
-}
-
-func createProjectScopedAPIKeyStore(t *testing.T, plain string, projects []string) *auth.APIKeyStore {
-	t.Helper()
-	entry, err := auth.NewAPIKeyEntry(plain)
-	assert.NilError(t, err)
-	entry.ID = "key_test"
 	entry.Projects = projects
 	path := filepath.Join(t.TempDir(), "api_keys.json")
 	assert.NilError(t, auth.WriteAPIKeyFile(path, &auth.APIKeyFile{Keys: []auth.APIKeyEntry{entry}}))
-	store, err := auth.LoadAPIKeys(path)
-	assert.NilError(t, err)
-	return store
+	provider := auth.NewFilePrincipalProvider(path)
+	assert.NilError(t, provider.Setup(context.Background()))
+	return provider
 }
 
 func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool) {

--- a/internal/proxy/proxy_sessions.go
+++ b/internal/proxy/proxy_sessions.go
@@ -108,12 +108,12 @@ func (p *CentianEndpoint) createUpstreamSession(id string, r *http.Request, iden
 
 // resolveIdentityKey maps a request to the pool identity used for downstream reuse decisions.
 func (p *CentianEndpoint) resolveIdentityKey(r *http.Request) (string, error) {
-	if p.server == nil || p.server.APIKeys == nil {
+	if p.server == nil || p.server.Principals == nil {
 		return sharedLocalIdentity, nil
 	}
 	identity, ok := requestIdentityFromContext(r.Context())
 	if !ok {
-		return "", fmt.Errorf("authenticated request missing resolved API key identity")
+		return "", fmt.Errorf("authenticated request missing resolved principal identity")
 	}
 	return identity, nil
 }

--- a/internal/proxy/proxy_sessions_test.go
+++ b/internal/proxy/proxy_sessions_test.go
@@ -60,7 +60,7 @@ func TestGetOrCreateServerForRequest_SessionAndIdentityGuards(t *testing.T) {
 			Config: &config.GlobalConfig{Version: "1.0.0"},
 		}
 		if withAuth {
-			endpoint.server.APIKeys = createTestAPIKeyStore(t)
+			endpoint.server.Principals = createTestAPIKeyStore(t)
 		}
 		return endpoint
 	}

--- a/internal/proxy/proxy_setup.go
+++ b/internal/proxy/proxy_setup.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -76,9 +77,13 @@ func NewCentianServerWithOptions(globalConfig *config.GlobalConfig, options Cent
 		return nil, fmt.Errorf("failed to create base logger: %w", err)
 	}
 
-	apiKeyStore, err := loadAPIKeyStore(globalConfig)
+	principals, err := loadPrincipalProvider(globalConfig)
 	if err != nil {
 		return nil, err
+	}
+	var authorizer centauth.Authorizer
+	if principals != nil {
+		authorizer = centauth.DirectGrantAuthorizer{}
 	}
 
 	workingDir, err := os.Getwd()
@@ -87,13 +92,14 @@ func NewCentianServerWithOptions(globalConfig *config.GlobalConfig, options Cent
 	}
 
 	centianServer := &CentianServer{
-		Config:   globalConfig,
-		Mux:      mux,
-		Server:   server,
-		Logger:   logger,
-		ServerID: getServerID(),
-		Projects: make(map[string]*CentianProject),
-		APIKeys:  apiKeyStore,
+		Config:     globalConfig,
+		Mux:        mux,
+		Server:     server,
+		Logger:     logger,
+		ServerID:   getServerID(),
+		Projects:   make(map[string]*CentianProject),
+		Principals: principals,
+		Authorizer: authorizer,
 		// AuthHeader is set per-project now, but keep a default for global middleware.
 		AuthHeader: config.DefaultAuthHeader,
 		// Legacy fields - will be populated from the default project below.
@@ -269,7 +275,7 @@ func resolveProjectLogDir(projectSlug string) (string, error) {
 	return filepath.Join(configDir, "projects", projectSlug, "logs"), nil
 }
 
-func loadAPIKeyStore(globalConfig *config.GlobalConfig) (*centauth.APIKeyStore, error) {
+func loadPrincipalProvider(globalConfig *config.GlobalConfig) (centauth.PrincipalProvider, error) {
 	// Check if any project has auth enabled.
 	anyAuthEnabled := false
 	if len(globalConfig.Projects) > 0 {
@@ -286,23 +292,22 @@ func loadAPIKeyStore(globalConfig *config.GlobalConfig) (*centauth.APIKeyStore, 
 
 	if !anyAuthEnabled {
 		common.LogInfo("API key auth disabled via config\n")
-		//nolint:nilnil // nil store is the sentinel that downstream auth middleware is disabled.
+		//nolint:nilnil // nil provider is the sentinel that downstream auth middleware is disabled.
 		return nil, nil
 	}
 
-	apiKeyStore, err := centauth.LoadDefaultAPIKeys()
+	provider, err := centauth.DefaultFilePrincipalProvider()
 	if err != nil {
+		return nil, fmt.Errorf("failed to resolve api key path: %w", err)
+	}
+	if err := provider.Setup(context.Background()); err != nil {
 		if errors.Is(err, centauth.ErrAPIKeysNotFound) {
 			return nil, fmt.Errorf("api key auth enabled but key file not found \n - run `centian auth new-key` to create a new api key\nError: %w", err)
 		}
 		return nil, fmt.Errorf("failed to load api keys: %w", err)
 	}
-	if apiKeyStore.Count() == 0 {
-		common.LogWarn("Auth enabled but no API keys available from %s\n", apiKeyStore.Path())
-	} else {
-		common.LogInfo("Loaded %d API keys from %s\n", apiKeyStore.Count(), apiKeyStore.Path())
-	}
-	return apiKeyStore, nil
+	common.LogInfo("Loaded %d API keys from %s\n", provider.Count(), provider.Path())
+	return provider, nil
 }
 
 type noopCloser struct{}
@@ -430,10 +435,10 @@ func (c *CentianServer) registerProjectHTTPRoutes() {
 
 	centapi.NewProjectsHandler(c.projectSummaries()).WithFilter(func(r *http.Request, project centapi.ProjectSummary) bool {
 		authData := getAuthData(r.Context())
-		if authData == nil || authData.KeyEntry == nil {
+		if authData == nil || authData.Principal == nil || c.Authorizer == nil {
 			return true
 		}
-		return authData.KeyEntry.AllowsProject(project.Slug)
+		return c.Authorizer.Authorize(r.Context(), authData.Principal, centauth.ActionAccess, centauth.ProjectResource(project.Slug)) == nil
 	}).RegisterRoutesWithMiddleware(c.Mux, func(next http.Handler) http.Handler {
 		return wrapWithAPIKeyAuth(c, "", next)
 	})
@@ -521,6 +526,13 @@ func (c *CentianServer) Close() []error {
 	}
 
 	errs := make([]error, 0)
+
+	// Close the principal provider (releases any backend resources).
+	if c.Principals != nil {
+		if err := c.Principals.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 
 	// Close project-scoped resources.
 	for _, project := range c.Projects {

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -46,7 +46,8 @@ type CentianServer struct {
 	Server     *http.Server
 	Logger     *logging.Logger
 	Projects   map[string]*CentianProject
-	APIKeys    *centauth.APIKeyStore
+	Principals centauth.PrincipalProvider
+	Authorizer centauth.Authorizer
 	AuthHeader string
 
 	// Legacy flat-access fields - point to the default project's data for backwards compatibility.


### PR DESCRIPTION
## Description

This PR introduces a foundational authentication and authorization abstraction layer that decouples the proxy from file-based API key storage and enables future extensibility to SQL/external identity providers.

### Key Changes

**Authentication Abstraction:**
- Introduced `PrincipalProvider` interface to resolve tokens to `Principal` objects (replacing direct `APIKeyStore` lookups)
- Created `FilePrincipalProvider` as the file-based implementation backed by `~/.centian/api_keys.json`
- `Principal` is now a first-class actor identity with a stable, persisted `pr_` identifier that remains constant across restarts (critical for downstream pool reuse and OAuth binding stability)

**Authorization Abstraction:**
- Introduced `Authorizer` interface to centralize authorization decisions
- Implemented `DirectGrantAuthorizer` that replicates historical per-credential allowlist semantics (empty list or "*" = allow-all, otherwise case-insensitive match)
- Separated authorization logic from middleware, enabling future role-based or policy-based extensions

**Token Format Evolution:**
- API key tokens now embed the credential ID: `sk-<credentialId>.<secret>` (previously just `sk-<randomBytes>`)
- Embedded credential ID enables O(1) lookup via index before bcrypt verification (previously O(n) scan)
- Legacy token format (without embedded credential ID) is explicitly rejected with `ErrLegacyTokenFormat`
- `GenerateAPIKey()` now returns `GeneratedKey` struct with `Token`, `CredID`, and `Secret` for clarity

**APIKeyEntry Enhancements:**
- Added `PrincipalID` field to persist the stable principal identity
- Added `Name` field for human-friendly principal labeling
- Added `toPrincipal()` method to map stored entries to resolved principals
- Deprecated `APIKeyStore` in favor of `FilePrincipalProvider` (retained until full migration)

**CLI Improvements:**
- `centian auth new-key` now prompts for an optional human-friendly name (or accepts `--name` flag)
- Name is stored with the credential and used as the principal's `DisplayName`

**Middleware Refactoring:**
- Renamed `apiKeyMiddlewareWithHeader` to `principalAuthMiddleware` to reflect the new abstraction
- Middleware now uses `PrincipalProvider.GetPrincipal()` and `Authorizer.Authorize()` instead of direct entry lookups
- `AuthData` now carries `Principal` instead of `APIKeyEntry`, with `CredentialID` as a separate field

**Identifier System:**
- Added `KindPrincipal` ("pr_") to the identifier system for generating stable principal IDs

### Testing

- Added comprehensive unit tests for `FilePrincipalProvider` covering token resolution, rejection cases, and ID stability across reloads
- Added unit tests for `DirectGrantAuthorizer` covering allowlist semantics, case-insensitivity, and wildcard handling
- Added prompt helper tests for the new interactive name input
- Updated existing proxy and auth tests to use the new token format and abstractions
- All tests follow the "Given-when-then" structure per project conventions

### Backward Compatibility

- Legacy token format is explicitly rejected; operators must regenerate keys with `centian auth new-key`
- Historical allowlist semantics (empty = allow-all, "*" = allow-all) are preserved in `DirectGrantAuthorizer`
- Existing error types (`ErrAPIKeysNotFound`, `ErrAPIKeysEmpty`, `ErrAPIKeysInvalid`) are retained for setup compatibility

### Future Extensibility

This change establishes the seams for:
- SQL-based principal providers
- External identity providers (OIDC, LDAP, etc.)
- Role-based access control (behind the `Authorizer` interface)
- Per-principal audit logging and rate limiting

## Related Issues

N/A

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (HTTP_PROXY_SETUP.md)
- [x] No breaking changes (legacy tokens must be regenerated; documented in CHANGELOG)
- [x] Code has been l

https://claude.ai/code/session_01X7Emm4oRHF8rsNv8PCvBGw