### PR TITLE
Introduce ConfigProvider seam for on-demand project config loading

### DIFF
--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -124,7 +124,7 @@ func runInMemoryDemo(ctx context.Context, stdout, stderr io.Writer) error {
 }
 
 func newInMemoryDemoServer(ctx context.Context) (*proxy.CentianServer, error) {
-	server, err := proxy.NewCentianServerWithOptions(newDemoConfig(), proxy.CentianServerOptions{
+	server, err := proxy.NewCentianServerWithOptions(config.NewConfigProviderFromConfig(newDemoConfig()), proxy.CentianServerOptions{
 		LoggerFactory: func(string) (*logging.Logger, error) {
 			return logging.NewDiscardLogger()
 		},

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -167,13 +167,20 @@ func printProjectEndpoints(slug string, project *config.ProjectConfig, host, por
 func handleServerStartCommand(_ context.Context, cmd *cli.Command) error {
 	configPath := cmd.String("config-path")
 
-	// Load configuration.
-	var globalConfig *config.GlobalConfig
-	var err error
+	// Build a file-backed config provider. This is the seam through which the
+	// server fetches per-project config on demand; the file provider preloads and
+	// serves from memory, so behavior is unchanged.
 	if configPath == "" {
 		configPath, _ = config.GetConfigPath()
 	}
-	globalConfig, err = config.LoadConfigFromPath(configPath)
+	provider, err := config.NewFileConfigProvider(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config from %s: %w", configPath, err)
+	}
+
+	// Read the global settings for the operational validation, logging, and the
+	// startup banner below.
+	globalConfig, err := provider.Global(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to load config from %s: %w", configPath, err)
 	}
@@ -197,8 +204,8 @@ func handleServerStartCommand(_ context.Context, cmd *cli.Command) error {
 	}()
 	common.LogInfo("Loaded config from: %s", configPath)
 
-	// Create HTTP proxy server.
-	server, err := proxy.NewCentianServer(globalConfig)
+	// Create HTTP proxy server from the config provider.
+	server, err := proxy.NewCentianServerWithOptions(provider, proxy.CentianServerOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to create centian server: %w", err)
 	}

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"context"
+	"fmt"
+)
+
+// ConfigProvider abstracts where and when configuration is loaded. The proxy
+// consumes config through this seam instead of taking a monolithic GlobalConfig,
+// so a project's ProjectConfig can be fetched on demand and an implementation can
+// source config from somewhere other than a local file (e.g. a database or an HTTP
+// API) without changing the server.
+//
+// The methods take a context so implementations backed by I/O can honor
+// cancellation and deadlines; in-memory implementations ignore it.
+//
+//nolint:revive // "ConfigProvider" is the established name for this seam (see T2); config.Provider would be less descriptive at call sites.
+type ConfigProvider interface {
+	// Global returns the truly-global settings (proxy bind/port/timeout, auth
+	// backend, version/name). It is small and needed before any project is served,
+	// so implementations may load it eagerly.
+	Global(ctx context.Context) (*GlobalConfig, error)
+
+	// ListProjects returns the slugs of all known projects.
+	ListProjects(ctx context.Context) ([]string, error)
+
+	// GetProject fetches a single project's ProjectConfig on demand. File-backed
+	// implementations serve this from a preloaded in-memory map; an I/O-backed
+	// implementation may load it here, which can add latency to the MCP initialize
+	// request.
+	GetProject(ctx context.Context, slug string) (*ProjectConfig, error)
+}
+
+// FileConfigProvider is the file-backed ConfigProvider. It preloads the whole
+// config once and serves each request from an in-memory map, so GetProject never
+// performs I/O. This keeps the on-demand seam in place while preserving the
+// "pre-load the file" behavior.
+type FileConfigProvider struct {
+	cfg *GlobalConfig
+}
+
+// compile-time assertion that FileConfigProvider satisfies ConfigProvider.
+var _ ConfigProvider = (*FileConfigProvider)(nil)
+
+// NewFileConfigProvider loads and validates a config from path, normalizes it to
+// the project-based layout, and returns a provider that serves it from memory.
+func NewFileConfigProvider(path string) (*FileConfigProvider, error) {
+	cfg, err := LoadConfigFromPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return NewConfigProviderFromConfig(cfg), nil
+}
+
+// NewConfigProviderFromConfig wraps an already-loaded GlobalConfig in a file
+// provider. It normalizes the config to the project-based layout (idempotent) so
+// callers can always reach projects via ListProjects/GetProject. Primarily used by
+// the back-compat NewCentianServer constructor and tests.
+func NewConfigProviderFromConfig(cfg *GlobalConfig) *FileConfigProvider {
+	if cfg != nil {
+		cfg.ResolveProjects()
+	}
+	return &FileConfigProvider{cfg: cfg}
+}
+
+// Global returns the preloaded global config.
+func (p *FileConfigProvider) Global(_ context.Context) (*GlobalConfig, error) {
+	if p == nil || p.cfg == nil {
+		return nil, fmt.Errorf("config provider has no config loaded")
+	}
+	return p.cfg, nil
+}
+
+// ListProjects returns the slugs of all preloaded projects.
+func (p *FileConfigProvider) ListProjects(_ context.Context) ([]string, error) {
+	if p == nil || p.cfg == nil {
+		return nil, fmt.Errorf("config provider has no config loaded")
+	}
+	slugs := make([]string, 0, len(p.cfg.Projects))
+	for slug := range p.cfg.Projects {
+		slugs = append(slugs, slug)
+	}
+	return slugs, nil
+}
+
+// GetProject returns the ProjectConfig for slug from the preloaded map.
+func (p *FileConfigProvider) GetProject(_ context.Context, slug string) (*ProjectConfig, error) {
+	if p == nil || p.cfg == nil {
+		return nil, fmt.Errorf("config provider has no config loaded")
+	}
+	project, ok := p.cfg.Projects[slug]
+	if !ok {
+		return nil, fmt.Errorf("project %q not found", slug)
+	}
+	return project, nil
+}

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFileConfigProviderServesPreloadedProjects verifies that a provider built
+// from a file exposes the resolved projects via Global/ListProjects/GetProject.
+func TestFileConfigProviderServesPreloadedProjects(t *testing.T) {
+	// Given: a legacy-flat config file with a single gateway on disk.
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	cfg := DefaultConfig()
+	cfg.Gateways = map[string]*GatewayConfig{
+		"gateway1": {
+			MCPServers: map[string]*MCPServerConfig{
+				"server1": {Name: "server1", Command: "node"},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// When: constructing a file-backed provider.
+	provider, err := NewFileConfigProvider(configPath)
+	if err != nil {
+		t.Fatalf("NewFileConfigProvider failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Then: Global returns the loaded config with proxy settings populated.
+	global, err := provider.Global(ctx)
+	if err != nil {
+		t.Fatalf("Global failed: %v", err)
+	}
+	if global == nil || global.Proxy == nil {
+		t.Fatalf("expected global config with proxy settings, got %+v", global)
+	}
+
+	// Then: the legacy-flat layout was auto-migrated to a single "default" project.
+	slugs, err := provider.ListProjects(ctx)
+	if err != nil {
+		t.Fatalf("ListProjects failed: %v", err)
+	}
+	if len(slugs) != 1 || slugs[0] != DefaultProjectSlug {
+		t.Fatalf("expected [%q], got %v", DefaultProjectSlug, slugs)
+	}
+
+	// Then: GetProject returns the default project carrying the gateway.
+	project, err := provider.GetProject(ctx, DefaultProjectSlug)
+	if err != nil {
+		t.Fatalf("GetProject failed: %v", err)
+	}
+	if _, ok := project.Gateways["gateway1"]; !ok {
+		t.Fatalf("expected gateway1 in default project, got %v", project.Gateways)
+	}
+}
+
+// TestFileConfigProviderGetProjectUnknownSlug verifies an error on a missing slug.
+func TestFileConfigProviderGetProjectUnknownSlug(t *testing.T) {
+	// Given: a provider built from an in-memory default config.
+	provider := NewConfigProviderFromConfig(DefaultConfig())
+
+	// When: fetching a project that does not exist.
+	_, err := provider.GetProject(context.Background(), "does-not-exist")
+
+	// Then: an error is returned.
+	if err == nil {
+		t.Fatalf("expected error for unknown project slug, got nil")
+	}
+}
+
+// TestNewConfigProviderFromConfigResolvesLegacyLayout verifies that wrapping a
+// legacy-flat in-memory config normalizes it to the project-based layout.
+func TestNewConfigProviderFromConfigResolvesLegacyLayout(t *testing.T) {
+	// Given: a legacy-flat config with no Projects map.
+	cfg := DefaultConfig()
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("expected legacy layout with no projects, got %v", cfg.Projects)
+	}
+
+	// When: wrapping it in a file provider.
+	provider := NewConfigProviderFromConfig(cfg)
+
+	// Then: a synthesized "default" project is reachable via GetProject.
+	project, err := provider.GetProject(context.Background(), DefaultProjectSlug)
+	if err != nil {
+		t.Fatalf("GetProject failed: %v", err)
+	}
+	if project == nil || project.Slug != DefaultProjectSlug {
+		t.Fatalf("expected default project, got %+v", project)
+	}
+}

--- a/internal/proxy/proxy_server_setup_test.go
+++ b/internal/proxy/proxy_server_setup_test.go
@@ -429,7 +429,7 @@ func TestNewCentianServerWithOptionsUsesLoggerFactory(t *testing.T) {
 	}
 	calls := make(map[string]int)
 
-	server, err := NewCentianServerWithOptions(globalConfig, CentianServerOptions{
+	server, err := NewCentianServerWithOptions(config.NewConfigProviderFromConfig(globalConfig), CentianServerOptions{
 		LoggerFactory: func(projectSlug string) (*logging.Logger, error) {
 			calls[projectSlug]++
 			return logging.NewDiscardLogger()

--- a/internal/proxy/proxy_setup.go
+++ b/internal/proxy/proxy_setup.go
@@ -33,23 +33,41 @@ type CentianServerOptions struct {
 }
 
 // NewCentianServer takes a GlobalConfig struct and returns a new CentianServer.
-// It resolves the config into the project-based layout and initializes per-project
-// services (persistence, task verification) for each project.
+// It wraps the config in a file-backed ConfigProvider, resolves the config into
+// the project-based layout, and initializes per-project services (persistence,
+// task verification) for each project. Retained for backwards compatibility with
+// callers and tests that already hold a fully-loaded config.
 func NewCentianServer(globalConfig *config.GlobalConfig) (*CentianServer, error) {
-	return NewCentianServerWithOptions(globalConfig, CentianServerOptions{})
+	return NewCentianServerWithOptions(config.NewConfigProviderFromConfig(globalConfig), CentianServerOptions{})
 }
 
-// NewCentianServerWithOptions takes a GlobalConfig struct and explicit runtime
-// dependencies, then returns a new CentianServer.
+// NewCentianServerWithOptions consumes config through a ConfigProvider seam and,
+// together with explicit runtime dependencies, returns a new CentianServer. It
+// fetches each project's config on demand via provider.GetProject; the file-backed
+// provider serves these from a preloaded map, while an I/O-backed provider may
+// load them lazily.
 //
 //nolint:gocyclo // Server startup coordinates several subsystems; helpers keep the branches local and explicit.
-func NewCentianServerWithOptions(globalConfig *config.GlobalConfig, options CentianServerOptions) (*CentianServer, error) {
+func NewCentianServerWithOptions(provider config.ConfigProvider, options CentianServerOptions) (*CentianServer, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("config provider is required")
+	}
+
+	// Setup runs at startup with no request scope, so use a background context.
+	ctx := context.Background()
+
+	globalConfig, err := provider.Global(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load global config: %w", err)
+	}
 	if globalConfig == nil || globalConfig.Proxy == nil {
 		return nil, fmt.Errorf("proxy settings are required")
 	}
 
-	// Normalize config to project-based layout.
-	globalConfig.ResolveProjects()
+	projectSlugs, err := provider.ListProjects(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list projects: %w", err)
+	}
 
 	host := globalConfig.Proxy.Host
 	if host == "" {
@@ -57,7 +75,11 @@ func NewCentianServerWithOptions(globalConfig *config.GlobalConfig, options Cent
 	}
 	if host == "0.0.0.0" {
 		// When binding to all interfaces, all projects must have auth explicitly configured.
-		for slug, project := range globalConfig.Projects {
+		for _, slug := range projectSlugs {
+			project, projErr := provider.GetProject(ctx, slug)
+			if projErr != nil {
+				return nil, fmt.Errorf("project '%s': %w", slug, projErr)
+			}
 			if project != nil && project.AuthEnabled == nil {
 				return nil, fmt.Errorf("auth must be explicitly set when binding to 0.0.0.0 (project '%s')", slug)
 			}
@@ -92,14 +114,15 @@ func NewCentianServerWithOptions(globalConfig *config.GlobalConfig, options Cent
 	}
 
 	centianServer := &CentianServer{
-		Config:     globalConfig,
-		Mux:        mux,
-		Server:     server,
-		Logger:     logger,
-		ServerID:   getServerID(),
-		Projects:   make(map[string]*CentianProject),
-		Principals: principals,
-		Authorizer: authorizer,
+		Config:         globalConfig,
+		ConfigProvider: provider,
+		Mux:            mux,
+		Server:         server,
+		Logger:         logger,
+		ServerID:       getServerID(),
+		Projects:       make(map[string]*CentianProject),
+		Principals:     principals,
+		Authorizer:     authorizer,
 		// AuthHeader is set per-project now, but keep a default for global middleware.
 		AuthHeader: config.DefaultAuthHeader,
 		// Legacy fields - will be populated from the default project below.
@@ -107,11 +130,16 @@ func NewCentianServerWithOptions(globalConfig *config.GlobalConfig, options Cent
 		Endpoints: []*CentianEndpoint{},
 	}
 
-	// Initialize per-project state.
-	for slug, projectConfig := range globalConfig.Projects {
-		project, err := newCentianProject(slug, projectConfig, workingDir, logger, loggerFactory)
-		if err != nil {
-			return nil, fmt.Errorf("project '%s': %w", slug, err)
+	// Initialize per-project state. Each project's config is fetched on demand via
+	// the provider; the file-backed provider serves it from its preloaded map.
+	for _, slug := range projectSlugs {
+		projectConfig, projErr := provider.GetProject(ctx, slug)
+		if projErr != nil {
+			return nil, fmt.Errorf("project '%s': %w", slug, projErr)
+		}
+		project, projErr := newCentianProject(slug, projectConfig, workingDir, logger, loggerFactory)
+		if projErr != nil {
+			return nil, fmt.Errorf("project '%s': %w", slug, projErr)
 		}
 		centianServer.Projects[slug] = project
 	}

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -39,16 +39,20 @@ type CentianProject struct {
 //
 // CentianServer is the main process for providing routes and delegating endpoint creation.
 type CentianServer struct {
-	Name       string
-	ServerID   string
-	Config     *config.GlobalConfig
-	Mux        *http.ServeMux
-	Server     *http.Server
-	Logger     *logging.Logger
-	Projects   map[string]*CentianProject
-	Principals centauth.PrincipalProvider
-	Authorizer centauth.Authorizer
-	AuthHeader string
+	Name     string
+	ServerID string
+	Config   *config.GlobalConfig
+	// ConfigProvider is the seam through which per-project config is fetched on
+	// demand. The file-backed provider serves from a preloaded map; an I/O-backed
+	// provider may load lazily.
+	ConfigProvider config.ConfigProvider
+	Mux            *http.ServeMux
+	Server         *http.Server
+	Logger         *logging.Logger
+	Projects       map[string]*CentianProject
+	Principals     centauth.PrincipalProvider
+	Authorizer     centauth.Authorizer
+	AuthHeader     string
 
 	// Legacy flat-access fields - point to the default project's data for backwards compatibility.
 	Gateways         map[string]*CentianEndpoint


### PR DESCRIPTION
## Description

This PR introduces a `ConfigProvider` interface that abstracts configuration loading, enabling on-demand per-project config fetching instead of requiring all configuration upfront. This seam prepares the codebase for future remote config backends (REST API, database) while maintaining current file-backed behavior.

### Key Changes

1. **New `ConfigProvider` interface** (`internal/config/provider.go`):
   - `Global(ctx)` - Returns truly-global settings (proxy bind/port, auth backend)
   - `ListProjects(ctx)` - Returns all project slugs
   - `GetProject(ctx, slug)` - Fetches individual project config on demand

2. **`FileConfigProvider` implementation**:
   - File-backed provider that preloads config once and serves from in-memory map
   - `NewFileConfigProvider(path)` - Loads config from file and wraps it
   - `NewConfigProviderFromConfig(cfg)` - Wraps already-loaded config (for backwards compatibility)
   - Automatically normalizes legacy flat layout to project-based layout via `ResolveProjects()`

3. **Server initialization refactored** (`internal/proxy/proxy_setup.go`):
   - `NewCentianServerWithOptions` now accepts `ConfigProvider` instead of `GlobalConfig`
   - Fetches global config and project list via provider
   - Iterates projects by slug and fetches each via `GetProject()` on demand
   - `NewCentianServer` retained for backwards compatibility, wraps config in file provider

4. **CLI updated** (`internal/cli/server.go`):
   - Creates `FileConfigProvider` from config path
   - Passes provider to `NewCentianServerWithOptions`

5. **CentianServer struct** (`internal/proxy/proxy_types.go`):
   - Added `ConfigProvider` field for future route refactoring

### Testing

- Added comprehensive test suite (`internal/config/provider_test.go`):
  - `TestFileConfigProviderServesPreloadedProjects` - Verifies file provider loads and serves projects
  - `TestFileConfigProviderGetProjectUnknownSlug` - Verifies error handling for missing projects
  - `TestNewConfigProviderFromConfigResolvesLegacyLayout` - Verifies legacy layout auto-migration
- Existing tests updated to use new provider interface

### Backwards Compatibility

- `NewCentianServer(globalConfig)` retained and wraps config in file provider
- Legacy flat config layout continues to auto-migrate to "default" project
- File-backed provider serves all config from preloaded map (no I/O on GetProject)
- Current behavior unchanged; seam is in place for future remote backends

## Related Issues

Closes #<!-- issue number -->

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or breaking changes are described below)
- [x] Code has been linted and formatted

https://claude.ai/code/session_01B1xHDRgWxnJb89JRzLmscE